### PR TITLE
fix: make active work lifecycle canonical across deployments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "filetime",
  "flate2",
  "fs2",
+ "futures-util",
  "hmac",
  "jsonwebtoken",
  "openssl",

--- a/crates/astra-cli/src/cli/agent_runtime.rs
+++ b/crates/astra-cli/src/cli/agent_runtime.rs
@@ -243,6 +243,7 @@ pub(crate) async fn initialize_multi_agent_runtime(
             progress_broadcaster,
         )
         .with_executor(std::sync::Arc::new(spawn_executor))
+        .with_active_work_registry(state.active_work_registry.clone())
         .with_prefix_store(prefix_store)
         .with_max_concurrent_agents(resolved_spawn_concurrency_cap()),
         state.session_id.as_deref(),

--- a/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -818,6 +818,7 @@ pub(crate) async fn stream_chat_sse(
         max_consecutive_empty_name: resolved_tool_policy.max_consecutive_empty_name,
         stall: StallTrackingState {
             work_unit_observations: Default::default(),
+            active_work_registry: None,
             turn_sigs: Vec::new(),
             turn_tool_names: Vec::new(),
             events: Vec::new(),

--- a/crates/astra-cli/src/cli/session/session_state.rs
+++ b/crates/astra-cli/src/cli/session/session_state.rs
@@ -401,6 +401,10 @@ pub(crate) struct SessionState {
     pub dead_letter_queue: Option<std::sync::Arc<astra_messaging::dead_letter::DeadLetterQueue>>,
     /// Dynamic agent spawner for runtime agent creation.
     pub agent_spawner: Option<std::sync::Arc<astra_runtime::orchestration::DynamicAgentSpawner>>,
+    /// Session-scoped typed authority for every asynchronous work kind. Model
+    /// boundaries consume this registry instead of querying UI projections or
+    /// one producer-specific cache.
+    pub active_work_registry: std::sync::Arc<astra_core::work_unit::ActiveWorkRegistry>,
     /// Persistent top-level mailbox so spawned agents can reply across turns.
     pub root_mailbox: Option<astra_messaging::router::AgentMailbox>,
     /// Replies received while the REPL is idle at the prompt. Flushed only at safe redraw points.
@@ -678,6 +682,9 @@ impl Default for SessionState {
                 astra_messaging::dead_letter::DeadLetterQueue::new(),
             )),
             agent_spawner: None, // Created lazily when agent spawning is first used
+            active_work_registry: std::sync::Arc::new(
+                astra_core::work_unit::ActiveWorkRegistry::default(),
+            ),
             root_mailbox: None,
             redo_stack: Vec::new(),
             resume_guidance: None,

--- a/crates/astra-cli/src/cli/session/session_state.rs
+++ b/crates/astra-cli/src/cli/session/session_state.rs
@@ -794,6 +794,12 @@ impl SessionState {
     /// session boundary; this synchronous reset does not tear down the
     /// asynchronously registered root mailbox.
     pub fn reset_for_new_session(&mut self) {
+        // A registry generation belongs to exactly one session. Old producers
+        // may still be retiring after the bounded rebind deadline; replacing
+        // the Arc keeps their late observations isolated from the new model
+        // boundary without requiring unbounded shutdown waits.
+        self.active_work_registry =
+            std::sync::Arc::new(astra_core::work_unit::ActiveWorkRegistry::default());
         self.pending_recovery = None;
         self.run_id = None;
         *astra_core::sync_poison::recover_mutex_lock(&self.active_turn_local_run_control) = None;
@@ -1009,6 +1015,53 @@ mod default_tests {
         assert!(state.pending_bg_notifications.is_empty());
         assert_eq!(state.turns_since_task_use, 0);
         assert_eq!(state.turns_since_task_reminder, 0);
+    }
+
+    #[test]
+    fn reset_for_new_session_rotates_active_work_generation() {
+        use astra_core::work_unit::{WorkUnitObservation, WorkUnitObservationMode, WorkUnitStatus};
+
+        let mut state = SessionState::default();
+        let old_registry = state.active_work_registry.clone();
+        let old_running = WorkUnitObservation::new(
+            "agent-old",
+            "agent",
+            WorkUnitStatus::Running,
+            1,
+            WorkUnitObservationMode::Transition,
+        )
+        .unwrap();
+        old_registry.observe(&old_running);
+
+        state.reset_for_new_session();
+
+        assert!(!std::sync::Arc::ptr_eq(
+            &old_registry,
+            &state.active_work_registry
+        ));
+        assert!(
+            state
+                .active_work_registry
+                .active_work_observations()
+                .is_empty()
+        );
+
+        let late_old_observation = WorkUnitObservation::new(
+            "agent-late",
+            "agent",
+            WorkUnitStatus::Running,
+            1,
+            WorkUnitObservationMode::Transition,
+        )
+        .unwrap();
+        old_registry.observe(&late_old_observation);
+        assert!(
+            state
+                .active_work_registry
+                .active_work_observations()
+                .is_empty(),
+            "late observations from a retiring producer must remain in the old generation"
+        );
     }
 
     #[test]

--- a/crates/astra-cli/src/cli/slash/slash_agent.rs
+++ b/crates/astra-cli/src/cli/slash/slash_agent.rs
@@ -1168,6 +1168,7 @@ fn fanout_slot_status_label(status: AgentFanoutSlotStatus) -> &'static str {
     match status {
         AgentFanoutSlotStatus::Planned => "planned",
         AgentFanoutSlotStatus::SpawnAccepted | AgentFanoutSlotStatus::Running => "running",
+        AgentFanoutSlotStatus::WaitingForInput => "needs input",
         AgentFanoutSlotStatus::SpawnRejected => "spawn rejected",
         AgentFanoutSlotStatus::Completed => "completed",
         AgentFanoutSlotStatus::Interrupted => "interrupted",

--- a/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -6843,7 +6843,7 @@ mod tests {
                 "id": "work-1",
                 "kind": "future_async_capability",
                 "status": "completed",
-                "version": "revision-2",
+                "revision": 2,
                 "mode": "transition",
                 "wake_policy": "none"
             }

--- a/crates/astra-cli/src/cli/turn/turn_stream_runner.rs
+++ b/crates/astra-cli/src/cli/turn/turn_stream_runner.rs
@@ -76,10 +76,7 @@ async fn prepare_turn_stream_state(state: &SessionState) -> PreparedTurnStreamSt
     // Capture producer truth at the actual model boundary. This refreshes on
     // retries and wake turns and avoids feeding the TUI's rendered XML cache
     // back into lifecycle decisions.
-    let input_work_unit_observations = match state.agent_spawner.as_ref() {
-        Some(spawner) => spawner.active_fanout_work_unit_observations().await,
-        None => Vec::new(),
-    };
+    let input_work_unit_observations = state.active_work_registry.active_work_observations();
 
     let run_control =
         astra_core::sync_poison::recover_mutex_lock(&state.active_turn_local_run_control)
@@ -335,9 +332,11 @@ mod tests {
         let transport = Arc::new(astra_messaging::InProcessTransport::new());
         let tracker = Arc::new(astra_runtime::server::delegation::engine::DelegationTracker::new());
         let router = Arc::new(astra_messaging::AgentMailboxRouter::new(transport, tracker));
-        let spawner = Arc::new(astra_runtime::orchestration::DynamicAgentSpawner::new(
-            router,
-        ));
+        let active_work_registry = Arc::new(astra_core::work_unit::ActiveWorkRegistry::default());
+        let spawner = Arc::new(
+            astra_runtime::orchestration::DynamicAgentSpawner::new(router)
+                .with_active_work_registry(active_work_registry.clone()),
+        );
         spawner
             .declare_fanout_group(
                 "review-group",
@@ -350,6 +349,7 @@ mod tests {
             .unwrap();
         let state = SessionState {
             agent_spawner: Some(spawner),
+            active_work_registry,
             ..SessionState::default()
         };
 
@@ -365,7 +365,7 @@ mod tests {
         );
         assert_eq!(
             observation.wake_policy,
-            astra_core::work_unit::WorkUnitWakePolicy::OnTerminal
+            astra_core::work_unit::WorkUnitWakePolicy::OnAttentionOrTerminal
         );
     }
 

--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -4054,7 +4054,7 @@ impl ToolExecutor {
                     observation_mode,
                 )
                 .expect("fanout task projections have canonical identities and revisions")
-                .with_wake_policy(WorkUnitWakePolicy::OnTerminal);
+                .with_wake_policy(WorkUnitWakePolicy::OnAttentionOrTerminal);
                 let mut fields = background_task_output_result_fields(
                     &projection.group_id,
                     &projection.snapshot,
@@ -6405,7 +6405,7 @@ mod tests {
                     "id": "fanout-group-1",
                     "kind": "agent_fanout",
                     "status": "completed",
-                    "version": "revision-4",
+                    "revision": 4,
                     "mode": "current",
                     "wake_policy": "on_terminal"
                 }
@@ -8110,23 +8110,26 @@ mod tests {
     }
 
     #[test]
-    fn background_task_output_projection_names_failed_and_killed_empty_states() {
+    fn background_task_output_projection_names_failed_and_cancelled_empty_states() {
         let failed = format_background_task_output(
             "bg-shell-1",
             0,
             &bg_snapshot(0, 0, 0, "failed", ""),
             BgTaskOutputReadMode::Current,
         );
-        let killed = format_background_task_output(
+        let cancelled = format_background_task_output(
             "bg-shell-2",
             0,
-            &bg_snapshot(0, 0, 0, "killed", ""),
+            &bg_snapshot(0, 0, 0, "cancelled", ""),
             BgTaskOutputReadMode::Current,
         );
         assert!(failed.contains("Failed with no output"), "{failed}");
-        assert!(killed.contains("Stopped with no output"), "{killed}");
+        assert!(cancelled.contains("Stopped with no output"), "{cancelled}");
         assert!(!failed.contains("Completed with no output"), "{failed}");
-        assert!(!killed.contains("Completed with no output"), "{killed}");
+        assert!(
+            !cancelled.contains("Completed with no output"),
+            "{cancelled}"
+        );
         assert!(failed.contains("failure_cause unverified"), "{failed}");
         assert!(failed.contains("task_output(pattern=...)"), "{failed}");
         assert!(

--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -650,6 +650,22 @@ fn categorize_reference(line: &str, _symbol: &str) -> &'static str {
 /// Commands queued by the tool executor for the TUI's BackgroundTaskRegistry.
 pub type BgTaskOutputStatus = WorkUnitStatus;
 
+fn shell_work_revision(status: WorkUnitStatus, total_bytes: u64) -> u64 {
+    let phase = match status {
+        WorkUnitStatus::Pending => 1,
+        WorkUnitStatus::Running => 2,
+        WorkUnitStatus::WaitingForInput => 3,
+        WorkUnitStatus::Stopping => 4,
+        WorkUnitStatus::Completed
+        | WorkUnitStatus::CompletedWithIssues
+        | WorkUnitStatus::Failed
+        | WorkUnitStatus::Interrupted
+        | WorkUnitStatus::Cancelled
+        | WorkUnitStatus::Unavailable => 5,
+    };
+    total_bytes.saturating_mul(8).saturating_add(phase)
+}
+
 #[derive(Debug, Clone)]
 pub struct BgTaskOutputSnapshot {
     pub kind: String,
@@ -1192,7 +1208,7 @@ fn background_task_output_result_fields(
         task_id,
         snapshot.kind.trim().to_ascii_lowercase().replace(' ', "_"),
         snapshot.status,
-        format!("{}:{}", snapshot.status.as_str(), snapshot.total_bytes),
+        shell_work_revision(snapshot.status, snapshot.total_bytes),
         match observation_mode {
             "wait" => WorkUnitObservationMode::Wait,
             "historical" => WorkUnitObservationMode::Historical,
@@ -1227,12 +1243,7 @@ fn background_task_output_search_result_fields(
         task_id,
         snapshot.kind.trim().to_ascii_lowercase().replace(' ', "_"),
         snapshot.status,
-        format!(
-            "diagnostic:{}:{}:{}",
-            snapshot.status.as_str(),
-            snapshot.matching_lines,
-            snapshot.truncated
-        ),
+        snapshot.matching_lines.saturating_add(1),
         WorkUnitObservationMode::Diagnostic,
     )
     .expect("background diagnostics have a task id, kind, and version")
@@ -4039,7 +4050,7 @@ impl ToolExecutor {
                     &projection.group_id,
                     "agent_fanout",
                     projection.snapshot.status,
-                    projection.revision.to_string(),
+                    projection.revision,
                     observation_mode,
                 )
                 .expect("fanout task projections have canonical identities and revisions")
@@ -7400,7 +7411,7 @@ mod tests {
         assert_eq!(work.id, "bg-shell-1");
         assert_eq!(work.kind, "shell");
         assert_eq!(work.status, astra_core::work_unit::WorkUnitStatus::Running);
-        assert_eq!(work.version, "running:1000");
+        assert_eq!(work.revision, 8002);
         assert_eq!(
             work.mode,
             astra_core::work_unit::WorkUnitObservationMode::Current

--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -650,22 +650,6 @@ fn categorize_reference(line: &str, _symbol: &str) -> &'static str {
 /// Commands queued by the tool executor for the TUI's BackgroundTaskRegistry.
 pub type BgTaskOutputStatus = WorkUnitStatus;
 
-fn shell_work_revision(status: WorkUnitStatus, total_bytes: u64) -> u64 {
-    let phase = match status {
-        WorkUnitStatus::Pending => 1,
-        WorkUnitStatus::Running => 2,
-        WorkUnitStatus::WaitingForInput => 3,
-        WorkUnitStatus::Stopping => 4,
-        WorkUnitStatus::Completed
-        | WorkUnitStatus::CompletedWithIssues
-        | WorkUnitStatus::Failed
-        | WorkUnitStatus::Interrupted
-        | WorkUnitStatus::Cancelled
-        | WorkUnitStatus::Unavailable => 5,
-    };
-    total_bytes.saturating_mul(8).saturating_add(phase)
-}
-
 #[derive(Debug, Clone)]
 pub struct BgTaskOutputSnapshot {
     pub kind: String,
@@ -1194,7 +1178,7 @@ fn background_task_output_result_fields(
             BgTaskOutputReadMode::Historical => "historical",
         }
     };
-    let mut fields = serde_json::Map::from_iter([(
+    serde_json::Map::from_iter([(
         "background_task_observation".to_string(),
         serde_json::json!({
             "task_id": task_id,
@@ -1203,22 +1187,7 @@ fn background_task_output_result_fields(
             "terminal": snapshot.status.is_terminal(),
             "mode": observation_mode,
         }),
-    )]);
-    WorkUnitObservation::new(
-        task_id,
-        snapshot.kind.trim().to_ascii_lowercase().replace(' ', "_"),
-        snapshot.status,
-        shell_work_revision(snapshot.status, snapshot.total_bytes),
-        match observation_mode {
-            "wait" => WorkUnitObservationMode::Wait,
-            "historical" => WorkUnitObservationMode::Historical,
-            _ => WorkUnitObservationMode::Current,
-        },
-    )
-    .expect("background snapshots have a task id, kind, and version")
-    .with_wake_policy(WorkUnitWakePolicy::OnTerminal)
-    .insert_into(&mut fields);
-    fields
+    )])
 }
 
 fn background_task_output_search_result_fields(
@@ -1226,7 +1195,7 @@ fn background_task_output_search_result_fields(
     pattern: &str,
     snapshot: &BgTaskOutputSearchSnapshot,
 ) -> serde_json::Map<String, Value> {
-    let mut fields = serde_json::Map::from_iter([(
+    serde_json::Map::from_iter([(
         "background_task_observation".to_string(),
         serde_json::json!({
             "task_id": task_id,
@@ -1238,18 +1207,7 @@ fn background_task_output_search_result_fields(
             "matching_lines": snapshot.matching_lines,
             "truncated": snapshot.truncated,
         }),
-    )]);
-    WorkUnitObservation::new(
-        task_id,
-        snapshot.kind.trim().to_ascii_lowercase().replace(' ', "_"),
-        snapshot.status,
-        snapshot.matching_lines.saturating_add(1),
-        WorkUnitObservationMode::Diagnostic,
-    )
-    .expect("background diagnostics have a task id, kind, and version")
-    .with_wake_policy(WorkUnitWakePolicy::OnTerminal)
-    .insert_into(&mut fields);
-    fields
+    )])
 }
 
 fn format_background_task_output_registry_timeout(task_id: &str, timeout: Duration) -> String {
@@ -6379,9 +6337,10 @@ mod tests {
     use super::{
         AGGREGATE_SOFT_LIMIT, BgTaskCommand, BgTaskOutputReadMode, BgTaskOutputSearchSnapshot,
         BgTaskOutputSnapshot, BgTaskOutputStatus, PERSIST_THRESHOLD, ToolExecutor,
-        WorkUnitObservation, WorkUnitStatus, all_tool_schemas, cli_tool_output_is_error,
-        detect_git_remote_repos, embedded_work_unit_observation, extract_github_owner_repo,
-        file_checkpoint_dir_for, format_background_task_error, format_background_task_output,
+        WorkUnitObservation, WorkUnitStatus, all_tool_schemas,
+        background_task_output_result_fields, cli_tool_output_is_error, detect_git_remote_repos,
+        embedded_work_unit_observation, extract_github_owner_repo, file_checkpoint_dir_for,
+        format_background_task_error, format_background_task_output,
         format_background_task_output_wait_timeout, format_background_task_stop_error,
         git_stash_sub_action_args, memoria, parse_memory_search_contents, utf16_col_to_char_idx,
     };
@@ -7404,21 +7363,12 @@ mod tests {
         assert_eq!(observation["task_id"], "bg-shell-1");
         assert_eq!(observation["task_kind"], "shell");
         assert_eq!(observation["mode"], "current");
-        let work = result_fields
-            .as_ref()
-            .and_then(astra_core::work_unit::WorkUnitObservation::from_fields)
-            .expect("current task output must publish the shared work-unit contract");
-        assert_eq!(work.id, "bg-shell-1");
-        assert_eq!(work.kind, "shell");
-        assert_eq!(work.status, astra_core::work_unit::WorkUnitStatus::Running);
-        assert_eq!(work.revision, 8002);
-        assert_eq!(
-            work.mode,
-            astra_core::work_unit::WorkUnitObservationMode::Current
-        );
-        assert_eq!(
-            work.wake_policy,
-            astra_core::work_unit::WorkUnitWakePolicy::OnTerminal
+        assert!(
+            result_fields
+                .as_ref()
+                .and_then(astra_core::work_unit::WorkUnitObservation::from_fields)
+                .is_none(),
+            "task_output is a reader; only the shell producer may advance lifecycle revision"
         );
     }
 
@@ -7484,18 +7434,12 @@ mod tests {
         assert_eq!(observation["mode"], "diagnostic");
         assert_eq!(observation["terminal"], true);
         assert_eq!(observation["matching_lines"], 1);
-        let work = result_fields
-            .as_ref()
-            .and_then(astra_core::work_unit::WorkUnitObservation::from_fields)
-            .expect("diagnostic output must still publish its non-live observation mode");
-        assert_eq!(work.status, astra_core::work_unit::WorkUnitStatus::Failed);
-        assert_eq!(
-            work.mode,
-            astra_core::work_unit::WorkUnitObservationMode::Diagnostic
-        );
-        assert_eq!(
-            work.wake_policy,
-            astra_core::work_unit::WorkUnitWakePolicy::OnTerminal
+        assert!(
+            result_fields
+                .as_ref()
+                .and_then(astra_core::work_unit::WorkUnitObservation::from_fields)
+                .is_none(),
+            "diagnostic reads must not publish lifecycle identity or revision"
         );
     }
 
@@ -8051,6 +7995,34 @@ mod tests {
         assert!(output.contains("title review auth flow"), "{output}");
         assert!(!output.contains("Read shell output"), "{output}");
         assert!(!output.contains("Job"), "{output}");
+    }
+
+    #[test]
+    fn task_output_readers_never_publish_lifecycle_identity_or_revision() {
+        for kind in ["shell", "local agent"] {
+            let snapshot = BgTaskOutputSnapshot {
+                kind: kind.to_string(),
+                title: Some("background work".to_string()),
+                output: "progress".to_string(),
+                end_offset: 8,
+                total_bytes: 8,
+                total_lines: 1,
+                status: BgTaskOutputStatus::Running,
+                output_ref: "producer-owned".to_string(),
+            };
+            let fields = background_task_output_result_fields(
+                "work-1",
+                &snapshot,
+                BgTaskOutputReadMode::Current,
+                false,
+            );
+
+            assert!(fields.contains_key("background_task_observation"));
+            assert!(
+                WorkUnitObservation::from_fields(&fields).is_none(),
+                "{kind} task_output must return read evidence without becoming a lifecycle producer"
+            );
+        }
     }
 
     #[test]

--- a/crates/astra-cli/src/edge_tools/shell.rs
+++ b/crates/astra-cli/src/edge_tools/shell.rs
@@ -4440,7 +4440,7 @@ impl ToolExecutor {
                     task_id,
                     "shell",
                     WorkUnitStatus::Running,
-                    "running:0",
+                    1,
                     WorkUnitObservationMode::Transition,
                 )
                 .expect("detached shell task ids are non-empty")

--- a/crates/astra-cli/src/tests/chat_stream_tests.rs
+++ b/crates/astra-cli/src/tests/chat_stream_tests.rs
@@ -81,7 +81,7 @@ async fn stream_chat_sse_cannot_turn_active_fanout_into_a_completion_claim() {
             "review-group",
             "agent_fanout",
             astra_core::work_unit::WorkUnitStatus::Running,
-            "7",
+            7,
             astra_core::work_unit::WorkUnitObservationMode::Current,
         )
         .unwrap()

--- a/crates/astra-cli/src/tui/background_tasks.rs
+++ b/crates/astra-cli/src/tui/background_tasks.rs
@@ -18,6 +18,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 
+use astra_core::work_unit::{
+    ActiveWorkRegistry, WorkUnitObservation, WorkUnitObservationMode, WorkUnitStatus,
+    WorkUnitWakePolicy,
+};
 use astra_pipeline::output_stream::OutputStream;
 use astra_services::session_workspace::BackgroundShellTaskProjection;
 use astra_text_utils::str_preview::truncate_line;
@@ -186,6 +190,7 @@ pub(crate) struct BackgroundTaskHandle {
     last_tail_probe_at: Option<Instant>,
     no_recent_output_reported: bool,
     cancel_reason: Arc<AtomicU8>,
+    work_revision: u64,
 }
 
 impl BackgroundTaskHandle {
@@ -336,6 +341,7 @@ pub(crate) struct BackgroundTaskRegistry {
     output_probe_rx: mpsc::UnboundedReceiver<Vec<ShellOutputObservation>>,
     output_probe_in_flight: bool,
     last_output_probe_started: Option<Instant>,
+    active_work_registry: Option<Arc<ActiveWorkRegistry>>,
 }
 
 impl BackgroundTaskRegistry {
@@ -350,7 +356,42 @@ impl BackgroundTaskRegistry {
             output_probe_rx,
             output_probe_in_flight: false,
             last_output_probe_started: None,
+            active_work_registry: None,
         }
+    }
+
+    pub fn with_active_work_registry(mut self, registry: Arc<ActiveWorkRegistry>) -> Self {
+        self.active_work_registry = Some(registry);
+        let task_ids = self.tasks.keys().cloned().collect::<Vec<_>>();
+        for task_id in task_ids {
+            self.publish_task(&task_id);
+        }
+        self
+    }
+
+    fn publish_task(&self, task_id: &str) {
+        let (Some(registry), Some(handle)) =
+            (self.active_work_registry.as_ref(), self.tasks.get(task_id))
+        else {
+            return;
+        };
+        let status = match handle.status() {
+            BgTaskStatus::Running => WorkUnitStatus::Running,
+            BgTaskStatus::Stopping => WorkUnitStatus::Stopping,
+            BgTaskStatus::Completed => WorkUnitStatus::Completed,
+            BgTaskStatus::Failed => WorkUnitStatus::Failed,
+            BgTaskStatus::Killed => WorkUnitStatus::Cancelled,
+        };
+        let observation = WorkUnitObservation::new(
+            &handle.id,
+            "shell",
+            status,
+            handle.work_revision.max(1),
+            WorkUnitObservationMode::Current,
+        )
+        .expect("background shell task identities and revisions are canonical")
+        .with_wake_policy(WorkUnitWakePolicy::OnAttentionOrTerminal);
+        registry.observe(&observation);
     }
 
     /// Re-scope output created by tasks spawned after the initial server
@@ -399,8 +440,10 @@ impl BackgroundTaskRegistry {
             last_tail_probe_at: None,
             no_recent_output_reported: false,
             cancel_reason: cancel_reason.clone(),
+            work_revision: 1,
         };
         self.tasks.insert(id.clone(), handle);
+        self.publish_task(&id);
 
         // Enqueue Started BEFORE spawning the JoinSet future. A fast-
         // resolving runner can otherwise emit Completed before the
@@ -496,8 +539,10 @@ impl BackgroundTaskRegistry {
             last_tail_probe_at: None,
             no_recent_output_reported: false,
             cancel_reason: cancel_reason.clone(),
+            work_revision: 1,
         };
         self.tasks.insert(id.clone(), handle);
+        self.publish_task(&id);
 
         self.pending_completions.push(BgTaskEvent::Started {
             id: id.clone(),
@@ -576,8 +621,10 @@ impl BackgroundTaskRegistry {
             last_tail_probe_at: None,
             no_recent_output_reported: false,
             cancel_reason: Arc::new(AtomicU8::new(BgTaskCancelReason::None as u8)),
+            work_revision: if status.is_terminal() { 2 } else { 1 },
         };
         self.tasks.insert(id.to_string(), handle);
+        self.publish_task(id);
         Ok(())
     }
 
@@ -600,7 +647,7 @@ impl BackgroundTaskRegistry {
         self.drain_join_set();
         let handle = self
             .tasks
-            .get(id)
+            .get_mut(id)
             .ok_or_else(|| BackgroundTaskError::not_found(id))?;
         if !handle.live_control.is_available() {
             return Err(BackgroundTaskError::StaleHandle {
@@ -629,6 +676,8 @@ impl BackgroundTaskRegistry {
         // `poll_completions` replaces it with Killed or Failed exactly once.
         handle.set_cancel_reason_if_empty(BgTaskCancelReason::User);
         handle.cancel_token.cancel();
+        handle.work_revision = handle.work_revision.saturating_add(1);
+        self.publish_task(id);
         Ok(())
     }
 
@@ -663,6 +712,7 @@ impl BackgroundTaskRegistry {
                 return;
             }
         };
+        let completion_id = completion.id.clone();
         let mut title = completion.id.clone();
         if let Some(handle) = self.tasks.get_mut(&completion.id) {
             title = handle.description.clone();
@@ -684,7 +734,9 @@ impl BackgroundTaskRegistry {
                     BgTaskStatus::Killed => Some("stopped by user".to_string()),
                     _ => None,
                 });
+            handle.work_revision = handle.work_revision.saturating_add(1);
         }
+        self.publish_task(&completion_id);
         let event = match completion.status {
             BgTaskStatus::Completed => BgTaskEvent::Completed {
                 id: completion.id,
@@ -813,8 +865,10 @@ impl BackgroundTaskRegistry {
                 handle.set_status(BgTaskStatus::Killed);
                 handle.ended_at_ms = Some(unix_epoch_millis());
                 handle.terminal_reason = Some("stopped during registry shutdown".to_string());
+                handle.work_revision = handle.work_revision.saturating_add(1);
                 handle.description.clone()
             };
+            self.publish_task(&id);
             self.pending_completions
                 .push(BgTaskEvent::Killed { id, title });
         }
@@ -2368,6 +2422,7 @@ mod tests {
             last_tail_probe_at: None,
             no_recent_output_reported: false,
             cancel_reason: Arc::new(AtomicU8::new(BgTaskCancelReason::None as u8)),
+            work_revision: 1,
         };
         (handle, dir)
     }

--- a/crates/astra-cli/src/tui/bottom_pane/background_task_view/mod.rs
+++ b/crates/astra-cli/src/tui/bottom_pane/background_task_view/mod.rs
@@ -580,7 +580,7 @@ mod tests {
             typed_row(
                 "agent-storage",
                 BackgroundTaskKind::LocalAgent,
-                "killed",
+                "cancelled",
                 "storage review",
             )
             .with_fanout(fanout("review-1", 3, 1)),

--- a/crates/astra-cli/src/tui/chat_widget/mod.rs
+++ b/crates/astra-cli/src/tui/chat_widget/mod.rs
@@ -6813,7 +6813,7 @@ mod tests {
                 "id": "review-large-terminal",
                 "kind": "agent_fanout",
                 "status": "completed",
-                "version": "terminal-3",
+                "revision": 3,
                 "mode": "transition",
                 "wake_policy": "none"
             }

--- a/crates/astra-cli/src/tui/event_loop.rs
+++ b/crates/astra-cli/src/tui/event_loop.rs
@@ -4869,7 +4869,8 @@ pub(crate) async fn run_tui_session(
     // Background task registry — owns spawned shell/agent processes.
     let mut background_registry = super::background_tasks::BackgroundTaskRegistry::new(
         background_task_output_dir(state.session_id.as_deref()),
-    );
+    )
+    .with_active_work_registry(state.active_work_registry.clone());
     let mut restored_local_agent_task_projections =
         restore_background_task_projections(&mut background_registry, state.session_id.as_deref())
             .await;
@@ -5919,6 +5920,8 @@ pub(crate) async fn run_tui_session(
                                             state.bg_task_commands.clone();
                                         let bg_task_list_cache_for_turn =
                                             state.bg_task_list_cache.clone();
+                                        let active_work_registry_for_turn =
+                                            state.active_work_registry.clone();
                                         let ctx = crate::cli::turn::turn_entry::TurnContext {
                                             api,
                                             profile,
@@ -6299,8 +6302,8 @@ pub(crate) async fn run_tui_session(
                                                                                 .await
                                                                                 .clone();
                                                                         let active_work_observations =
-                                                                            local_agent_snapshot
-                                                                                .fanout_work_unit_observations();
+                                                                            active_work_registry_for_turn
+                                                                                .active_work_observations();
                                                                         match submit_active_run_guidance(
                                                                             &active_turn_local_run_control,
                                                                             &queued_text,
@@ -8273,7 +8276,8 @@ pub(crate) async fn run_tui_session(
                         .await;
                         background_registry = super::background_tasks::BackgroundTaskRegistry::new(
                             background_task_output_dir(state.session_id.as_deref()),
-                        );
+                        )
+                        .with_active_work_registry(state.active_work_registry.clone());
                         restored_local_agent_task_projections = restore_background_task_projections(
                             &mut background_registry,
                             state.session_id.as_deref(),

--- a/crates/astra-cli/src/tui/local_agent_snapshot.rs
+++ b/crates/astra-cli/src/tui/local_agent_snapshot.rs
@@ -9,6 +9,8 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use astra_turn_core::orchestration_fanout_group::AgentFanoutSlotStatus;
+
 #[derive(Clone, Default)]
 pub(crate) struct LocalAgentSnapshot {
     pub available: bool,
@@ -225,6 +227,18 @@ impl LocalAgentSnapshot {
                     && group.summary().uncollected == 0
             });
         }
+        if value.get("event").and_then(serde_json::Value::as_str)
+            == Some("fanout_group_needs_input")
+        {
+            let Some(group_id) = value.get("group_id").and_then(serde_json::Value::as_str) else {
+                return true;
+            };
+            return self.fanout_groups.iter().any(|group| {
+                group.group_id == group_id
+                    && group.work_unit_status()
+                        == astra_core::work_unit::WorkUnitStatus::WaitingForInput
+            });
+        }
         if value.get("event").and_then(serde_json::Value::as_str) != Some("agent_status_changed") {
             return true;
         }
@@ -275,11 +289,11 @@ impl LocalAgentSnapshot {
             // repeated analysis.
             .filter(|agent| agent.run_in_background)
             .filter(|agent| {
-                matches!(
-                    agent.status,
-                    astra_turn_core::orchestration_types::AgentStatus::Waiting { .. }
-                ) || (agent.status.is_terminal()
-                    && !fanout_agent_ids.contains(agent.agent_id.as_str()))
+                !fanout_agent_ids.contains(agent.agent_id.as_str())
+                    && (matches!(
+                        agent.status,
+                        astra_turn_core::orchestration_types::AgentStatus::Waiting { .. }
+                    ) || agent.status.is_terminal())
             })
             .filter(|agent| {
                 previous_status
@@ -346,6 +360,63 @@ impl LocalAgentSnapshot {
             .iter()
             .map(|group| (group.group_id.as_str(), group))
             .collect::<BTreeMap<_, _>>();
+        updates.extend(
+            self.fanout_groups
+                .iter()
+                .filter(|group| {
+                    group.work_unit_status()
+                        == astra_core::work_unit::WorkUnitStatus::WaitingForInput
+                })
+                .filter(|group| {
+                    previous_groups
+                        .get(group.group_id.as_str())
+                        .is_none_or(|previous| {
+                            previous.work_unit_status()
+                                != astra_core::work_unit::WorkUnitStatus::WaitingForInput
+                        })
+                })
+                .map(|group| {
+                    let title = if group.title.trim().is_empty() {
+                        "Agent group".to_string()
+                    } else {
+                        group.title.trim().chars().take(80).collect::<String>()
+                    };
+                    let waiting_slots = group
+                        .slots
+                        .iter()
+                        .filter(|slot| {
+                            slot.status == AgentFanoutSlotStatus::WaitingForInput
+                        })
+                        .map(|slot| {
+                            serde_json::json!({
+                                "slot_index": slot.slot_index,
+                                "slot_id": slot.slot_id,
+                                "agent_id": slot.agent_id,
+                                "reason": slot.terminal_reason,
+                            })
+                        })
+                        .collect::<Vec<_>>();
+                    LocalAgentAttentionUpdate {
+                        receipt: format!("{title} needs input · Shift+↓ inspect"),
+                        notification: serde_json::json!({
+                            "schema": "agent_attention_hint.v1",
+                            "event": "fanout_group_needs_input",
+                            "group_id": group.group_id,
+                            "title": group.title,
+                            "parent_run_id": group.parent_run_id,
+                            "status": "waiting_for_input",
+                            "waiting_slots": waiting_slots,
+                            "authoritative_result_call": {
+                                "tool": "agent_fanout",
+                                "action": "get_results",
+                                "group_id": group.group_id,
+                            },
+                            "instruction": "Resolve this fanout's attention boundary once as one work unit; do not start separate analysis for individual child events.",
+                        })
+                        .to_string(),
+                    }
+                }),
+        );
         updates.extend(
             self.fanout_groups
                 .iter()
@@ -496,8 +567,11 @@ mod tests {
         assert_eq!(running.len(), 1);
         assert_eq!(running[0].id, "review");
         assert_eq!(running[0].status, WorkUnitStatus::Running);
-        assert_eq!(running[0].version, running_revision.to_string());
-        assert_eq!(running[0].wake_policy, WorkUnitWakePolicy::OnTerminal);
+        assert_eq!(running[0].revision, running_revision);
+        assert_eq!(
+            running[0].wake_policy,
+            WorkUnitWakePolicy::OnAttentionOrTerminal
+        );
         let receipt = LocalAgentSnapshot {
             available: true,
             fanout_groups: vec![group.clone()],
@@ -518,7 +592,61 @@ mod tests {
         }
         .fanout_work_unit_observations();
         assert_eq!(terminal[0].status, WorkUnitStatus::Completed);
-        assert_ne!(terminal[0].version, running_revision.to_string());
+        assert_ne!(terminal[0].revision, running_revision);
+    }
+
+    #[test]
+    fn fanout_waiting_wakes_once_at_group_boundary() {
+        let mut running = AgentFanoutGroupProjection::new("review", "Three reviews", 2);
+        running.parent_run_id = Some("root-run".into());
+        running
+            .record_spawn_accepted_with_run(0, "reviewer-1", Some("run-1".into()))
+            .unwrap();
+        running
+            .record_spawn_accepted_with_run(1, "reviewer-2", Some("run-2".into()))
+            .unwrap();
+        let before = LocalAgentSnapshot {
+            available: true,
+            fanout_groups: vec![running.clone()],
+            ..LocalAgentSnapshot::default()
+        };
+
+        running
+            .record_status_by_agent(
+                "reviewer-1",
+                AgentFanoutSlotStatus::WaitingForInput,
+                Some("Which API contract?".into()),
+            )
+            .unwrap();
+        let waiting = LocalAgentSnapshot {
+            available: true,
+            agents: vec![agent(
+                "reviewer-1",
+                "run-1",
+                AgentStatus::Waiting {
+                    reason: "Which API contract?".into(),
+                },
+            )],
+            fanout_groups: vec![running.clone()],
+        };
+        let observation = waiting.fanout_work_unit_observations();
+        assert_eq!(observation[0].status, WorkUnitStatus::WaitingForInput);
+        assert_eq!(
+            observation[0].wake_policy,
+            WorkUnitWakePolicy::OnAttentionOrTerminal
+        );
+
+        let updates = waiting.attention_updates_since(&before);
+        assert_eq!(
+            updates.len(),
+            1,
+            "fanout child must not create a second wake"
+        );
+        let value: serde_json::Value = serde_json::from_str(&updates[0].notification).unwrap();
+        assert_eq!(value["event"], "fanout_group_needs_input");
+        assert_eq!(value["group_id"], "review");
+        assert_eq!(value["waiting_slots"].as_array().unwrap().len(), 1);
+        assert!(waiting.attention_updates_since(&waiting).is_empty());
     }
 
     #[test]

--- a/crates/astra-tools/src/shell_ops.rs
+++ b/crates/astra-tools/src/shell_ops.rs
@@ -992,7 +992,7 @@ pub async fn execute_bash(ctx: &crate::ToolContext, args: &Value) -> ToolResult 
                     task_id,
                     "shell",
                     WorkUnitStatus::Running,
-                    "running:0",
+                    1,
                     WorkUnitObservationMode::Transition,
                 )
                 .expect("detached shell task ids are non-empty")

--- a/crates/astra-turn-core/src/edge_ledger.rs
+++ b/crates/astra-turn-core/src/edge_ledger.rs
@@ -320,6 +320,19 @@ pub fn expect_ledger_entry(ledger: &Arc<tokio::sync::Mutex<HashMap<String, Value
     }
 }
 
+/// Withdraw an expectation when its request could not be committed and
+/// delivered. Callers must do this before returning an execution error so a
+/// request that was never visible cannot authorize a late/spoofed callback.
+pub fn cancel_expected_ledger_entry(
+    ledger: &Arc<tokio::sync::Mutex<HashMap<String, Value>>>,
+    key: &str,
+) {
+    clear_ledger_expectation(ledger, key);
+    if let Ok(mut meta) = ledger_meta().lock() {
+        meta.remove(key);
+    }
+}
+
 /// Whether this process has an active waiter or an unconsumed entry for `key`.
 pub fn ledger_entry_is_expected(
     ledger: &Arc<tokio::sync::Mutex<HashMap<String, Value>>>,
@@ -1192,6 +1205,17 @@ mod tests {
             !ledger_entry_is_expected(&ledger, &key),
             "a timed-out waiter must stop authorizing future callbacks"
         );
+    }
+
+    #[test]
+    fn undelivered_request_withdraws_callback_authority_immediately() {
+        let ledger = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let key = tool_callback_key("u", &Uuid::now_v7().to_string());
+
+        expect_ledger_entry(&ledger, &key);
+        assert!(ledger_entry_is_expected(&ledger, &key));
+        cancel_expected_ledger_entry(&ledger, &key);
+        assert!(!ledger_entry_is_expected(&ledger, &key));
     }
 
     #[test]

--- a/crates/astra-turn-core/src/orchestration/fanout_group.rs
+++ b/crates/astra-turn-core/src/orchestration/fanout_group.rs
@@ -123,6 +123,7 @@ pub enum AgentFanoutSlotStatus {
     SpawnAccepted,
     SpawnRejected,
     Running,
+    WaitingForInput,
     Completed,
     Interrupted,
     Failed,
@@ -139,6 +140,7 @@ impl AgentFanoutSlotStatus {
             Self::SpawnAccepted => "spawn_accepted",
             Self::SpawnRejected => "spawn_rejected",
             Self::Running => "running",
+            Self::WaitingForInput => "waiting_for_input",
             Self::Completed => "completed",
             Self::Interrupted => "interrupted",
             Self::Failed => "failed",
@@ -155,6 +157,7 @@ pub struct AgentFanoutSummary {
     pub planned: usize,
     pub accepted: usize,
     pub active: usize,
+    pub waiting_for_input: usize,
     pub terminal: usize,
     pub completed: usize,
     pub interrupted: usize,
@@ -191,7 +194,7 @@ impl AgentFanoutGroupProjection {
             parent_run_id: None,
             slots,
             status: AgentFanoutStatus::Planned,
-            revision: 0,
+            revision: 1,
             last_touched: SystemTime::now(),
             summary_cache: AgentFanoutSummary {
                 target_count,
@@ -229,7 +232,9 @@ impl AgentFanoutGroupProjection {
     /// this producer-owned projection instead of re-counting slot causes.
     pub fn work_unit_status(&self) -> WorkUnitStatus {
         if !self.is_terminal() {
-            return if self.summary_cache.active > 0 {
+            return if self.summary_cache.waiting_for_input > 0 {
+                WorkUnitStatus::WaitingForInput
+            } else if self.summary_cache.active > 0 {
                 WorkUnitStatus::Running
             } else {
                 WorkUnitStatus::Pending
@@ -247,16 +252,16 @@ impl AgentFanoutGroupProjection {
     /// Consumers must carry this value across model/UI boundaries instead of
     /// rebuilding lifecycle truth from child events, XML projections, or
     /// hand-copied agent IDs. The group revision is the opaque material-state
-    /// version and the runtime owns one update when the group settles.
+    /// revision and the runtime owns attention-required and terminal updates.
     pub fn work_unit_observation(&self) -> Option<WorkUnitObservation> {
         WorkUnitObservation::new(
             &self.group_id,
             "agent_fanout",
             self.work_unit_status(),
-            self.revision.to_string(),
+            self.revision,
             WorkUnitObservationMode::Current,
         )
-        .map(|observation| observation.with_wake_policy(WorkUnitWakePolicy::OnTerminal))
+        .map(|observation| observation.with_wake_policy(WorkUnitWakePolicy::OnAttentionOrTerminal))
     }
 
     pub fn set_slot_request(
@@ -396,6 +401,42 @@ impl AgentFanoutGroupProjection {
         Ok(())
     }
 
+    /// Apply the producer-owned lifecycle state for an accepted slot. Waiting
+    /// is non-terminal but attention-worthy; terminal states remain absorbing.
+    pub fn record_status_by_agent(
+        &mut self,
+        agent_id: &str,
+        status: AgentFanoutSlotStatus,
+        reason: Option<String>,
+    ) -> Result<(), String> {
+        if status.is_terminal() {
+            return self.record_terminal_by_agent(agent_id, status, reason);
+        }
+        let Some(slot_index) = self.agent_slot_index.get(agent_id).copied() else {
+            return Err(format!("fanout agent {agent_id} is not assigned to a slot"));
+        };
+        let Some(slot) = self.slots.get_mut(slot_index) else {
+            self.agent_slot_index.remove(agent_id);
+            return Err(format!("fanout agent {agent_id} is not assigned to a slot"));
+        };
+        if slot.status.is_terminal() {
+            return Err(format!(
+                "fanout agent {agent_id} already recorded terminal status {:?}",
+                slot.status
+            ));
+        }
+        if slot.status == status && slot.terminal_reason == reason {
+            return Ok(());
+        }
+        let old_status = slot.status;
+        slot.status = status;
+        slot.terminal_reason = reason;
+        self.apply_slot_status_transition(old_status, status, true, false);
+        self.recompute_status_from_cache();
+        self.revision = self.revision.saturating_add(1);
+        Ok(())
+    }
+
     pub fn summary(&self) -> AgentFanoutSummary {
         self.summary_cache
     }
@@ -406,7 +447,7 @@ impl AgentFanoutGroupProjection {
             "fanout failed to start fully"
         } else if summary.cancelled_by_parent_budget > 0 {
             "fanout interrupted by budget"
-        } else if summary.active > 0 && summary.terminal > 0 {
+        } else if (summary.active > 0 || summary.waiting_for_input > 0) && summary.terminal > 0 {
             "fanout incomplete"
         } else {
             match self.status {
@@ -461,7 +502,10 @@ impl AgentFanoutGroupProjection {
         let summary = self.summary_cache;
         self.status = if summary.terminal == self.target_count {
             AgentFanoutStatus::Finished
-        } else if summary.active > 0 || (summary.terminal > 0 && summary.planned > 0) {
+        } else if summary.active > 0
+            || summary.waiting_for_input > 0
+            || (summary.terminal > 0 && summary.planned > 0)
+        {
             AgentFanoutStatus::Running
         } else if summary.terminal > 0 {
             AgentFanoutStatus::Incomplete
@@ -491,9 +535,14 @@ fn adjust_summary_for_status(
     }
     if matches!(
         status,
-        AgentFanoutSlotStatus::Running | AgentFanoutSlotStatus::SpawnAccepted
+        AgentFanoutSlotStatus::Running
+            | AgentFanoutSlotStatus::WaitingForInput
+            | AgentFanoutSlotStatus::SpawnAccepted
     ) {
         adjust_summary_value(&mut summary.active, delta);
+    }
+    if status == AgentFanoutSlotStatus::WaitingForInput {
+        adjust_summary_value(&mut summary.waiting_for_input, delta);
     }
     if status.is_terminal() {
         adjust_summary_value(&mut summary.terminal, delta);
@@ -519,7 +568,8 @@ fn adjust_summary_for_status(
         }
         AgentFanoutSlotStatus::Planned
         | AgentFanoutSlotStatus::SpawnAccepted
-        | AgentFanoutSlotStatus::Running => {}
+        | AgentFanoutSlotStatus::Running
+        | AgentFanoutSlotStatus::WaitingForInput => {}
     }
 }
 
@@ -610,26 +660,26 @@ mod tests {
     #[test]
     fn revision_changes_only_for_material_projection_mutations() {
         let mut group = AgentFanoutGroupProjection::new("review-1", "Review fanout", 1);
-        assert_eq!(group.revision, 0);
+        assert_eq!(group.revision, 1);
 
         group.touch();
-        assert_eq!(group.revision, 0, "reads and LRU touches are not progress");
+        assert_eq!(group.revision, 1, "reads and LRU touches are not progress");
 
         group
             .set_slot_request(0, None, "reviewer", "Review auth")
             .unwrap();
-        assert_eq!(group.revision, 1);
-        group.record_spawn_accepted(0, "reviewer@run-1").unwrap();
         assert_eq!(group.revision, 2);
+        group.record_spawn_accepted(0, "reviewer@run-1").unwrap();
+        assert_eq!(group.revision, 3);
         group
             .record_terminal_by_agent("reviewer@run-1", AgentFanoutSlotStatus::Completed, None)
             .unwrap();
-        assert_eq!(group.revision, 3);
-        assert!(group.mark_result_collected("reviewer@run-1"));
         assert_eq!(group.revision, 4);
         assert!(group.mark_result_collected("reviewer@run-1"));
+        assert_eq!(group.revision, 5);
+        assert!(group.mark_result_collected("reviewer@run-1"));
         assert_eq!(
-            group.revision, 4,
+            group.revision, 5,
             "idempotent collection cannot manufacture progress"
         );
     }
@@ -805,10 +855,10 @@ mod tests {
         assert_eq!(planned_observation.id, "planned");
         assert_eq!(planned_observation.kind, "agent_fanout");
         assert_eq!(planned_observation.status, WorkUnitStatus::Pending);
-        assert_eq!(planned_observation.version, planned.revision.to_string());
+        assert_eq!(planned_observation.revision, planned.revision);
         assert_eq!(
             planned_observation.wake_policy,
-            WorkUnitWakePolicy::OnTerminal
+            WorkUnitWakePolicy::OnAttentionOrTerminal
         );
 
         let mut completed = AgentFanoutGroupProjection::new("completed", "Completed", 1);

--- a/crates/astra-turn-core/src/orchestration/types.rs
+++ b/crates/astra-turn-core/src/orchestration/types.rs
@@ -156,7 +156,10 @@ pub fn project_agent_status_to_fanout_slot(status: &AgentStatus) -> AgentFanoutS
                 (AgentFanoutSlotStatus::CancelledByParentBudget, reason)
             }
         }
-        AgentStatus::Waiting { .. } => (AgentFanoutSlotStatus::Running, None),
+        AgentStatus::Waiting { reason } => (
+            AgentFanoutSlotStatus::WaitingForInput,
+            (!reason.trim().is_empty()).then(|| reason.clone()),
+        ),
         AgentStatus::Initializing | AgentStatus::Running { .. } | AgentStatus::Idle => {
             (AgentFanoutSlotStatus::Running, None)
         }

--- a/crates/core/src/work_unit.rs
+++ b/crates/core/src/work_unit.rs
@@ -253,12 +253,6 @@ impl WorkUnitObservationTracker {
             }
             self.cursors.remove(&identity);
             self.terminal.insert(identity, observation.clone());
-            while self.terminal.len() > 256 {
-                let Some(oldest_identity) = self.terminal.keys().next().cloned() else {
-                    break;
-                };
-                self.terminal.remove(&oldest_identity);
-            }
             return WorkUnitObservationOutcome::Terminal;
         }
         match self.cursors.get_mut(&identity) {
@@ -549,6 +543,49 @@ mod tests {
             )),
             WorkUnitObservationOutcome::Ignored,
             "a delayed non-terminal snapshot must not resurrect terminal work"
+        );
+        assert!(tracker.is_empty());
+    }
+
+    #[test]
+    fn terminal_truth_is_not_evicted_during_a_long_session() {
+        let mut tracker = WorkUnitObservationTracker::default();
+        for index in 0..512 {
+            let running = WorkUnitObservation::new(
+                format!("work-{index:04}"),
+                "agent",
+                WorkUnitStatus::Running,
+                1,
+                WorkUnitObservationMode::Transition,
+            )
+            .unwrap();
+            let completed = WorkUnitObservation::new(
+                format!("work-{index:04}"),
+                "agent",
+                WorkUnitStatus::Completed,
+                2,
+                WorkUnitObservationMode::Transition,
+            )
+            .unwrap();
+            assert_eq!(tracker.observe(&running), WorkUnitObservationOutcome::First);
+            assert_eq!(
+                tracker.observe(&completed),
+                WorkUnitObservationOutcome::Terminal
+            );
+        }
+
+        let delayed = WorkUnitObservation::new(
+            "work-0000",
+            "agent",
+            WorkUnitStatus::Running,
+            1,
+            WorkUnitObservationMode::Current,
+        )
+        .unwrap();
+        assert_eq!(
+            tracker.observe(&delayed),
+            WorkUnitObservationOutcome::Ignored,
+            "session-scoped terminal truth must remain absorbing regardless of identity order"
         );
         assert!(tracker.is_empty());
     }

--- a/crates/core/src/work_unit.rs
+++ b/crates/core/src/work_unit.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -50,7 +51,7 @@ impl WorkUnitStatus {
             "completed_with_issues" => Some(Self::CompletedWithIssues),
             "failed" => Some(Self::Failed),
             "interrupted" => Some(Self::Interrupted),
-            "cancelled" | "killed" => Some(Self::Cancelled),
+            "cancelled" => Some(Self::Cancelled),
             "unavailable" => Some(Self::Unavailable),
             _ => None,
         }
@@ -119,15 +120,16 @@ impl WorkUnitWakePolicy {
 
 /// Canonical observation of one asynchronously evolving unit of work.
 ///
-/// `version` is an opaque producer-owned token. It must change whenever the
-/// material state represented by this observation changes. Consumers compare
-/// it for equality; they do not parse it or manufacture their own revision.
+/// `revision` is a producer-owned monotonic sequence for this `(kind, id)`.
+/// Consumers reject older observations instead of treating arrival order as
+/// lifecycle order. Producers must increment it whenever material state
+/// changes; equal revisions are idempotent re-observations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkUnitObservation {
     pub id: String,
     pub kind: String,
     pub status: WorkUnitStatus,
-    pub version: String,
+    pub revision: u64,
     pub mode: WorkUnitObservationMode,
     /// Delivery contract for the next meaningful boundary. Defaults to
     /// `none` so older or third-party producers cannot accidentally claim an
@@ -141,14 +143,14 @@ impl WorkUnitObservation {
         id: impl Into<String>,
         kind: impl Into<String>,
         status: WorkUnitStatus,
-        version: impl Into<String>,
+        revision: u64,
         mode: WorkUnitObservationMode,
     ) -> Option<Self> {
         let observation = Self {
             id: id.into(),
             kind: kind.into(),
             status,
-            version: version.into(),
+            revision,
             mode,
             wake_policy: WorkUnitWakePolicy::None,
         };
@@ -161,9 +163,7 @@ impl WorkUnitObservation {
     }
 
     pub fn is_valid(&self) -> bool {
-        !self.id.trim().is_empty()
-            && !self.kind.trim().is_empty()
-            && !self.version.trim().is_empty()
+        !self.id.trim().is_empty() && !self.kind.trim().is_empty() && self.revision > 0
     }
 
     pub fn identity(&self) -> String {
@@ -200,7 +200,8 @@ struct WorkUnitCursor {
     kind: String,
     status: WorkUnitStatus,
     wake_policy: WorkUnitWakePolicy,
-    version: String,
+    revision: u64,
+    mode: WorkUnitObservationMode,
     unchanged: u32,
 }
 
@@ -218,7 +219,7 @@ pub struct ActiveWorkUnit {
     pub wake_policy: WorkUnitWakePolicy,
 }
 
-/// Turn-scoped progress tracker shared by every asynchronous work producer.
+/// Progress tracker shared by every asynchronous work producer.
 ///
 /// It deliberately knows nothing about tool names or argument shapes.
 #[derive(Debug, Clone, Default)]
@@ -237,12 +238,27 @@ impl WorkUnitObservationTracker {
             return WorkUnitObservationOutcome::Ignored;
         }
         let identity = observation.identity();
-        if self.terminal.contains_key(&identity) && !observation.status.is_terminal() {
+        if let Some(terminal) = self.terminal.get(&identity)
+            && (!observation.status.is_terminal() || observation.revision <= terminal.revision)
+        {
             return WorkUnitObservationOutcome::Ignored;
         }
         if observation.status.is_terminal() {
+            if self
+                .cursors
+                .get(&identity)
+                .is_some_and(|cursor| observation.revision <= cursor.revision)
+            {
+                return WorkUnitObservationOutcome::Ignored;
+            }
             self.cursors.remove(&identity);
             self.terminal.insert(identity, observation.clone());
+            while self.terminal.len() > 256 {
+                let Some(oldest_identity) = self.terminal.keys().next().cloned() else {
+                    break;
+                };
+                self.terminal.remove(&oldest_identity);
+            }
             return WorkUnitObservationOutcome::Terminal;
         }
         match self.cursors.get_mut(&identity) {
@@ -254,30 +270,33 @@ impl WorkUnitObservationTracker {
                         kind: observation.kind.trim().to_string(),
                         status: observation.status,
                         wake_policy: observation.wake_policy,
-                        version: observation.version.clone(),
+                        revision: observation.revision,
+                        mode: observation.mode,
                         unchanged: 0,
                     },
                 );
                 WorkUnitObservationOutcome::First
             }
-            Some(cursor) if cursor.version == observation.version => {
+            Some(cursor) if cursor.revision == observation.revision => {
                 // Wake ownership is delivery metadata, not lifecycle state.
                 // Honor the latest producer contract even if an adapter adds
                 // it without changing the underlying work revision.
-                cursor.status = observation.status;
                 cursor.wake_policy = observation.wake_policy;
+                cursor.mode = observation.mode;
                 cursor.unchanged = cursor.unchanged.saturating_add(1);
                 WorkUnitObservationOutcome::Unchanged {
                     consecutive: cursor.unchanged,
                 }
             }
-            Some(cursor) => {
-                cursor.version.clone_from(&observation.version);
+            Some(cursor) if observation.revision > cursor.revision => {
+                cursor.revision = observation.revision;
                 cursor.status = observation.status;
                 cursor.wake_policy = observation.wake_policy;
+                cursor.mode = observation.mode;
                 cursor.unchanged = 0;
                 WorkUnitObservationOutcome::Advanced
             }
+            Some(_) => WorkUnitObservationOutcome::Ignored,
         }
     }
 
@@ -317,14 +336,46 @@ impl WorkUnitObservationTracker {
             .collect()
     }
 
+    /// Return the latest canonical producer observations, preserving revision
+    /// so another turn or deployment entrypoint can seed its own tracker
+    /// without reconstructing lifecycle state from display projections.
+    pub fn active_observations(&self) -> Vec<WorkUnitObservation> {
+        self.cursors
+            .values()
+            .map(|cursor| WorkUnitObservation {
+                id: cursor.id.clone(),
+                kind: cursor.kind.clone(),
+                status: cursor.status,
+                revision: cursor.revision,
+                mode: cursor.mode,
+                wake_policy: cursor.wake_policy,
+            })
+            .collect()
+    }
+
     /// Accepted terminal producer observation for an identity, if any.
     ///
-    /// This is intentionally identity-based and does not compare opaque
-    /// versions. Arrival at the producer seam establishes order; terminal is
-    /// absorbing for a work-unit identity within one turn.
+    /// Terminal is absorbing for a work-unit identity; a producer may only
+    /// refine terminal truth with a strictly newer terminal revision.
     pub fn terminal_observation(&self, id: &str, kind: &str) -> Option<&WorkUnitObservation> {
         let identity = format!("{}:{}", kind.trim(), id.trim());
         self.terminal.get(&identity)
+    }
+
+    pub fn canonical_observation(&self, id: &str, kind: &str) -> Option<WorkUnitObservation> {
+        let identity = format!("{}:{}", kind.trim(), id.trim());
+        self.terminal.get(&identity).cloned().or_else(|| {
+            self.cursors
+                .get(&identity)
+                .map(|cursor| WorkUnitObservation {
+                    id: cursor.id.clone(),
+                    kind: cursor.kind.clone(),
+                    status: cursor.status,
+                    revision: cursor.revision,
+                    mode: cursor.mode,
+                    wake_policy: cursor.wake_policy,
+                })
+        })
     }
 
     pub fn clear(&mut self) {
@@ -337,12 +388,52 @@ impl WorkUnitObservationTracker {
     }
 }
 
+/// One session-scoped authority for asynchronous work visible at model
+/// boundaries. Producers publish typed observations here; CLI, Server-only,
+/// and Edge-backed turns consume the same provider contract.
+#[derive(Debug, Default)]
+pub struct ActiveWorkRegistry {
+    tracker: Mutex<WorkUnitObservationTracker>,
+}
+
+impl ActiveWorkRegistry {
+    pub fn observe(&self, observation: &WorkUnitObservation) -> WorkUnitObservationOutcome {
+        crate::sync_poison::recover_mutex_lock(&self.tracker).observe(observation)
+    }
+
+    pub fn active_work_observations(&self) -> Vec<WorkUnitObservation> {
+        crate::sync_poison::recover_mutex_lock(&self.tracker).active_observations()
+    }
+
+    pub fn terminal_observation(&self, id: &str, kind: &str) -> Option<WorkUnitObservation> {
+        crate::sync_poison::recover_mutex_lock(&self.tracker)
+            .terminal_observation(id, kind)
+            .cloned()
+    }
+
+    pub fn canonical_observation(&self, id: &str, kind: &str) -> Option<WorkUnitObservation> {
+        crate::sync_poison::recover_mutex_lock(&self.tracker).canonical_observation(id, kind)
+    }
+}
+
+#[async_trait::async_trait]
+pub trait ActiveWorkProvider: Send + Sync {
+    async fn active_work_observations(&self) -> Vec<WorkUnitObservation>;
+}
+
+#[async_trait::async_trait]
+impl ActiveWorkProvider for ActiveWorkRegistry {
+    async fn active_work_observations(&self) -> Vec<WorkUnitObservation> {
+        self.active_work_observations()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn canonical_status_protocol_accepts_legacy_killed_without_reemitting_it() {
+    fn canonical_status_protocol_has_one_spelling_per_state() {
         for status in [
             WorkUnitStatus::Pending,
             WorkUnitStatus::Running,
@@ -357,28 +448,25 @@ mod tests {
         ] {
             assert_eq!(WorkUnitStatus::parse(status.as_str()), Some(status));
         }
-        assert_eq!(
-            WorkUnitStatus::parse("killed"),
-            Some(WorkUnitStatus::Cancelled)
-        );
         assert_eq!(WorkUnitStatus::Cancelled.as_str(), "cancelled");
+        assert_eq!(WorkUnitStatus::parse("killed"), None);
         assert_eq!(WorkUnitStatus::parse("unknown"), None);
     }
 
     fn observation(
-        version: &str,
+        revision: u64,
         status: WorkUnitStatus,
         mode: WorkUnitObservationMode,
     ) -> WorkUnitObservation {
-        WorkUnitObservation::new("work-1", "test", status, version, mode).unwrap()
+        WorkUnitObservation::new("work-1", "test", status, revision, mode).unwrap()
     }
 
     #[test]
-    fn tracker_uses_producer_version_instead_of_tool_identity() {
+    fn tracker_uses_monotonic_producer_revision_instead_of_arrival_order() {
         let mut tracker = WorkUnitObservationTracker::default();
         assert_eq!(
             tracker.observe(&observation(
-                "v1",
+                1,
                 WorkUnitStatus::Running,
                 WorkUnitObservationMode::Transition,
             )),
@@ -386,7 +474,7 @@ mod tests {
         );
         assert_eq!(
             tracker.observe(&observation(
-                "v1",
+                1,
                 WorkUnitStatus::Running,
                 WorkUnitObservationMode::Current,
             )),
@@ -394,13 +482,25 @@ mod tests {
         );
         assert_eq!(
             tracker.observe(&observation(
-                "v2",
+                2,
                 WorkUnitStatus::Running,
                 WorkUnitObservationMode::Wait,
             )),
             WorkUnitObservationOutcome::Advanced
         );
         assert!(tracker.repeatedly_unchanged_ids(1).is_empty());
+        assert_eq!(
+            tracker.observe(&observation(
+                1,
+                WorkUnitStatus::WaitingForInput,
+                WorkUnitObservationMode::Current,
+            )),
+            WorkUnitObservationOutcome::Ignored
+        );
+        assert_eq!(
+            tracker.active_work_units()[0].status,
+            WorkUnitStatus::Running
+        );
     }
 
     #[test]
@@ -411,7 +511,7 @@ mod tests {
             WorkUnitObservationMode::Diagnostic,
         ] {
             assert_eq!(
-                tracker.observe(&observation("v1", WorkUnitStatus::Running, mode)),
+                tracker.observe(&observation(1, WorkUnitStatus::Running, mode)),
                 WorkUnitObservationOutcome::Ignored
             );
         }
@@ -422,13 +522,13 @@ mod tests {
     fn terminal_status_is_the_single_source_of_truth() {
         let mut tracker = WorkUnitObservationTracker::default();
         tracker.observe(&observation(
-            "v1",
+            1,
             WorkUnitStatus::Running,
             WorkUnitObservationMode::Current,
         ));
         assert_eq!(
             tracker.observe(&observation(
-                "v2",
+                2,
                 WorkUnitStatus::CompletedWithIssues,
                 WorkUnitObservationMode::Transition,
             )),
@@ -443,7 +543,7 @@ mod tests {
         );
         assert_eq!(
             tracker.observe(&observation(
-                "stale-v1",
+                1,
                 WorkUnitStatus::Running,
                 WorkUnitObservationMode::Current,
             )),
@@ -456,11 +556,7 @@ mod tests {
     #[test]
     fn automatic_wake_is_an_explicit_producer_promise() {
         let mut tracker = WorkUnitObservationTracker::default();
-        let first = observation(
-            "v1",
-            WorkUnitStatus::Running,
-            WorkUnitObservationMode::Current,
-        );
+        let first = observation(1, WorkUnitStatus::Running, WorkUnitObservationMode::Current);
         tracker.observe(&first);
         tracker.observe(&first);
         assert_eq!(tracker.repeatedly_unchanged_without_wake(1), ["work-1"]);
@@ -473,12 +569,8 @@ mod tests {
     #[test]
     fn active_work_snapshot_tracks_latest_nonterminal_truth_and_drops_terminal_units() {
         let mut tracker = WorkUnitObservationTracker::default();
-        let running = observation(
-            "revision-1",
-            WorkUnitStatus::Running,
-            WorkUnitObservationMode::Current,
-        )
-        .with_wake_policy(WorkUnitWakePolicy::OnTerminal);
+        let running = observation(1, WorkUnitStatus::Running, WorkUnitObservationMode::Current)
+            .with_wake_policy(WorkUnitWakePolicy::OnTerminal);
         assert_eq!(tracker.observe(&running), WorkUnitObservationOutcome::First);
         assert_eq!(
             tracker.active_work_units(),
@@ -491,7 +583,7 @@ mod tests {
         );
 
         let waiting = observation(
-            "revision-2",
+            2,
             WorkUnitStatus::WaitingForInput,
             WorkUnitObservationMode::Transition,
         )
@@ -506,7 +598,7 @@ mod tests {
         );
 
         let completed = observation(
-            "revision-3",
+            3,
             WorkUnitStatus::Completed,
             WorkUnitObservationMode::Transition,
         );

--- a/crates/runtime/src/app_state.rs
+++ b/crates/runtime/src/app_state.rs
@@ -68,6 +68,21 @@ pub enum MemoriaHealth {
     Disabled,
 }
 
+#[derive(Clone, Debug)]
+struct CachedMemoriaHealth {
+    value: MemoriaHealth,
+    refreshed_at: Option<std::time::Instant>,
+}
+
+impl CachedMemoriaHealth {
+    fn new(value: MemoriaHealth) -> Self {
+        Self {
+            value,
+            refreshed_at: None,
+        }
+    }
+}
+
 impl MemoriaHealth {
     pub fn label(&self) -> &'static str {
         match self {
@@ -200,6 +215,8 @@ pub struct AppState {
     pub memoria_base_url: String,
     pub memoria_master_key: Option<String>,
     pub memoria_forwarder: Arc<dyn MemoriaForwarder>,
+    memoria_health_cache: Arc<std::sync::RwLock<CachedMemoriaHealth>>,
+    memoria_health_refresh: Arc<tokio::sync::Mutex<()>>,
     pub shared_pool: Option<SharedPool>,
     /// Owner-neutral Matrix pool, journal ingestion, sync persistence, and shutdown tracking.
     pub(crate) matrix_cloud_runtime: Option<Arc<crate::matrix_cloud_runtime::MatrixCloudRuntime>>,
@@ -309,6 +326,10 @@ impl AppState {
             memoria_base_url: default_memoria.base_url,
             memoria_master_key: default_memoria.master_key,
             memoria_forwarder: Arc::new(NoopMemoriaForwarder),
+            memoria_health_cache: Arc::new(std::sync::RwLock::new(CachedMemoriaHealth::new(
+                MemoriaHealth::Disabled,
+            ))),
+            memoria_health_refresh: Arc::new(tokio::sync::Mutex::new(())),
             shared_pool: None,
             matrix_cloud_runtime: None,
             edge_callback_ledger: Arc::new(tokio::sync::Mutex::new(
@@ -362,6 +383,14 @@ impl AppState {
         } else {
             Arc::new(ReqwestMemoriaForwarder::new(base_url.clone(), key))
         };
+        *astra_core::sync_poison::recover_rwlock_write(&self.memoria_health_cache) =
+            CachedMemoriaHealth::new(
+                if master_key.as_deref().is_some_and(|key| !key.is_empty()) {
+                    MemoriaHealth::Unavailable("probe pending".to_string())
+                } else {
+                    MemoriaHealth::Disabled
+                },
+            );
         self.memoria_base_url = base_url;
         self.memoria_master_key = master_key;
         self
@@ -370,7 +399,38 @@ impl AppState {
     /// Inject a custom MemoriaForwarder (for testing).
     pub fn with_memoria_forwarder(mut self, forwarder: Arc<dyn MemoriaForwarder>) -> Self {
         self.memoria_forwarder = forwarder;
+        *astra_core::sync_poison::recover_rwlock_write(&self.memoria_health_cache) =
+            CachedMemoriaHealth::new(MemoriaHealth::Unavailable("probe pending".to_string()));
         self
+    }
+
+    pub fn cached_memoria_health(&self) -> MemoriaHealth {
+        astra_core::sync_poison::recover_rwlock_read(&self.memoria_health_cache)
+            .value
+            .clone()
+    }
+
+    /// Refresh a capability probe at most once per `max_age`. The lock is
+    /// rechecked after acquisition, so concurrent callers collapse into one
+    /// outbound request instead of serially replaying the same probe.
+    pub async fn refresh_memoria_health_if_stale(
+        &self,
+        max_age: std::time::Duration,
+    ) -> MemoriaHealth {
+        let _refresh = self.memoria_health_refresh.lock().await;
+        {
+            let cached = astra_core::sync_poison::recover_rwlock_read(&self.memoria_health_cache);
+            if cached.refreshed_at.is_some_and(|at| at.elapsed() < max_age) {
+                return cached.value.clone();
+            }
+        }
+        let value = self.memoria_forwarder.health().await;
+        *astra_core::sync_poison::recover_rwlock_write(&self.memoria_health_cache) =
+            CachedMemoriaHealth {
+                value: value.clone(),
+                refreshed_at: Some(std::time::Instant::now()),
+            };
+        value
     }
 
     pub fn with_admin_authorizer(mut self, admin_authorizer: Arc<dyn AdminAuthorizer>) -> Self {
@@ -872,6 +932,18 @@ impl ReqwestMemoriaForwarder {
             .header("Authorization", format!("Bearer {}", self.master_key))
             .json(body)
     }
+
+    async fn bounded_error_body(mut response: reqwest::Response, limit: usize) -> String {
+        let mut body = Vec::with_capacity(limit.min(1024));
+        while body.len() < limit {
+            let Ok(Some(chunk)) = response.chunk().await else {
+                break;
+            };
+            let remaining = limit - body.len();
+            body.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+        }
+        String::from_utf8_lossy(&body).into_owned()
+    }
 }
 
 #[async_trait]
@@ -889,7 +961,7 @@ impl MemoriaForwarder for ReqwestMemoriaForwarder {
             .map_err(|e| format!("Memoria request failed: {e}"))?;
         if !resp.status().is_success() {
             let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
+            let text = Self::bounded_error_body(resp, 4096).await;
             return Err(format!("Memoria error {status}: {text}"));
         }
         let text = resp
@@ -915,9 +987,8 @@ impl MemoriaForwarder for ReqwestMemoriaForwarder {
             Ok(response) if response.status().is_success() => MemoriaHealth::Connected,
             Ok(response) => {
                 let status = response.status();
-                let body = response.text().await.unwrap_or_default();
-                let bounded_body = body.chars().take(1024).collect::<String>();
-                MemoriaHealth::Unavailable(format!("status={status}, body={bounded_body}"))
+                let body = Self::bounded_error_body(response, 1024).await;
+                MemoriaHealth::Unavailable(format!("status={status}, body={body}"))
             }
             Err(error) => MemoriaHealth::Unavailable(error.to_string()),
         }
@@ -1183,9 +1254,14 @@ mod tests {
                     .contains("authorization: bearer test-key"),
                 "{request}"
             );
+            let body = format!("database absent{}", "x".repeat(8192));
             socket
                 .write_all(
-                    b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 15\r\nConnection: close\r\n\r\ndatabase absent",
+                    format!(
+                        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(), body
+                    )
+                    .as_bytes(),
                 )
                 .await
                 .unwrap();
@@ -1202,7 +1278,9 @@ mod tests {
         assert!(matches!(
             health,
             MemoriaHealth::Unavailable(detail)
-                if detail.contains("503") && detail.contains("database absent")
+                if detail.contains("503")
+                    && detail.contains("database absent")
+                    && detail.len() < 1200
         ));
         server.await.unwrap();
     }

--- a/crates/runtime/src/orchestration/agent_tool.rs
+++ b/crates/runtime/src/orchestration/agent_tool.rs
@@ -2386,7 +2386,10 @@ mod tests {
         assert_eq!(observation.kind, "agent");
         assert_eq!(observation.status, WorkUnitStatus::Running);
         assert_eq!(observation.mode, WorkUnitObservationMode::Transition);
-        assert_eq!(observation.wake_policy, WorkUnitWakePolicy::OnTerminal);
+        assert_eq!(
+            observation.wake_policy,
+            WorkUnitWakePolicy::OnAttentionOrTerminal
+        );
     }
 
     #[test]
@@ -3891,7 +3894,7 @@ mod tests {
         assert_eq!(value["results"].as_array().unwrap().len(), 3);
         assert_eq!(
             value[WORK_UNIT_OBSERVATION_FIELD]["wake_policy"],
-            "on_terminal"
+            "on_attention_or_terminal"
         );
         assert!(
             rendered.len() < 40_000,

--- a/crates/runtime/src/orchestration/agent_tool.rs
+++ b/crates/runtime/src/orchestration/agent_tool.rs
@@ -95,7 +95,7 @@ fn render_spawn_agent_output(
         .and_then(Value::as_str)
         .unwrap_or("failed")
         .to_string();
-    if let (Some(agent_id), Some(run_id)) = (
+    if let (Some(agent_id), Some(_run_id)) = (
         object.get("agent_id").and_then(Value::as_str),
         object.get("run_id").and_then(Value::as_str),
     ) {
@@ -111,13 +111,17 @@ fn render_spawn_agent_output(
             agent_id,
             "agent",
             work_status,
-            format!("{run_id}:{status}"),
+            match work_status {
+                WorkUnitStatus::Running => 1,
+                WorkUnitStatus::WaitingForInput => 2,
+                _ => 3,
+            },
             WorkUnitObservationMode::Transition,
         ) {
             let observation = if work_status.is_terminal() {
                 observation
             } else {
-                observation.with_wake_policy(WorkUnitWakePolicy::OnTerminal)
+                observation.with_wake_policy(WorkUnitWakePolicy::OnAttentionOrTerminal)
             };
             object.insert(
                 WORK_UNIT_OBSERVATION_FIELD.to_string(),
@@ -1568,11 +1572,11 @@ async fn render_agent_fanout_results(
         group_id,
         "agent_fanout",
         work_status,
-        updated.revision.to_string(),
+        updated.revision,
         observation_mode,
     )
     .expect("fanout groups have non-empty identities and revisions")
-    .with_wake_policy(WorkUnitWakePolicy::OnTerminal);
+    .with_wake_policy(WorkUnitWakePolicy::OnAttentionOrTerminal);
     let mut response = json!({
         "status": fanout_get_results_status_label(&updated),
         "group_id": group_id,

--- a/crates/runtime/src/orchestration/spawner.rs
+++ b/crates/runtime/src/orchestration/spawner.rs
@@ -622,6 +622,8 @@ pub struct SpawnedAgentState {
     pub agent_type: String,
     pub description: String,
     pub status: AgentStatus,
+    /// Producer-owned monotonic lifecycle revision for this agent work unit.
+    pub work_revision: u64,
     pub messaging_address: Option<AgentAddress>,
     pub worktree_path: Option<PathBuf>,
     pub started_at: SystemTime,
@@ -983,7 +985,7 @@ pub struct DynamicAgentSpawner {
     /// are sequential, so an identical second control read reuses this result
     /// instead of repeating child-result collection and durable reads.
     fanout_terminal_result_cache: Arc<RwLock<HashMap<String, String>>>,
-    /// Cached count of active fanout slots (Running status). Derived from
+    /// Cached count of active fanout slots (running or waiting for input). Derived from
     /// `fanout_groups`; state-transition paths update it for cheap telemetry.
     ///
     /// Updated atomically on every state transition for cheap fanout
@@ -997,6 +999,9 @@ pub struct DynamicAgentSpawner {
     /// Only these states may be replaced by durable reconciliation.
     durable_observed_agent_ids: Arc<RwLock<HashSet<String>>>,
     durable_reconcile_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Session-scoped typed work authority shared by CLI and Server model
+    /// boundaries. Fanout mutations publish here at the producer seam.
+    active_work_registry: Option<Arc<astra_core::work_unit::ActiveWorkRegistry>>,
 }
 
 impl DynamicAgentSpawner {
@@ -1031,6 +1036,7 @@ impl DynamicAgentSpawner {
             durable_reconciler: Arc::new(RwLock::new(None)),
             durable_observed_agent_ids: Arc::new(RwLock::new(HashSet::new())),
             durable_reconcile_lock: Arc::new(tokio::sync::Mutex::new(())),
+            active_work_registry: None,
         }
     }
 
@@ -1077,6 +1083,7 @@ impl DynamicAgentSpawner {
                     continue;
                 }
                 state.status = status;
+                state.work_revision = state.work_revision.saturating_add(1);
                 state.ended_at = durable_run_is_terminal(&run.status).then(SystemTime::now);
                 state.metrics.tool_calls = run.total_tool_calls;
                 state.metrics.prompt_tokens = run.total_prompt_tokens;
@@ -1085,6 +1092,7 @@ impl DynamicAgentSpawner {
             }
         }
         for state in &changed {
+            self.publish_background_agent(state);
             if agent_status_is_terminal(&state.status) {
                 self.record_fanout_terminal_state(state).await;
                 self.notify_completion(&state.agent_id).await;
@@ -1137,6 +1145,7 @@ impl DynamicAgentSpawner {
                 agent_type: "restored".into(),
                 description: projection.title.clone(),
                 status,
+                work_revision: 2,
                 messaging_address: None,
                 worktree_path: None,
                 started_at,
@@ -1177,6 +1186,7 @@ impl DynamicAgentSpawner {
                     self.record_fanout_terminal_state(&state).await;
                 }
             }
+            self.publish_background_agent(&state);
             self.archive_state(state).await;
             restored += 1;
         }
@@ -1221,6 +1231,7 @@ impl DynamicAgentSpawner {
                     .or_else(|| run.agent_binding_name.clone())
                     .unwrap_or_else(|| agent_id.to_string()),
                 status,
+                work_revision: run.run_generation.max(1),
                 messaging_address: None,
                 worktree_path: None,
                 started_at: SystemTime::now(),
@@ -1262,6 +1273,7 @@ impl DynamicAgentSpawner {
                 .write()
                 .await
                 .insert(state.agent_id.clone());
+            self.publish_background_agent(&state);
             self.archive_state(state).await;
             restored += 1;
         }
@@ -1299,6 +1311,14 @@ impl DynamicAgentSpawner {
             executor.bind_parent_session(&session_id);
         }
         self.executor = Some(executor);
+        self
+    }
+
+    pub fn with_active_work_registry(
+        mut self,
+        registry: Arc<astra_core::work_unit::ActiveWorkRegistry>,
+    ) -> Self {
+        self.active_work_registry = Some(registry);
         self
     }
 
@@ -1385,6 +1405,48 @@ impl DynamicAgentSpawner {
             .collect()
     }
 
+    fn publish_fanout_group(&self, group: &AgentFanoutGroupProjection) {
+        let Some(registry) = self.active_work_registry.as_ref() else {
+            return;
+        };
+        if let Some(observation) = group.work_unit_observation() {
+            registry.observe(&observation);
+        }
+    }
+
+    fn publish_background_agent(&self, state: &SpawnedAgentState) {
+        use astra_core::work_unit::{
+            WorkUnitObservation, WorkUnitObservationMode, WorkUnitStatus, WorkUnitWakePolicy,
+        };
+
+        let Some(registry) = self.active_work_registry.as_ref() else {
+            return;
+        };
+        // Fanout children are represented by exactly one group work unit.
+        if !state.run_in_background || state.fanout_slot.is_some() {
+            return;
+        }
+        let status = match &state.status {
+            AgentStatus::Initializing => WorkUnitStatus::Pending,
+            AgentStatus::Running { .. } | AgentStatus::Idle => WorkUnitStatus::Running,
+            AgentStatus::Waiting { .. } => WorkUnitStatus::WaitingForInput,
+            AgentStatus::Completed { .. } => WorkUnitStatus::Completed,
+            AgentStatus::Interrupted { .. } => WorkUnitStatus::Interrupted,
+            AgentStatus::Failed { .. } => WorkUnitStatus::Failed,
+            AgentStatus::Cancelled { .. } => WorkUnitStatus::Cancelled,
+        };
+        let Some(observation) = WorkUnitObservation::new(
+            state.agent_id.clone(),
+            "agent",
+            status,
+            state.work_revision.max(1),
+            WorkUnitObservationMode::Current,
+        ) else {
+            return;
+        };
+        registry.observe(&observation.with_wake_policy(WorkUnitWakePolicy::OnAttentionOrTerminal));
+    }
+
     pub async fn declare_fanout_group(
         &self,
         group_id: &str,
@@ -1409,6 +1471,7 @@ impl DynamicAgentSpawner {
         }
         if let Some(group) = groups.get_mut(group_id) {
             group.touch();
+            self.publish_fanout_group(group);
         }
         Ok(())
     }
@@ -1709,6 +1772,7 @@ impl DynamicAgentSpawner {
             .remove(&identity.group_id);
         self.adjust_cached_active_fanout_slots(active_before, active_after);
         index.insert(agent_id.to_string(), identity.group_id.clone());
+        self.publish_fanout_group(group);
         Ok(())
     }
 
@@ -1757,6 +1821,7 @@ impl DynamicAgentSpawner {
         let active_after = group.summary().active;
         group.touch();
         self.adjust_cached_active_fanout_slots(active_before, active_after);
+        self.publish_fanout_group(group);
         Ok(())
     }
 
@@ -1812,18 +1877,19 @@ impl DynamicAgentSpawner {
             return;
         };
         let active_before = group.summary().active;
-        if let Err(error) = group.record_terminal_by_agent(&state.agent_id, status, reason) {
+        if let Err(error) = group.record_status_by_agent(&state.agent_id, status, reason) {
             tracing::warn!(
                 target: "fanout",
                 agent_id = %state.agent_id,
                 group_id = %identity.group_id,
                 error = %error,
-                "record fanout terminal failed; skipping touch/budget adjust",
+                "record fanout lifecycle state failed; skipping touch/budget adjust",
             );
             return;
         }
         let active_after = group.summary().active;
         group.touch();
+        self.publish_fanout_group(group);
         self.fanout_terminal_result_cache
             .write()
             .await
@@ -1917,7 +1983,7 @@ impl DynamicAgentSpawner {
         }
     }
 
-    /// Authoritative count: number of slots in Running status across
+    /// Authoritative count: number of non-terminal accepted slots across
     /// all non-terminal fanout groups.  This is the single source of
     /// truth — `cached_active_fanout_slots` is just a performance
     /// optimization derived from this computation.
@@ -1927,7 +1993,12 @@ impl DynamicAgentSpawner {
             .values()
             .filter(|g| !g.is_terminal())
             .flat_map(|g| g.slots.iter())
-            .filter(|s| matches!(s.status, AgentFanoutSlotStatus::Running))
+            .filter(|s| {
+                matches!(
+                    s.status,
+                    AgentFanoutSlotStatus::Running | AgentFanoutSlotStatus::WaitingForInput
+                )
+            })
             .count()
     }
 
@@ -1939,6 +2010,7 @@ impl DynamicAgentSpawner {
         if let Some(group) = groups.get_mut(&identity.group_id) {
             group.mark_result_collected(&state.agent_id);
             group.touch();
+            self.publish_fanout_group(group);
         }
     }
 
@@ -2372,6 +2444,7 @@ impl DynamicAgentSpawner {
             agent_type: input.agent_type.clone(),
             description: input.description.clone(),
             status: AgentStatus::Initializing,
+            work_revision: 1,
             messaging_address: None,
             worktree_path: None,
             started_at: SystemTime::now(),
@@ -2552,6 +2625,7 @@ impl DynamicAgentSpawner {
         }
         self.emit_agent_spawned_trace(&spawned_state_for_trace)
             .await;
+        self.publish_background_agent(&spawned_state_for_trace);
 
         // 6b. Reconstruct the inherited prefix payload for the
         // executor BEFORE moving resolve_outcome into the outcomes
@@ -3043,10 +3117,12 @@ impl DynamicAgentSpawner {
             },
         };
         state.status = status;
+        state.work_revision = state.work_revision.saturating_add(1);
         state.ended_at = Some(SystemTime::now());
         let messaging_address = state.messaging_address.take();
 
         self.record_fanout_terminal_state(state).await;
+        self.publish_background_agent(state);
         self.emit_agent_terminal_trace(state, "cancelled", Some(reason), Some(reason), None)
             .await;
         self.persist_agent_terminated_state(state, "cancelled", Some(reason))
@@ -3117,12 +3193,14 @@ impl DynamicAgentSpawner {
                 }
             }
             state.status = status;
+            state.work_revision = state.work_revision.saturating_add(1);
             state.ended_at = Some(SystemTime::now());
             let messaging_address = state.messaging_address.take();
             (state, messaging_address)
         };
 
         self.record_fanout_terminal_state(&state).await;
+        self.publish_background_agent(&state);
         self.emit_agent_terminal_trace(&state, journal_status, finish_reason, output, error)
             .await;
         self.persist_agent_terminated_state(&state, journal_status, finish_reason)
@@ -3439,6 +3517,7 @@ impl DynamicAgentSpawner {
             durable_reconciler: Arc::clone(&self.durable_reconciler),
             durable_observed_agent_ids: Arc::clone(&self.durable_observed_agent_ids),
             durable_reconcile_lock: Arc::clone(&self.durable_reconcile_lock),
+            active_work_registry: self.active_work_registry.clone(),
         }
     }
 
@@ -3706,10 +3785,15 @@ impl DynamicAgentSpawner {
     /// Update agent status.
     pub async fn update_status(&self, agent_id: &str, status: AgentStatus) {
         if let Some(state) = self.active_agents.write().await.get_mut(agent_id) {
+            if state.status == status {
+                return;
+            }
             state.status = status.clone();
+            state.work_revision = state.work_revision.saturating_add(1);
             if status.is_terminal() {
                 state.ended_at.get_or_insert_with(SystemTime::now);
             }
+            self.publish_background_agent(state);
 
             let Some(event_type) =
                 agent_status_to_progress_event(&status, &state.metrics, state.started_at)
@@ -5638,6 +5722,7 @@ mod tests {
                 result: "ok".to_string(),
                 finish_reason: Some("normal".to_string()),
             },
+            work_revision: 1,
             messaging_address: None,
             worktree_path: None,
             started_at: SystemTime::now(),
@@ -5651,6 +5736,64 @@ mod tests {
             fanout_slot: None,
             execution_metadata: None,
         }
+    }
+
+    #[test]
+    fn background_agent_publishes_one_monotonic_session_work_unit() {
+        use astra_core::work_unit::{ActiveWorkRegistry, WorkUnitStatus, WorkUnitWakePolicy};
+
+        let registry = Arc::new(ActiveWorkRegistry::default());
+        let spawner =
+            DynamicAgentSpawner::new(mock_router()).with_active_work_registry(registry.clone());
+        let mut state = completed_test_state(7);
+        state.status = AgentStatus::Running {
+            activity: "reviewing".into(),
+        };
+        state.ended_at = None;
+        state.work_revision = 1;
+        spawner.publish_background_agent(&state);
+        let running = registry.active_work_observations();
+        assert_eq!(running.len(), 1);
+        assert_eq!(running[0].kind, "agent");
+        assert_eq!(running[0].status, WorkUnitStatus::Running);
+        assert_eq!(
+            running[0].wake_policy,
+            WorkUnitWakePolicy::OnAttentionOrTerminal
+        );
+
+        state.status = AgentStatus::Waiting {
+            reason: "need a contract decision".into(),
+        };
+        state.work_revision = 2;
+        spawner.publish_background_agent(&state);
+        assert_eq!(
+            registry.active_work_observations()[0].status,
+            WorkUnitStatus::WaitingForInput
+        );
+
+        state.status = AgentStatus::Completed {
+            result: "done".into(),
+            finish_reason: Some("normal".into()),
+        };
+        state.work_revision = 3;
+        spawner.publish_background_agent(&state);
+        assert!(registry.active_work_observations().is_empty());
+        assert_eq!(
+            registry
+                .terminal_observation(&state.agent_id, "agent")
+                .unwrap()
+                .revision,
+            3
+        );
+
+        state.fanout_slot = AgentFanoutSlotIdentity::new("group", 1, 0, None).ok();
+        state.agent_id = "fanout-child".into();
+        spawner.publish_background_agent(&state);
+        assert!(
+            registry
+                .canonical_observation("fanout-child", "agent")
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/server/meta_handlers.rs
+++ b/crates/runtime/src/server/meta_handlers.rs
@@ -170,10 +170,8 @@ pub(super) async fn root_handler(State(state): State<AppState>) -> Json<RootResp
 }
 
 pub(super) async fn current_health(state: &AppState) -> HealthResponse {
-    let (database_health, memoria_health) = tokio::join!(
-        state.health_checker.database_health(),
-        state.memoria_forwarder.health(),
-    );
+    let database_health = state.health_checker.database_health().await;
+    let memoria_health = state.cached_memoria_health();
 
     let status = if !database_health.is_healthy() {
         "unhealthy"
@@ -194,6 +192,45 @@ pub(super) async fn current_health(state: &AppState) -> HealthResponse {
 
 pub(super) async fn health_handler(State(state): State<AppState>) -> Json<HealthResponse> {
     Json(current_health(&state).await)
+}
+
+#[derive(Serialize)]
+pub(super) struct LivenessResponse {
+    status: &'static str,
+}
+
+#[derive(Serialize)]
+pub(super) struct ReadinessResponse {
+    status: &'static str,
+    database: &'static str,
+}
+
+/// Process liveness never performs dependency I/O. Orchestrators should only
+/// restart the process when this endpoint itself is unreachable.
+pub(super) async fn live_handler() -> Json<LivenessResponse> {
+    Json(LivenessResponse { status: "alive" })
+}
+
+/// Traffic readiness is owned by core dependencies only. Optional capability
+/// failures remain visible on `/health` without evicting every replica.
+pub(super) async fn ready_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let database = state.health_checker.database_health().await;
+    let status = if database.is_healthy() {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (
+        status,
+        Json(ReadinessResponse {
+            status: if database.is_healthy() {
+                "ready"
+            } else {
+                "not_ready"
+            },
+            database: database.database_label(),
+        }),
+    )
 }
 
 /// `GET /metrics` — Prometheus text format 0.0.4.
@@ -224,6 +261,7 @@ mod tests {
     use crate::{AppState, HealthChecker, MemoriaForwarder, MemoriaHealth, ServiceInfo};
     use async_trait::async_trait;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Clone)]
     struct AlwaysHealthy;
@@ -263,6 +301,28 @@ mod tests {
         }
     }
 
+    struct CountingMemoria {
+        probes: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl MemoriaForwarder for CountingMemoria {
+        async fn forward(
+            &self,
+            _method: reqwest::Method,
+            _endpoint: &str,
+            _body: serde_json::Value,
+        ) -> Result<serde_json::Value, String> {
+            Err("unused".to_string())
+        }
+
+        async fn health(&self) -> MemoriaHealth {
+            self.probes.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            MemoriaHealth::Unavailable("optional dependency down".to_string())
+        }
+    }
+
     #[tokio::test]
     async fn configured_dependency_failure_is_reported_as_degraded() {
         let state = AppState::new(ServiceInfo::default(), Arc::new(AlwaysHealthy))
@@ -285,6 +345,52 @@ mod tests {
         assert_eq!(health.status, "unhealthy");
         assert_eq!(health.database, "unavailable");
         assert_eq!(health.memoria, "unavailable");
+    }
+
+    #[tokio::test]
+    async fn capability_probe_is_cached_singleflight_and_does_not_block_health_requests() {
+        let probes = Arc::new(AtomicUsize::new(0));
+        let state = AppState::new(ServiceInfo::default(), Arc::new(AlwaysHealthy))
+            .with_memoria_forwarder(Arc::new(CountingMemoria {
+                probes: probes.clone(),
+            }));
+        let callers = (0..8)
+            .map(|_| {
+                let state = state.clone();
+                tokio::spawn(async move {
+                    state
+                        .refresh_memoria_health_if_stale(std::time::Duration::from_secs(60))
+                        .await
+                })
+            })
+            .collect::<Vec<_>>();
+        for caller in callers {
+            assert!(matches!(
+                caller.await.unwrap(),
+                MemoriaHealth::Unavailable(_)
+            ));
+        }
+        assert_eq!(probes.load(Ordering::SeqCst), 1);
+
+        let health = current_health(&state).await;
+        assert_eq!(health.status, "degraded");
+        assert_eq!(
+            probes.load(Ordering::SeqCst),
+            1,
+            "request path must use cache"
+        );
+
+        let ready = ready_handler(State(state)).await.into_response();
+        assert_eq!(ready.status(), StatusCode::OK);
+        assert_eq!(probes.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn readiness_rejects_only_core_database_failure() {
+        let state = AppState::new(ServiceInfo::default(), Arc::new(DatabaseUnavailable))
+            .with_memoria_forwarder(Arc::new(UnavailableMemoria));
+        let response = ready_handler(State(state)).await.into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/runtime/src/server/mod.rs
+++ b/crates/runtime/src/server/mod.rs
@@ -256,6 +256,10 @@ pub async fn serve(addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
     // the runtime / pool / OTLP exporter.
     let bg_cancel = tokio_util::sync::CancellationToken::new();
     let mut bg_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+    bg_handles.push(spawn_memoria_health_refresh(
+        state.clone(),
+        bg_cancel.clone(),
+    ));
     if let Some(ref pool) = state.shared_pool {
         bg_handles.push(spawn_data_cleanup(pool.clone(), bg_cancel.clone()));
         bg_handles.push(spawn_edge_dispatch_cleanup(
@@ -310,7 +314,10 @@ pub async fn serve(addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn log_memoria_startup_health(state: &AppState) {
-    match state.memoria_forwarder.health().await {
+    match state
+        .refresh_memoria_health_if_stale(std::time::Duration::ZERO)
+        .await
+    {
         crate::MemoriaHealth::Connected => tracing::info!(
             target: "astra_runtime::serve",
             memoria_base_url = %state.memoria_base_url,
@@ -324,6 +331,23 @@ async fn log_memoria_startup_health(state: &AppState) {
         ),
         crate::MemoriaHealth::Disabled => {}
     }
+}
+
+fn spawn_memoria_health_refresh(
+    state: AppState,
+    cancel: tokio_util::sync::CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        const PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => break,
+                _ = tokio::time::sleep(PROBE_INTERVAL) => {
+                    let _ = state.refresh_memoria_health_if_stale(PROBE_INTERVAL).await;
+                }
+            }
+        }
+    })
 }
 
 /// Completes on SIGTERM (Unix) or Ctrl+C so `axum::serve` can exit cleanly and OTLP can flush.

--- a/crates/runtime/src/server/router_builder/realtime.rs
+++ b/crates/runtime/src/server/router_builder/realtime.rs
@@ -5,6 +5,8 @@ use super::*;
 pub(super) fn add_routes(router: Router<AppState>) -> Router<AppState> {
     router
         .route("/", get(meta_handlers::root_handler))
+        .route("/live", get(meta_handlers::live_handler))
+        .route("/ready", get(meta_handlers::ready_handler))
         .route("/health", get(meta_handlers::health_handler))
         .route("/metrics", get(meta_handlers::metrics_handler))
         .route("/auth/register", post(auth_handlers::auth_register_handler))

--- a/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -8376,16 +8376,42 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             state.session_turn,
             request.agent_id.clone(),
         );
-        let (host_event_tx, mut host_event_rx) = mpsc::unbounded_channel::<Value>();
+        const HOST_EVENT_CHANNEL_CAPACITY: usize = 256;
+        let (host_event_tx, mut host_event_rx) =
+            mpsc::channel::<Value>(HOST_EVENT_CHANNEL_CAPACITY);
+        let host_event_gap = server_loop_host::HostEventGapTracker::default();
+        let bridge_gap = host_event_gap.clone();
         let host_event_bridge_tx = event_tx.clone();
-        let host_event_bridge = tokio::spawn(async move {
+        let host_event_bridge_run_id = run_id.clone();
+        let mut host_event_bridge = tokio::spawn(async move {
             while let Some(event) = host_event_rx.recv().await {
+                let dropped = bridge_gap.take();
+                if dropped > 0
+                    && host_event_bridge_tx
+                        .send(stream_delivery_gap_event(
+                            &host_event_bridge_run_id,
+                            dropped,
+                        ))
+                        .await
+                        .is_err()
+                {
+                    return;
+                }
                 if host_event_bridge_tx.send(event).await.is_err() {
-                    break;
+                    return;
                 }
             }
+            let dropped = bridge_gap.take();
+            if dropped > 0 {
+                let _ = host_event_bridge_tx
+                    .send(stream_delivery_gap_event(
+                        &host_event_bridge_run_id,
+                        dropped,
+                    ))
+                    .await;
+            }
         });
-        host.set_unbounded_event_tx(host_event_tx);
+        host.set_event_tx_with_gap(host_event_tx, host_event_gap);
         host.set_client_cancel(cancel_flag.clone(), llm_cancel_token.clone());
         if let Some(snapshot) = execution_bindings.as_ref() {
             host.set_execution_metadata(Value::Object(binding_event_fields(
@@ -8906,13 +8932,23 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 let loop_result =
                     run_agentic_loop_with_host_panic_safe(&mut host, &mut state).await;
                 host.detach_event_tx();
-                if let Err(error) = host_event_bridge.await {
-                    tracing::warn!(
+                match tokio::time::timeout(Duration::from_secs(2), &mut host_event_bridge).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => tracing::warn!(
                         target: "astra_runtime::run_lifecycle",
                         run_id = %bg_run_id,
                         error = %error,
-                        "lossless host event bridge stopped before draining"
-                    );
+                        "bounded host event bridge stopped before draining"
+                    ),
+                    Err(_) => {
+                        host_event_bridge.abort();
+                        let _ = host_event_bridge.await;
+                        tracing::warn!(
+                            target: "astra_runtime::run_lifecycle",
+                            run_id = %bg_run_id,
+                            "bounded host event bridge drain exceeded 2 seconds; detached remaining live progress"
+                        );
+                    }
                 }
                 park_server_root_mailbox(&mut state).await;
                 let loop_success = loop_result.is_ok();
@@ -10876,10 +10912,20 @@ fn start_child_client_tool_delivery_bridge(
     child_run_id: String,
     child_agent_id: String,
     session_id: String,
-    mut child_rx: mpsc::UnboundedReceiver<Value>,
+    mut child_rx: mpsc::Receiver<Value>,
+    gap: server_loop_host::HostEventGapTracker,
 ) -> ChildClientToolDeliveryBridge {
     let join = tokio::spawn(async move {
         while let Some(mut event) = child_rx.recv().await {
+            let dropped = gap.take();
+            if dropped > 0
+                && parent_tx
+                    .send(stream_delivery_gap_event(&child_run_id, dropped))
+                    .await
+                    .is_err()
+            {
+                break;
+            }
             if !is_client_tool_delivery_event(&event) {
                 continue;
             }
@@ -10903,6 +10949,12 @@ fn start_child_client_tool_delivery_bridge(
                 );
                 break;
             }
+        }
+        let dropped = gap.take();
+        if dropped > 0 {
+            let _ = parent_tx
+                .send(stream_delivery_gap_event(&child_run_id, dropped))
+                .await;
         }
     });
     ChildClientToolDeliveryBridge { join }
@@ -11388,8 +11440,10 @@ impl SubRunExecutor for ServerSubRunExecutor {
             );
         }
         let _client_tool_delivery_bridge = if client_tool_delivery_available {
-            let (child_tx, child_rx) = mpsc::unbounded_channel();
-            host.set_unbounded_event_tx(child_tx);
+            const CHILD_CLIENT_EVENT_CHANNEL_CAPACITY: usize = 64;
+            let (child_tx, child_rx) = mpsc::channel(CHILD_CLIENT_EVENT_CHANNEL_CAPACITY);
+            let child_event_gap = server_loop_host::HostEventGapTracker::default();
+            host.set_event_tx_with_gap(child_tx, child_event_gap.clone());
             host.prefer_client_tool_delivery();
             Some(start_child_client_tool_delivery_bridge(
                 self.client_tool_delivery_tx
@@ -11399,6 +11453,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
                 config.agent_profile.agent_id.clone(),
                 config.session_id.clone(),
                 child_rx,
+                child_event_gap,
             ))
         } else {
             None

--- a/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -2089,6 +2089,7 @@ async fn stream_missing_agent_lifecycle_events(
 struct ServerAgentSpawnerEntry {
     spawner: Arc<DynamicAgentSpawner>,
     executor: Arc<ServerSpawnAgentExecutor>,
+    active_work_registry: Arc<astra_core::work_unit::ActiveWorkRegistry>,
     durable_restore: Arc<tokio::sync::OnceCell<()>>,
     last_access: Arc<std::sync::Mutex<Instant>>,
 }
@@ -2799,11 +2800,13 @@ impl AgenticRunLifecycleService {
         }
         let executor = Arc::new(executor);
         let executor_for_spawner: Arc<dyn SpawnAgentExecutor> = executor.clone();
+        let active_work_registry = Arc::new(astra_core::work_unit::ActiveWorkRegistry::default());
         let mut spawner = DynamicAgentSpawner::with_broadcaster(
             Arc::clone(&self.server_agent_mailbox_router),
             self.dynamic_agent_progress_broadcaster(),
         )
         .with_executor(executor_for_spawner)
+        .with_active_work_registry(active_work_registry.clone())
         .with_session(session_id.to_string())
         // Same cap as the CLI side. Web/headless sessions are no less
         // susceptible to the runaway-spawn-on-failure pattern; without
@@ -2826,6 +2829,7 @@ impl AgenticRunLifecycleService {
         let entry = ServerAgentSpawnerEntry {
             spawner: Arc::new(spawner),
             executor,
+            active_work_registry,
             durable_restore: Arc::new(tokio::sync::OnceCell::new()),
             last_access: Arc::new(std::sync::Mutex::new(Instant::now())),
         };
@@ -3060,7 +3064,7 @@ impl AgenticRunLifecycleService {
         pause_flag: Option<Arc<AtomicBool>>,
         cancel_token: Option<Arc<CancellationToken>>,
         #[cfg(feature = "harness")] harness_sink: Option<Arc<dyn astra_harness::SnapshotSink>>,
-    ) {
+    ) -> Arc<astra_core::work_unit::ActiveWorkRegistry> {
         let entry = self
             .server_agent_spawner_for_session(user_id, session_id)
             .await;
@@ -3089,6 +3093,9 @@ impl AgenticRunLifecycleService {
                 %error,
                 "durable agent registry restore failed; the next turn will retry"
             );
+        }
+        for observation in entry.spawner.active_fanout_work_unit_observations().await {
+            entry.active_work_registry.observe(&observation);
         }
         // Validation already happened up the call chain (see
         // `validate_request_constraints`); this re-parse is safe because the
@@ -3131,6 +3138,7 @@ impl AgenticRunLifecycleService {
             .agent_id
             .clone()
             .unwrap_or_else(|| "root-agent".to_string());
+        let active_work_registry = entry.active_work_registry.clone();
         executor.set_agent_tool_context(AgentToolContext {
             run_id: run_id.to_string(),
             agent_id,
@@ -3160,6 +3168,7 @@ impl AgenticRunLifecycleService {
             execution_metadata,
             transcript_location: AgentTranscriptLocation::DurableServer,
         });
+        active_work_registry
     }
 
     fn build_csl_store(
@@ -7456,22 +7465,24 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             ));
             host.set_execution_metadata(executor.binding_metadata());
 
-            self.wire_server_dynamic_agent_tools(
-                &mut executor,
-                &user_id,
-                &session_id,
-                &run_id,
-                loop_state.session_turn,
-                &request,
-                agent_working_dir.as_path(),
-                None,
-                None,
-                Some(pause_flag.clone()),
-                Some(llm_cancel_token.clone()),
-                #[cfg(feature = "harness")]
-                loop_state.harness.sink.clone(),
-            )
-            .await;
+            let active_work_registry = self
+                .wire_server_dynamic_agent_tools(
+                    &mut executor,
+                    &user_id,
+                    &session_id,
+                    &run_id,
+                    loop_state.session_turn,
+                    &request,
+                    agent_working_dir.as_path(),
+                    None,
+                    None,
+                    Some(pause_flag.clone()),
+                    Some(llm_cancel_token.clone()),
+                    #[cfg(feature = "harness")]
+                    loop_state.harness.sink.clone(),
+                )
+                .await;
+            loop_state.attach_active_work_registry(active_work_registry);
 
             if request.interactive_client {
                 // ── Phase E: Wire WebSocket approval and ask_user gates ───
@@ -8645,22 +8656,24 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             ));
             host.set_execution_metadata(executor.binding_metadata());
             executor.set_work_surface_event_tx(event_tx.clone());
-            self.wire_server_dynamic_agent_tools(
-                &mut executor,
-                &user_id,
-                &session_id,
-                &run_id,
-                state.session_turn,
-                &request,
-                agent_working_dir.as_path(),
-                Some(event_tx.clone()),
-                Some(agent_live_gap_tracker.clone()),
-                Some(pause_flag.clone()),
-                Some(llm_cancel_token.clone()),
-                #[cfg(feature = "harness")]
-                state.harness.sink.clone(),
-            )
-            .await;
+            let active_work_registry = self
+                .wire_server_dynamic_agent_tools(
+                    &mut executor,
+                    &user_id,
+                    &session_id,
+                    &run_id,
+                    state.session_turn,
+                    &request,
+                    agent_working_dir.as_path(),
+                    Some(event_tx.clone()),
+                    Some(agent_live_gap_tracker.clone()),
+                    Some(pause_flag.clone()),
+                    Some(llm_cancel_token.clone()),
+                    #[cfg(feature = "harness")]
+                    state.harness.sink.clone(),
+                )
+                .await;
+            state.attach_active_work_registry(active_work_registry);
 
             // Match the background-run interaction contract.  The stream is
             // only a delivery surface: Server Only requests still wait on the

--- a/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -144,6 +144,7 @@ const MAX_DURABLE_RUN_PROJECTION_RECENT_EVENTS: u32 = 500;
 const MAX_ACTIVE_RUN_LIVE_EVENTS: usize = MAX_DURABLE_RUN_PROJECTION_RECENT_EVENTS as usize;
 const AGENT_PROGRESS_STREAM_DRAIN_GRACE: Duration = Duration::from_millis(25);
 const ATTACHED_INTERACTION_DELIVERY_GRACE: Duration = Duration::from_millis(250);
+const HOST_INTERACTION_COMMITTED_FIELD: &str = "_astra_host_interaction_committed";
 
 fn attached_stream_event_requires_reliable_delivery(event: &Value) -> bool {
     matches!(
@@ -151,6 +152,7 @@ fn attached_stream_event_requires_reliable_delivery(event: &Value) -> bool {
         Some(
             "approval_required"
                 | "approval_batch_required"
+                | "tool_request"
                 | "ask_user_prompted"
                 | "user_prompt_required"
                 | "stream_gap"
@@ -300,8 +302,15 @@ fn canonical_edge_approval_requests(event: &Value) -> Vec<Value> {
                     Value::String("edge_ledger".to_string()),
                 ),
             ]);
-            for field in ["path", "detail", "display_label"] {
-                if let Some(value) = request.get(field).cloned() {
+            for field in [
+                "path",
+                "detail",
+                "display_label",
+                "run_id",
+                "session_id",
+                "agent_id",
+            ] {
+                if let Some(value) = request.get(field).or_else(|| event.get(field)).cloned() {
                     data.insert(field.to_string(), value);
                 }
             }
@@ -314,8 +323,83 @@ fn canonical_edge_approval_requests(event: &Value) -> Vec<Value> {
         .collect()
 }
 
-fn incrementally_persisted_edge_approval_event(event: &Value) -> bool {
-    !canonical_edge_approval_requests(event).is_empty()
+fn canonical_edge_tool_request(event: &Value) -> Option<Value> {
+    if event.get("type").and_then(Value::as_str) != Some("tool_request") {
+        return None;
+    }
+    let request_id = event.get("request_id")?.as_str()?.trim();
+    let tool = event.get("tool")?.as_str()?.trim();
+    if request_id.is_empty() || tool.is_empty() {
+        return None;
+    }
+    let mut data = event.as_object()?.clone();
+    data.remove("type");
+    data.remove(HOST_INTERACTION_COMMITTED_FIELD);
+    Some(json!({
+        "event_type": "tool_request",
+        "idempotency_key": format!("edge-tool-request:{request_id}"),
+        "data": data,
+    }))
+}
+
+fn canonical_edge_interaction_events(event: &Value) -> Vec<Value> {
+    let mut interactions = canonical_edge_approval_requests(event);
+    interactions.extend(canonical_edge_tool_request(event));
+    interactions
+}
+
+fn incrementally_persisted_edge_interaction_event(event: &Value) -> bool {
+    !canonical_edge_interaction_events(event).is_empty()
+}
+
+struct DurableHostInteractionSink {
+    run_engine: RunEngine,
+    user_id: String,
+    run_id: String,
+    session_id: String,
+    agent_id: Option<String>,
+    event_tx: mpsc::Sender<Value>,
+}
+
+#[async_trait]
+impl server_loop_host::HostInteractionSink for DurableHostInteractionSink {
+    async fn commit_and_deliver(&self, mut event: Value) -> Result<(), String> {
+        let event_object = event
+            .as_object_mut()
+            .ok_or_else(|| "interaction event must be an object".to_string())?;
+        event_object
+            .entry("run_id".to_string())
+            .or_insert_with(|| Value::String(self.run_id.clone()));
+        event_object
+            .entry("session_id".to_string())
+            .or_insert_with(|| Value::String(self.session_id.clone()));
+        if let Some(agent_id) = &self.agent_id {
+            event_object
+                .entry("agent_id".to_string())
+                .or_insert_with(|| Value::String(agent_id.clone()));
+        }
+
+        let durable_events = canonical_edge_interaction_events(&event);
+        if durable_events.is_empty() {
+            return Err("interaction event has no durable canonical form".to_string());
+        }
+        self.run_engine
+            .append_events_batch(&self.user_id, &self.run_id, &durable_events)
+            .await
+            .map_err(|error| format!("interaction persistence failed: {error}"))?;
+
+        event
+            .as_object_mut()
+            .expect("validated interaction object")
+            .insert(
+                HOST_INTERACTION_COMMITTED_FIELD.to_string(),
+                Value::Bool(true),
+            );
+        self.event_tx
+            .send(event)
+            .await
+            .map_err(|_| "run interaction fanout is closed".to_string())
+    }
 }
 const ACTIVE_RUN_DURABLE_CONTROL_WATCH_INTERVAL: Duration = Duration::from_secs(2);
 const ACTIVE_RUN_DURABLE_CONTROL_POLL_TIMEOUT: Duration = Duration::from_secs(5);
@@ -8168,7 +8252,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 loop {
                     tokio::select! {
                         event = fanout_rx.recv() => {
-                            let Some(event) = event else {
+                            let Some(mut event) = event else {
                                 for gap in fanout_gap_tracker.drain() {
                                     let event = agent_live_gap_to_work_surface_sse(gap);
                                     let _ = live_tx_for_fanout.send(event.clone());
@@ -8181,6 +8265,11 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                                 }
                                 break;
                             };
+                            let interaction_already_committed = event
+                                .as_object_mut()
+                                .and_then(|event| event.remove(HOST_INTERACTION_COMMITTED_FIELD))
+                                .and_then(|value| value.as_bool())
+                                .unwrap_or(false);
                             let approval_requests = canonical_edge_approval_requests(&event);
                             let approval_run_id = event
                                 .get("run_id")
@@ -8189,7 +8278,8 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                                 .filter(|run_id| !run_id.is_empty())
                                 .unwrap_or(&fanout_run_id)
                                 .to_string();
-                            if !approval_requests.is_empty()
+                            if !interaction_already_committed
+                                && !approval_requests.is_empty()
                                 && let Err(error) = fanout_run_engine
                                     .append_events_batch(
                                         &fanout_user_id,
@@ -8384,21 +8474,40 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         let host_event_bridge_tx = event_tx.clone();
         let host_event_bridge_run_id = run_id.clone();
         let mut host_event_bridge = tokio::spawn(async move {
-            while let Some(event) = host_event_rx.recv().await {
-                let dropped = bridge_gap.take();
-                if dropped > 0
-                    && host_event_bridge_tx
-                        .send(stream_delivery_gap_event(
-                            &host_event_bridge_run_id,
-                            dropped,
-                        ))
-                        .await
-                        .is_err()
-                {
-                    return;
-                }
-                if host_event_bridge_tx.send(event).await.is_err() {
-                    return;
+            loop {
+                tokio::select! {
+                    event = host_event_rx.recv() => {
+                        let Some(event) = event else { break; };
+                        let dropped = bridge_gap.take();
+                        if dropped > 0
+                            && host_event_bridge_tx
+                                .send(stream_delivery_gap_event(
+                                    &host_event_bridge_run_id,
+                                    dropped,
+                                ))
+                                .await
+                                .is_err()
+                        {
+                            return;
+                        }
+                        if host_event_bridge_tx.send(event).await.is_err() {
+                            return;
+                        }
+                    }
+                    _ = bridge_gap.notified() => {
+                        let dropped = bridge_gap.take();
+                        if dropped > 0
+                            && host_event_bridge_tx
+                                .send(stream_delivery_gap_event(
+                                    &host_event_bridge_run_id,
+                                    dropped,
+                                ))
+                                .await
+                                .is_err()
+                        {
+                            return;
+                        }
+                    }
                 }
             }
             let dropped = bridge_gap.take();
@@ -8412,6 +8521,14 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             }
         });
         host.set_event_tx_with_gap(host_event_tx, host_event_gap);
+        host.set_interaction_sink(Arc::new(DurableHostInteractionSink {
+            run_engine: self.run_engine.clone(),
+            user_id: user_id.clone(),
+            run_id: run_id.clone(),
+            session_id: session_id.clone(),
+            agent_id: None,
+            event_tx: event_tx.clone(),
+        }));
         host.set_client_cancel(cancel_flag.clone(), llm_cancel_token.clone());
         if let Some(snapshot) = execution_bindings.as_ref() {
             host.set_execution_metadata(Value::Object(binding_event_fields(
@@ -9030,7 +9147,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                     &archived_lifecycle_events,
                 )
                 .into_iter()
-                .filter(|event| !incrementally_persisted_edge_approval_event(event))
+                .filter(|event| !incrementally_persisted_edge_interaction_event(event))
                 .collect();
                 let streaming_events_for_durable =
                     enforce_durable_run_event_batch_budget(terminal_persistence_events);
@@ -10880,10 +10997,6 @@ impl SpawnAgentExecutor for ServerSpawnAgentExecutor {
     }
 }
 
-struct ChildClientToolDeliveryBridge {
-    join: tokio::task::JoinHandle<()>,
-}
-
 fn child_uses_client_tool_delivery(
     parent_delivery_available: bool,
     bindings: Option<&ExecutionBindingSnapshot>,
@@ -10892,72 +11005,6 @@ fn child_uses_client_tool_delivery(
         && bindings.is_some_and(|snapshot| {
             matches!(snapshot.executor.transport, ToolTransportKind::EdgeLedger)
         })
-}
-
-impl Drop for ChildClientToolDeliveryBridge {
-    fn drop(&mut self) {
-        self.join.abort();
-    }
-}
-
-fn is_client_tool_delivery_event(event: &Value) -> bool {
-    matches!(
-        event.get("type").and_then(Value::as_str),
-        Some("approval_required" | "approval_batch_required" | "tool_request")
-    )
-}
-
-fn start_child_client_tool_delivery_bridge(
-    parent_tx: mpsc::Sender<Value>,
-    child_run_id: String,
-    child_agent_id: String,
-    session_id: String,
-    mut child_rx: mpsc::Receiver<Value>,
-    gap: server_loop_host::HostEventGapTracker,
-) -> ChildClientToolDeliveryBridge {
-    let join = tokio::spawn(async move {
-        while let Some(mut event) = child_rx.recv().await {
-            let dropped = gap.take();
-            if dropped > 0
-                && parent_tx
-                    .send(stream_delivery_gap_event(&child_run_id, dropped))
-                    .await
-                    .is_err()
-            {
-                break;
-            }
-            if !is_client_tool_delivery_event(&event) {
-                continue;
-            }
-            let Some(event) = event.as_object_mut() else {
-                continue;
-            };
-            event
-                .entry("run_id".to_string())
-                .or_insert_with(|| Value::String(child_run_id.clone()));
-            event
-                .entry("agent_id".to_string())
-                .or_insert_with(|| Value::String(child_agent_id.clone()));
-            event
-                .entry("session_id".to_string())
-                .or_insert_with(|| Value::String(session_id.clone()));
-            if parent_tx.send(Value::Object(event.clone())).await.is_err() {
-                tracing::debug!(
-                    run_id = %child_run_id,
-                    agent_id = %child_agent_id,
-                    "parent client tool-delivery lane closed"
-                );
-                break;
-            }
-        }
-        let dropped = gap.take();
-        if dropped > 0 {
-            let _ = parent_tx
-                .send(stream_delivery_gap_event(&child_run_id, dropped))
-                .await;
-        }
-    });
-    ChildClientToolDeliveryBridge { join }
 }
 
 /// Production sub-run executor backed by [`ServerAgenticLoopHost`].
@@ -11439,25 +11486,23 @@ impl SubRunExecutor for ServerSubRunExecutor {
                 sink,
             );
         }
-        let _client_tool_delivery_bridge = if client_tool_delivery_available {
-            const CHILD_CLIENT_EVENT_CHANNEL_CAPACITY: usize = 64;
-            let (child_tx, child_rx) = mpsc::channel(CHILD_CLIENT_EVENT_CHANNEL_CAPACITY);
-            let child_event_gap = server_loop_host::HostEventGapTracker::default();
-            host.set_event_tx_with_gap(child_tx, child_event_gap.clone());
-            host.prefer_client_tool_delivery();
-            Some(start_child_client_tool_delivery_bridge(
-                self.client_tool_delivery_tx
+        if client_tool_delivery_available {
+            let run_engine = self.run_engine.clone().ok_or_else(|| {
+                "thin-client child interaction delivery requires a durable run engine".to_string()
+            })?;
+            host.set_interaction_sink(Arc::new(DurableHostInteractionSink {
+                run_engine,
+                user_id: config.user_id.clone(),
+                run_id: config.run_id.clone(),
+                session_id: config.session_id.clone(),
+                agent_id: Some(config.agent_profile.agent_id.clone()),
+                event_tx: self
+                    .client_tool_delivery_tx
                     .clone()
                     .expect("availability checked above"),
-                config.run_id.clone(),
-                config.agent_profile.agent_id.clone(),
-                config.session_id.clone(),
-                child_rx,
-                child_event_gap,
-            ))
-        } else {
-            None
-        };
+            }));
+            host.prefer_client_tool_delivery();
+        }
 
         // Build the task prompt, incorporating previous output if pipeline.
         let full_task = if let Some(prev) = &config.previous_output {

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -12596,8 +12596,8 @@ fn edge_approval_persistence_normalizes_single_and_batch_requests() {
     assert_eq!(batch_facts[1]["data"]["request_id"], "approval-b");
     assert_eq!(batch_facts[0]["data"]["path"], "/tmp/a");
     assert_eq!(batch_facts[1]["data"]["path"], "/tmp/b");
-    assert!(incrementally_persisted_edge_approval_event(&single));
-    assert!(incrementally_persisted_edge_approval_event(&batch));
+    assert!(incrementally_persisted_edge_interaction_event(&single));
+    assert!(incrementally_persisted_edge_interaction_event(&batch));
 }
 
 #[test]
@@ -12619,93 +12619,91 @@ fn edge_approval_persistence_rejects_unaddressable_items() {
         "delivery": "durable",
     });
     assert!(canonical_edge_approval_requests(&already_durable).is_empty());
-    assert!(!incrementally_persisted_edge_approval_event(
+    assert!(!incrementally_persisted_edge_interaction_event(
         &already_durable
     ));
-    assert!(!incrementally_persisted_edge_approval_event(&json!({
-        "type": "tool_request"
+    assert!(!incrementally_persisted_edge_interaction_event(&json!({
+        "type": "tool_request",
+        "request_id": "missing-tool"
     })));
 }
 
-#[tokio::test]
-async fn child_client_tool_delivery_forwards_requests_without_leaking_child_transcript() {
-    let (parent_tx, mut parent_rx) = mpsc::channel(8);
-    let (child_tx, child_rx) = mpsc::channel(8);
-    let _bridge = start_child_client_tool_delivery_bridge(
-        parent_tx,
-        "child-run".to_string(),
-        "researcher".to_string(),
-        "session-1".to_string(),
-        child_rx,
-        server_loop_host::HostEventGapTracker::default(),
-    );
+#[test]
+fn edge_tool_request_has_a_replayable_canonical_fact() {
+    let request = json!({
+        "type": "tool_request",
+        "run_id": "child-run",
+        "session_id": "session-1",
+        "request_id": "tool-1",
+        "tool": "bash",
+        "args": {"cmd": "printf ok"}
+    });
 
-    child_tx
-        .send(json!({"type": "text_delta", "content": "private child output"}))
-        .await
-        .unwrap();
-    child_tx
-        .send(json!({"type": "tool_request", "request_id": "tool-1"}))
-        .await
-        .unwrap();
-    child_tx
-        .send(json!({
-            "type": "approval_required",
-            "request_id": "approval-1",
-            "tool": "bash"
-        }))
-        .await
-        .unwrap();
-
-    let tool_request = tokio::time::timeout(Duration::from_secs(1), parent_rx.recv())
-        .await
-        .unwrap()
-        .unwrap();
-    let approval = tokio::time::timeout(Duration::from_secs(1), parent_rx.recv())
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(tool_request["type"], "tool_request");
-    assert_eq!(approval["type"], "approval_required");
-    for event in [&tool_request, &approval] {
-        assert_eq!(event["run_id"], "child-run");
-        assert_eq!(event["agent_id"], "researcher");
-        assert_eq!(event["session_id"], "session-1");
-    }
-    assert!(
-        tokio::time::timeout(Duration::from_millis(25), parent_rx.recv())
-            .await
-            .is_err(),
-        "child text must remain on the typed agent-live transcript lane"
-    );
+    let durable = canonical_edge_tool_request(&request).expect("canonical tool request");
+    assert_eq!(durable["event_type"], "tool_request");
+    assert_eq!(durable["idempotency_key"], "edge-tool-request:tool-1");
+    assert_eq!(durable["data"]["run_id"], "child-run");
+    assert_eq!(durable["data"]["request_id"], "tool-1");
+    assert_eq!(durable["data"]["tool"], "bash");
+    assert!(incrementally_persisted_edge_interaction_event(&request));
 }
 
 #[tokio::test]
-async fn child_client_tool_delivery_surfaces_coalesced_gap_before_next_request() {
-    let (parent_tx, mut parent_rx) = mpsc::channel(8);
-    let (child_tx, child_rx) = mpsc::channel(1);
-    let gap = server_loop_host::HostEventGapTracker::default();
-    gap.record_drop();
-    gap.record_drop();
-    let _bridge = start_child_client_tool_delivery_bridge(
-        parent_tx,
-        "child-run".to_string(),
-        "researcher".to_string(),
-        "session-1".to_string(),
-        child_rx,
-        gap,
-    );
-    child_tx
-        .send(json!({"type": "tool_request", "request_id": "tool-1"}))
+async fn full_live_queue_cannot_hide_or_precede_durable_approval_truth() {
+    let engine = RunEngine::new(Arc::new(InMemoryRunStateStore::new()));
+    engine
+        .start_run("run-approval", "user-1", "session-1")
         .await
         .unwrap();
+    let (event_tx, mut event_rx) = mpsc::channel(1);
+    event_tx
+        .send(json!({"type": "text_delta", "content": "queue is full"}))
+        .await
+        .unwrap();
+    let sink = DurableHostInteractionSink {
+        run_engine: engine.clone(),
+        user_id: "user-1".to_string(),
+        run_id: "run-approval".to_string(),
+        session_id: "session-1".to_string(),
+        agent_id: None,
+        event_tx,
+    };
+    let delivery = server_loop_host::HostInteractionSink::commit_and_deliver(
+        &sink,
+        json!({
+            "type": "approval_required",
+            "request_id": "approval-1",
+            "tool": "bash",
+            "approval_kind": "standard"
+        }),
+    );
+    tokio::pin!(delivery);
 
-    let repair = parent_rx.recv().await.unwrap();
-    let request = parent_rx.recv().await.unwrap();
-    assert_eq!(repair["type"], "stream_gap");
-    assert_eq!(repair["run_id"], "child-run");
-    assert_eq!(repair["dropped_event_count"], 2);
-    assert_eq!(request["type"], "tool_request");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), &mut delivery)
+            .await
+            .is_err(),
+        "a full live queue should backpressure delivery"
+    );
+    let durable = engine
+        .load_run("user-1", "run-approval")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        durable.events.iter().any(|event| {
+            event["event_type"] == "approval_required"
+                && event["data"]["request_id"] == "approval-1"
+        }),
+        "approval replay truth must exist before any executor can wait for a callback"
+    );
+
+    let progress = event_rx.recv().await.unwrap();
+    assert_eq!(progress["type"], "text_delta");
+    delivery.await.unwrap();
+    let approval = event_rx.recv().await.unwrap();
+    assert_eq!(approval["type"], "approval_required");
+    assert_eq!(approval[HOST_INTERACTION_COMMITTED_FIELD], true);
 }
 
 #[test]

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -12630,20 +12630,23 @@ fn edge_approval_persistence_rejects_unaddressable_items() {
 #[tokio::test]
 async fn child_client_tool_delivery_forwards_requests_without_leaking_child_transcript() {
     let (parent_tx, mut parent_rx) = mpsc::channel(8);
-    let (child_tx, child_rx) = mpsc::unbounded_channel();
+    let (child_tx, child_rx) = mpsc::channel(8);
     let _bridge = start_child_client_tool_delivery_bridge(
         parent_tx,
         "child-run".to_string(),
         "researcher".to_string(),
         "session-1".to_string(),
         child_rx,
+        server_loop_host::HostEventGapTracker::default(),
     );
 
     child_tx
         .send(json!({"type": "text_delta", "content": "private child output"}))
+        .await
         .unwrap();
     child_tx
         .send(json!({"type": "tool_request", "request_id": "tool-1"}))
+        .await
         .unwrap();
     child_tx
         .send(json!({
@@ -12651,6 +12654,7 @@ async fn child_client_tool_delivery_forwards_requests_without_leaking_child_tran
             "request_id": "approval-1",
             "tool": "bash"
         }))
+        .await
         .unwrap();
 
     let tool_request = tokio::time::timeout(Duration::from_secs(1), parent_rx.recv())
@@ -12674,6 +12678,34 @@ async fn child_client_tool_delivery_forwards_requests_without_leaking_child_tran
             .is_err(),
         "child text must remain on the typed agent-live transcript lane"
     );
+}
+
+#[tokio::test]
+async fn child_client_tool_delivery_surfaces_coalesced_gap_before_next_request() {
+    let (parent_tx, mut parent_rx) = mpsc::channel(8);
+    let (child_tx, child_rx) = mpsc::channel(1);
+    let gap = server_loop_host::HostEventGapTracker::default();
+    gap.record_drop();
+    gap.record_drop();
+    let _bridge = start_child_client_tool_delivery_bridge(
+        parent_tx,
+        "child-run".to_string(),
+        "researcher".to_string(),
+        "session-1".to_string(),
+        child_rx,
+        gap,
+    );
+    child_tx
+        .send(json!({"type": "tool_request", "request_id": "tool-1"}))
+        .await
+        .unwrap();
+
+    let repair = parent_rx.recv().await.unwrap();
+    let request = parent_rx.recv().await.unwrap();
+    assert_eq!(repair["type"], "stream_gap");
+    assert_eq!(repair["run_id"], "child-run");
+    assert_eq!(repair["dropped_event_count"], 2);
+    assert_eq!(request["type"], "tool_request");
 }
 
 #[test]

--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -6813,6 +6813,27 @@ mod tests {
     }
 
     #[derive(Default)]
+    struct InMemoryInteractionSink {
+        committed: std::sync::Mutex<Vec<Value>>,
+    }
+
+    #[async_trait::async_trait]
+    impl HostInteractionSink for InMemoryInteractionSink {
+        async fn commit_and_deliver(&self, event: Value) -> Result<(), String> {
+            self.committed.lock().expect("interaction sink").push(event);
+            Ok(())
+        }
+    }
+
+    fn install_in_memory_interaction_sink(
+        host: &mut ServerAgenticLoopHost,
+    ) -> Arc<InMemoryInteractionSink> {
+        let sink = Arc::new(InMemoryInteractionSink::default());
+        host.set_interaction_sink(sink.clone());
+        sink
+    }
+
+    #[derive(Default)]
     struct ServerOnlyPromptMemory {
         calls: std::sync::atomic::AtomicUsize,
         scopes: std::sync::Mutex<Vec<(String, String)>>,
@@ -9750,6 +9771,7 @@ mod tests {
         )
         .with_execution_binding_snapshot(edge_runtime_snapshot())
         .build();
+        let interaction_sink = install_in_memory_interaction_sink(&mut host);
         host.set_approval_audit_context(test_approval_audit_context("u-batch", "s-batch"));
         // Register write_file as a valid tool so the edge ledger delivery path admits it.
         host.install_runtime_tool_schemas(
@@ -9819,6 +9841,22 @@ mod tests {
             })
             .expect("approval batch event");
         assert_eq!(batch["requests"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            interaction_sink
+                .committed
+                .lock()
+                .expect("committed interactions")
+                .iter()
+                .filter(|event| {
+                    matches!(
+                        event.get("type").and_then(Value::as_str),
+                        Some("approval_batch_required" | "tool_request")
+                    )
+                })
+                .count(),
+            3,
+            "the approval batch and both executable requests must cross the commit boundary"
+        );
 
         let tool_request_positions: Vec<_> = host
             .emitted_events
@@ -9923,6 +9961,7 @@ mod tests {
         )
         .with_execution_binding_snapshot(edge_runtime_snapshot())
         .build();
+        install_in_memory_interaction_sink(&mut host);
         // Register read_file as a valid tool so the edge ledger delivery path admits it.
         host.install_runtime_tool_schemas(
             vec![json!({
@@ -10047,6 +10086,7 @@ mod tests {
         )
         .with_execution_binding_snapshot(edge_runtime_snapshot())
         .build();
+        install_in_memory_interaction_sink(&mut host);
         // Register read_file and write_file as valid tools so the edge ledger delivery path admits them.
         host.install_runtime_tool_schemas(
             vec![

--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -15,7 +15,7 @@
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
@@ -1262,9 +1262,22 @@ struct AgentLiveMirror {
     sink: SharedAgentLiveEventSink,
 }
 
-enum ServerEventSender {
-    Bounded(tokio::sync::mpsc::Sender<Value>),
-    Unbounded(tokio::sync::mpsc::UnboundedSender<Value>),
+#[derive(Clone, Default)]
+pub(crate) struct HostEventGapTracker(Arc<AtomicU64>);
+
+impl HostEventGapTracker {
+    pub(crate) fn record_drop(&self) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn take(&self) -> u64 {
+        self.0.swap(0, Ordering::AcqRel)
+    }
+}
+
+struct ServerEventSender {
+    tx: tokio::sync::mpsc::Sender<Value>,
+    gap: HostEventGapTracker,
 }
 
 /// Builder for [`ServerAgenticLoopHost`].
@@ -2473,27 +2486,28 @@ impl ServerAgenticLoopHost {
     }
 
     /// Push an SSE event to both the internal buffer and the streaming channel.
-    /// The internal host → fanout lane is lossless: it carries approvals as
-    /// well as progress and is isolated from network backpressure by the
-    /// fanout's bounded observer channel. A closed receiver detaches delivery.
+    /// The internal host → fanout lane is bounded. When progress outruns its
+    /// consumer, the producer records a coalesced gap instead of accumulating
+    /// unbounded memory; the bridge emits a durable-snapshot repair boundary
+    /// before the next event. A closed receiver detaches delivery.
     fn emit_event(&mut self, mut event: Value) {
         self.attach_execution_metadata_to_tool_event(&mut event);
         self.mirror_agent_live_event(&event);
         let streaming_turn = self.event_tx.is_some();
-        if let Some(sender) = &self.event_tx {
-            let disconnected = match sender {
-                ServerEventSender::Bounded(tx) => match tx.try_send(event.clone()) {
-                    Ok(()) => false,
-                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => true,
-                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                        // Compatibility-only bounded hosts retain the old
-                        // detached behavior. Production root and child loops
-                        // install the lossless internal lane below.
-                        tracing::warn!(target: "sse_channel", "bounded compatibility stream filled; detaching it while durable run continues");
-                        true
-                    }
-                },
-                ServerEventSender::Unbounded(tx) => tx.send(event.clone()).is_err(),
+        let uses_attached_lane = !self.prefer_client_tool_delivery
+            || matches!(
+                event.get("type").and_then(Value::as_str),
+                Some("approval_required" | "approval_batch_required" | "tool_request")
+            );
+        if uses_attached_lane && let Some(sender) = &self.event_tx {
+            let disconnected = match sender.tx.try_send(event.clone()) {
+                Ok(()) => false,
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => true,
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                    sender.gap.record_drop();
+                    tracing::warn!(target: "sse_channel", "bounded host event lane filled; recording a durable repair boundary");
+                    false
+                }
             };
             if disconnected {
                 tracing::debug!(target: "sse_channel", "stream fanout disconnected; detaching live delivery while durable run continues");
@@ -2674,23 +2688,18 @@ impl ServerAgenticLoopHost {
         }
         std::mem::take(&mut self.emitted_events)
     }
-    /// Attach an incremental SSE channel. Events will be pushed through
-    /// this sender as they are emitted, enabling streaming to the client.
-    /// Channel closure detaches this observer; it does not cancel the run.
-    pub(crate) fn set_unbounded_event_tx(&mut self, tx: tokio::sync::mpsc::UnboundedSender<Value>) {
-        // In live streaming mode, run_lifecycle owns the dedicated progress
-        // bridge. Keeping the host subscription active would replay the same
-        // agent progress events at turn-boundary drains, duplicating cards and
-        // persisted work-surface deltas.
-        self.progress_rx = None;
-        self.progress_filter = None;
-        self.event_tx = Some(ServerEventSender::Unbounded(tx));
+    pub fn set_event_tx(&mut self, tx: tokio::sync::mpsc::Sender<Value>) {
+        self.set_event_tx_with_gap(tx, HostEventGapTracker::default());
     }
 
-    pub fn set_event_tx(&mut self, tx: tokio::sync::mpsc::Sender<Value>) {
+    pub(crate) fn set_event_tx_with_gap(
+        &mut self,
+        tx: tokio::sync::mpsc::Sender<Value>,
+        gap: HostEventGapTracker,
+    ) {
         self.progress_rx = None;
         self.progress_filter = None;
-        self.event_tx = Some(ServerEventSender::Bounded(tx));
+        self.event_tx = Some(ServerEventSender { tx, gap });
     }
 
     pub(crate) fn detach_event_tx(&mut self) {
@@ -12640,7 +12649,7 @@ mod tests {
     }
 
     #[test]
-    fn lossless_internal_stream_preserves_approval_after_progress_burst() {
+    fn bounded_internal_stream_coalesces_overflow_without_permanent_detach() {
         let mut host = ServerAgenticLoopHostBuilder::new(
             mock_matrixone(),
             mock_encryptor(),
@@ -12652,10 +12661,15 @@ mod tests {
         let cancel_token = Arc::new(CancellationToken::new());
         host.set_client_cancel(Arc::clone(&cancel_flag), Arc::clone(&cancel_token));
 
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        host.set_unbounded_event_tx(tx);
-        for sequence in 0..1_024 {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        let gap = HostEventGapTracker::default();
+        host.set_event_tx_with_gap(tx, gap.clone());
+        for sequence in 0..8 {
             host.emit_event(json!({"type": "text_delta", "sequence": sequence}));
+        }
+        for expected_sequence in 0..4 {
+            let event = rx.try_recv().expect("bounded prefix remains ordered");
+            assert_eq!(event["sequence"], expected_sequence);
         }
         host.emit_event(json!({
             "type": "approval_required",
@@ -12671,14 +12685,11 @@ mod tests {
             "LLM cancellation token must remain active on channel backpressure"
         );
         assert!(host.event_tx.is_some());
-        for expected_sequence in 0..1_024 {
-            let event = rx.try_recv().expect("every progress event remains ordered");
-            assert_eq!(event["sequence"], expected_sequence);
-        }
         let approval = rx.try_recv().expect("approval survives the progress burst");
         assert_eq!(approval["type"], "approval_required");
         assert_eq!(approval["request_id"], "approval-after-burst");
-        assert_eq!(host.emitted_events.len(), 1_025);
+        assert_eq!(gap.take(), 4, "overflow is one coalesced repair boundary");
+        assert_eq!(host.emitted_events.len(), 9);
     }
 
     #[test]

--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -1163,6 +1163,10 @@ pub struct ServerAgenticLoopHost {
     /// incremental streaming (web agent mode). The HTTP handler reads
     /// from the corresponding receiver to stream SSE to the client.
     event_tx: Option<ServerEventSender>,
+    /// Durable, bounded owner of human-input and executable-client
+    /// boundaries. Unlike progress SSE, these events may never be dropped or
+    /// exposed before their replay fact is committed.
+    interaction_sink: Option<Arc<dyn HostInteractionSink>>,
     /// A server-side child may share its parent's client tool-delivery lane
     /// while retaining a separate transcript stream. Only edge-bound tool
     /// requests use that lane; ordinary child output stays on the typed live
@@ -1262,17 +1266,35 @@ struct AgentLiveMirror {
     sink: SharedAgentLiveEventSink,
 }
 
+#[derive(Default)]
+struct HostEventGapState {
+    dropped: AtomicU64,
+    notify: tokio::sync::Notify,
+}
+
 #[derive(Clone, Default)]
-pub(crate) struct HostEventGapTracker(Arc<AtomicU64>);
+pub(crate) struct HostEventGapTracker(Arc<HostEventGapState>);
 
 impl HostEventGapTracker {
     pub(crate) fn record_drop(&self) {
-        self.0.fetch_add(1, Ordering::Relaxed);
+        self.0.dropped.fetch_add(1, Ordering::Relaxed);
+        self.0.notify.notify_one();
     }
 
     pub(crate) fn take(&self) -> u64 {
-        self.0.swap(0, Ordering::AcqRel)
+        self.0.dropped.swap(0, Ordering::AcqRel)
     }
+
+    pub(crate) async fn notified(&self) {
+        self.0.notify.notified().await;
+    }
+}
+
+#[async_trait]
+pub(crate) trait HostInteractionSink: Send + Sync {
+    /// Commit durable replay truth before exposing an interaction. Success is
+    /// the producer's permission to begin waiting for its callback.
+    async fn commit_and_deliver(&self, event: Value) -> Result<(), String>;
 }
 
 struct ServerEventSender {
@@ -1765,6 +1787,7 @@ impl ServerAgenticLoopHostBuilder {
             ),
             emitted_events: Vec::new(),
             event_tx: None,
+            interaction_sink: None,
             prefer_client_tool_delivery: false,
             client_cancel_flag: None,
             client_cancel_token: None,
@@ -2485,21 +2508,39 @@ impl ServerAgenticLoopHost {
             })
     }
 
-    /// Push an SSE event to both the internal buffer and the streaming channel.
-    /// The internal host → fanout lane is bounded. When progress outruns its
-    /// consumer, the producer records a coalesced gap instead of accumulating
-    /// unbounded memory; the bridge emits a durable-snapshot repair boundary
-    /// before the next event. A closed receiver detaches delivery.
+    fn interaction_event_requires_commit(event: &Value) -> bool {
+        matches!(
+            event.get("type").and_then(Value::as_str),
+            Some("approval_required" | "approval_batch_required" | "tool_request")
+        )
+    }
+
+    fn retain_emitted_event(&mut self, event: Value, streaming_turn: bool) {
+        self.emitted_events.push(event);
+        if streaming_turn && self.emitted_events.len() > MAX_STREAMED_TURN_EVENT_BUFFER {
+            let overflow = self
+                .emitted_events
+                .len()
+                .saturating_sub(MAX_STREAMED_TURN_EVENT_BUFFER);
+            self.emitted_events.drain(0..overflow);
+        }
+    }
+
+    /// Push ordinary progress to both the bounded live lane and terminal
+    /// buffer. Progress may be coalesced behind an explicit repair boundary;
+    /// interactions that can block execution must use
+    /// [`Self::emit_committed_interaction`] instead.
     fn emit_event(&mut self, mut event: Value) {
+        debug_assert!(
+            !Self::interaction_event_requires_commit(&event),
+            "blocking interactions require durable commit acknowledgement"
+        );
         self.attach_execution_metadata_to_tool_event(&mut event);
         self.mirror_agent_live_event(&event);
         let streaming_turn = self.event_tx.is_some();
-        let uses_attached_lane = !self.prefer_client_tool_delivery
-            || matches!(
-                event.get("type").and_then(Value::as_str),
-                Some("approval_required" | "approval_batch_required" | "tool_request")
-            );
-        if uses_attached_lane && let Some(sender) = &self.event_tx {
+        if !self.prefer_client_tool_delivery
+            && let Some(sender) = &self.event_tx
+        {
             let disconnected = match sender.tx.try_send(event.clone()) {
                 Ok(()) => false,
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => true,
@@ -2514,14 +2555,31 @@ impl ServerAgenticLoopHost {
                 self.event_tx = None;
             }
         }
-        self.emitted_events.push(event);
-        if streaming_turn && self.emitted_events.len() > MAX_STREAMED_TURN_EVENT_BUFFER {
-            let overflow = self
-                .emitted_events
-                .len()
-                .saturating_sub(MAX_STREAMED_TURN_EVENT_BUFFER);
-            self.emitted_events.drain(0..overflow);
+        self.retain_emitted_event(event, streaming_turn);
+    }
+
+    /// Commit and deliver an interaction before allowing the executor to wait
+    /// for its callback. Production installs a durable sink; direct host tests
+    /// fall back to bounded channel send, which is still lossless.
+    async fn emit_committed_interaction(&mut self, mut event: Value) -> Result<(), String> {
+        debug_assert!(Self::interaction_event_requires_commit(&event));
+        self.attach_execution_metadata_to_tool_event(&mut event);
+        let streaming_turn = self.event_tx.is_some() || self.interaction_sink.is_some();
+
+        if let Some(sink) = self.interaction_sink.clone() {
+            sink.commit_and_deliver(event.clone()).await?;
+        } else if let Some(sender) = self.event_tx.as_ref().map(|sender| sender.tx.clone()) {
+            sender
+                .send(event.clone())
+                .await
+                .map_err(|_| "interaction delivery lane is closed".to_string())?;
+        } else {
+            return Err("interactive event has no durable delivery owner".to_string());
         }
+
+        self.mirror_agent_live_event(&event);
+        self.retain_emitted_event(event, streaming_turn);
+        Ok(())
     }
 
     fn attach_execution_metadata_to_tool_event(&self, event: &mut Value) {
@@ -2700,6 +2758,10 @@ impl ServerAgenticLoopHost {
         self.progress_rx = None;
         self.progress_filter = None;
         self.event_tx = Some(ServerEventSender { tx, gap });
+    }
+
+    pub(crate) fn set_interaction_sink(&mut self, sink: Arc<dyn HostInteractionSink>) {
+        self.interaction_sink = Some(sink);
     }
 
     pub(crate) fn detach_event_tx(&mut self) {
@@ -3557,16 +3619,16 @@ impl ServerAgenticLoopHost {
         }
 
         for batch in collect_approval_batches(&tool_calls) {
-            if batch.items.len() == 1 {
+            let event = if batch.items.len() == 1 {
                 let item = &batch.items[0];
-                self.emit_event(Value::Object(build_approval_required_event(
+                Value::Object(build_approval_required_event(
                     &item.request_id,
                     &item.tool_name,
                     item.approval_kind,
                     item.path.as_deref(),
                     item.detail.as_deref(),
                     item.display_label.as_deref(),
-                )));
+                ))
             } else {
                 let requests = batch
                     .items
@@ -3580,9 +3642,35 @@ impl ServerAgenticLoopHost {
                         display_label: item.display_label.as_deref(),
                     })
                     .collect::<Vec<_>>();
-                self.emit_event(Value::Object(build_approval_batch_required_event(
-                    &requests,
-                )));
+                Value::Object(build_approval_batch_required_event(&requests))
+            };
+            if let Err(error) = self.emit_committed_interaction(event).await {
+                tracing::error!(
+                    target: "astra_runtime::server_loop_host",
+                    run_id,
+                    error = %error,
+                    "approval interaction could not be committed and delivered"
+                );
+                for item in &batch.items {
+                    let (_, _, args) = parse_flat_tool_call_event(&item.tool_call);
+                    results_by_id.insert(
+                        item.request_id.clone(),
+                        EdgeToolExecResult {
+                            request_id: item.request_id.clone(),
+                            tool: item.tool_name.clone(),
+                            args: args.clone(),
+                            output: format!("Approval request delivery failed: {error}"),
+                            tool_result_fields: Some(self.edge_result_fields_with_runtime(
+                                &item.request_id,
+                                &item.tool_name,
+                                &args,
+                                None,
+                            )),
+                            status: "error".to_string(),
+                            duration_ms: 0,
+                        },
+                    );
+                }
             }
         }
 
@@ -3606,6 +3694,9 @@ impl ServerAgenticLoopHost {
                         continue;
                     }
                     let (request_id, tool_name, args) = parse_flat_tool_call_event(tc);
+                    if results_by_id.contains_key(&request_id) {
+                        continue;
+                    }
                     if let Err(denied) = wait_approval_ledger_for_tool(
                         &self.edge_callback_ledger,
                         &self.user_id,
@@ -3694,7 +3785,8 @@ impl ServerAgenticLoopHost {
             // Register every callback before its SSE request is visible. This
             // makes the exact emitted identity—not session ownership alone—
             // the authorization boundary for same-process delivery.
-            for (tc, _) in &pending_calls {
+            let mut delivered_calls = Vec::with_capacity(pending_calls.len());
+            for (tc, sig) in pending_calls {
                 let request_id = tc.get("id").and_then(Value::as_str).unwrap_or("");
                 let identity = astra_services::multi_agent::EdgeDispatchIdentity::new(
                     &self.user_id,
@@ -3703,7 +3795,9 @@ impl ServerAgenticLoopHost {
                     turn_chain_id,
                     request_id,
                 );
-                expect_ledger_entry(&self.edge_callback_ledger, &tool_callback_key(&identity));
+                let callback_key = tool_callback_key(&identity);
+                expect_ledger_entry(&self.edge_callback_ledger, &callback_key);
+                let mut delivery_error = None;
                 for m in sse_maps_through_tool_request(tc, &identity) {
                     // L1094 (execute_mock_turn mock-LLM-response path) is the
                     // SINGLE owner of `tool_call` events per skill invocation.
@@ -3720,11 +3814,42 @@ impl ServerAgenticLoopHost {
                             continue;
                         }
                     }
-                    self.emit_event(Value::Object(m));
+                    let event = Value::Object(m);
+                    if Self::interaction_event_requires_commit(&event) {
+                        if let Err(error) = self.emit_committed_interaction(event).await {
+                            delivery_error = Some(error);
+                            break;
+                        }
+                    } else {
+                        self.emit_event(event);
+                    }
+                }
+                if let Some(error) = delivery_error {
+                    astra_turn_core::edge_ledger::cancel_expected_ledger_entry(
+                        &self.edge_callback_ledger,
+                        &callback_key,
+                    );
+                    let (id, tool_name, args) = parse_flat_tool_call_event(tc);
+                    results_by_id.insert(
+                        id.clone(),
+                        EdgeToolExecResult {
+                            request_id: id.clone(),
+                            tool: tool_name.clone(),
+                            args: args.clone(),
+                            output: format!("Tool request delivery failed: {error}"),
+                            tool_result_fields: Some(
+                                self.edge_result_fields_with_runtime(&id, &tool_name, &args, None),
+                            ),
+                            status: "error".to_string(),
+                            duration_ms: 0,
+                        },
+                    );
+                } else {
+                    delivered_calls.push((tc, sig));
                 }
             }
 
-            for (tc, sig) in pending_calls {
+            for (tc, sig) in delivered_calls {
                 let (id, tool_name, args) = parse_flat_tool_call_event(tc);
                 let identity = astra_services::multi_agent::EdgeDispatchIdentity::new(
                     &self.user_id,
@@ -12648,8 +12773,8 @@ mod tests {
         assert!(host.progress_filter.is_none());
     }
 
-    #[test]
-    fn bounded_internal_stream_coalesces_overflow_without_permanent_detach() {
+    #[tokio::test]
+    async fn full_progress_queue_backpressures_instead_of_dropping_interaction() {
         let mut host = ServerAgenticLoopHostBuilder::new(
             mock_matrixone(),
             mock_encryptor(),
@@ -12667,14 +12792,26 @@ mod tests {
         for sequence in 0..8 {
             host.emit_event(json!({"type": "text_delta", "sequence": sequence}));
         }
-        for expected_sequence in 0..4 {
-            let event = rx.try_recv().expect("bounded prefix remains ordered");
-            assert_eq!(event["sequence"], expected_sequence);
+        {
+            let interaction = host.emit_committed_interaction(json!({
+                "type": "approval_required",
+                "request_id": "approval-after-burst",
+                "tool": "bash",
+            }));
+            tokio::pin!(interaction);
+            assert!(
+                tokio::time::timeout(Duration::from_millis(25), &mut interaction)
+                    .await
+                    .is_err(),
+                "a full bounded queue must apply backpressure, not report false delivery"
+            );
+
+            let first = rx.try_recv().expect("bounded prefix remains available");
+            assert_eq!(first["sequence"], 0);
+            interaction
+                .await
+                .expect("capacity release delivers the interaction exactly once");
         }
-        host.emit_event(json!({
-            "type": "approval_required",
-            "request_id": "approval-after-burst",
-        }));
 
         assert!(
             !cancel_flag.load(Ordering::SeqCst),
@@ -12685,11 +12822,28 @@ mod tests {
             "LLM cancellation token must remain active on channel backpressure"
         );
         assert!(host.event_tx.is_some());
-        let approval = rx.try_recv().expect("approval survives the progress burst");
+        for expected_sequence in 1..4 {
+            let event = rx.try_recv().expect("bounded prefix remains ordered");
+            assert_eq!(event["sequence"], expected_sequence);
+        }
+        let approval = rx
+            .try_recv()
+            .expect("approval follows the accepted progress prefix");
         assert_eq!(approval["type"], "approval_required");
         assert_eq!(approval["request_id"], "approval-after-burst");
         assert_eq!(gap.take(), 4, "overflow is one coalesced repair boundary");
         assert_eq!(host.emitted_events.len(), 9);
+    }
+
+    #[tokio::test]
+    async fn overflow_gap_notifies_without_waiting_for_another_event() {
+        let gap = HostEventGapTracker::default();
+        gap.record_drop();
+
+        tokio::time::timeout(Duration::from_millis(25), gap.notified())
+            .await
+            .expect("a terminal progress drop must wake the bridge immediately");
+        assert_eq!(gap.take(), 1);
     }
 
     #[test]

--- a/crates/runtime/src/server/tool_execution_result.rs
+++ b/crates/runtime/src/server/tool_execution_result.rs
@@ -240,7 +240,7 @@ mod tests {
                     "id": "future-work-1",
                     "kind": "future_capability",
                     "status": "running",
-                    "version": "revision-9",
+                    "revision": 9,
                     "mode": "current"
                 }
             })
@@ -266,7 +266,7 @@ mod tests {
                     "id": "",
                     "kind": "future_capability",
                     "status": "running",
-                    "version": "revision-9",
+                    "revision": 9,
                     "mode": "current"
                 }
             })
@@ -293,7 +293,7 @@ mod tests {
                     "id": "future-agent-1",
                     "kind": "future_capability",
                     "status": "waiting_for_input",
-                    "version": "revision-10",
+                    "revision": 10,
                     "mode": "wait",
                     "wake_policy": "on_attention_or_terminal"
                 }

--- a/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -4251,9 +4251,9 @@ mod tests {
                             "id": "review-group",
                             "kind": "agent_fanout",
                             "status": "running",
-                            "version": "7",
+                            "revision": 7,
                             "mode": "current",
-                            "wake_policy": "on_terminal"
+                            "wake_policy": "on_attention_or_terminal"
                         }],
                     }
                 }),
@@ -4297,11 +4297,11 @@ mod tests {
             "review-group",
             "agent_fanout",
             astra_core::work_unit::WorkUnitStatus::Running,
-            "7",
+            7,
             astra_core::work_unit::WorkUnitObservationMode::Current,
         )
         .unwrap()
-        .with_wake_policy(astra_core::work_unit::WorkUnitWakePolicy::OnTerminal);
+        .with_wake_policy(astra_core::work_unit::WorkUnitWakePolicy::OnAttentionOrTerminal);
         assert_eq!(
             state.observe_work_unit(&unchanged),
             astra_core::work_unit::WorkUnitObservationOutcome::Unchanged { consecutive: 1 }
@@ -4326,11 +4326,11 @@ mod tests {
             "review-group",
             "agent_fanout",
             astra_core::work_unit::WorkUnitStatus::Completed,
-            "8",
+            8,
             astra_core::work_unit::WorkUnitObservationMode::Transition,
         )
         .unwrap()
-        .with_wake_policy(astra_core::work_unit::WorkUnitWakePolicy::OnTerminal);
+        .with_wake_policy(astra_core::work_unit::WorkUnitWakePolicy::OnAttentionOrTerminal);
         state.observe_work_unit(&completed);
         assert!(state.stall.work_unit_observations.is_empty());
         let refreshed = state
@@ -4347,6 +4347,48 @@ mod tests {
                 .get("background_work_snapshot")
                 .is_none(),
             "newer producer truth must retire the stale submission-time XML"
+        );
+    }
+
+    #[test]
+    fn delayed_nonterminal_snapshot_cannot_overwrite_newer_producer_revision() {
+        let mut state = make_state();
+        let registry = Arc::new(astra_core::work_unit::ActiveWorkRegistry::default());
+        let newer = astra_core::work_unit::WorkUnitObservation::new(
+            "review-group",
+            "agent_fanout",
+            astra_core::work_unit::WorkUnitStatus::WaitingForInput,
+            8,
+            astra_core::work_unit::WorkUnitObservationMode::Current,
+        )
+        .unwrap()
+        .with_wake_policy(astra_core::work_unit::WorkUnitWakePolicy::OnAttentionOrTerminal);
+        registry.observe(&newer);
+        state.attach_active_work_registry(registry);
+
+        let mut delayed = serde_json::json!({
+            "schema": "active_work_snapshot.v1",
+            "background_work_snapshot": "stale display projection",
+            "work_unit_observations": [{
+                "id": "review-group",
+                "kind": "agent_fanout",
+                "status": "running",
+                "revision": 7,
+                "mode": "current",
+                "wake_policy": "on_attention_or_terminal"
+            }]
+        });
+        state.reconcile_active_work_context(&mut delayed);
+
+        assert_eq!(
+            delayed["work_unit_observations"][0]["status"],
+            "waiting_for_input"
+        );
+        assert_eq!(delayed["work_unit_observations"][0]["revision"], 8);
+        assert!(delayed.get("background_work_snapshot").is_none());
+        assert_eq!(
+            delayed["projection_state"],
+            "superseded_by_newer_producer_observation"
         );
     }
 

--- a/crates/runtime/src/turn/agentic_loop/finalization.rs
+++ b/crates/runtime/src/turn/agentic_loop/finalization.rs
@@ -972,6 +972,11 @@ fn append_interruption_detail(
 
 fn reset_per_turn_advisory_state(state: &mut AgenticLoopState) {
     state.stall.work_unit_observations.clear();
+    if let Some(registry) = state.stall.active_work_registry.as_ref() {
+        for observation in registry.active_work_observations() {
+            state.stall.work_unit_observations.observe(&observation);
+        }
+    }
     state.stall.execution_escalation_advisory_emitted = false;
     state.stall.parallel_batching_advisory_emitted = false;
     state.stall.repetition_advisory_emitted = false;

--- a/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/crates/runtime/src/turn/agentic_loop/host.rs
@@ -1083,6 +1083,10 @@ pub struct StallTrackingState {
     /// progress is a version change, not a tool name, argument shape, prose
     /// fragment, elapsed timer, or low-level event count.
     pub work_unit_observations: astra_core::work_unit::WorkUnitObservationTracker,
+    /// Session-scoped producer registry. The turn tracker remains an
+    /// ephemeral settlement view, while this registry carries canonical work
+    /// across turns and product entrypoints.
+    pub active_work_registry: Option<std::sync::Arc<astra_core::work_unit::ActiveWorkRegistry>>,
     /// Per-turn tool-call dedup signatures.
     pub turn_sigs: Vec<BTreeSet<String>>,
     /// Per-turn tool name sets.
@@ -2617,11 +2621,23 @@ impl AgenticLoopState {
         &mut self,
         observation: &astra_core::work_unit::WorkUnitObservation,
     ) -> astra_core::work_unit::WorkUnitObservationOutcome {
-        let outcome = self.stall.work_unit_observations.observe(observation);
+        let canonical = if let Some(registry) = self.stall.active_work_registry.as_ref() {
+            if registry.observe(observation)
+                == astra_core::work_unit::WorkUnitObservationOutcome::Ignored
+            {
+                return astra_core::work_unit::WorkUnitObservationOutcome::Ignored;
+            }
+            registry
+                .canonical_observation(&observation.id, &observation.kind)
+                .unwrap_or_else(|| observation.clone())
+        } else {
+            observation.clone()
+        };
+        let outcome = self.stall.work_unit_observations.observe(&canonical);
         if outcome == astra_core::work_unit::WorkUnitObservationOutcome::Ignored {
             return outcome;
         }
-        let Ok(observation_value) = serde_json::to_value(observation) else {
+        let Ok(observation_value) = serde_json::to_value(&canonical) else {
             return outcome;
         };
         for injection in self
@@ -2649,9 +2665,9 @@ impl AgenticLoopState {
                 let mut replaced = false;
                 for current in observations.iter_mut() {
                     let same_identity = current.get("id").and_then(Value::as_str)
-                        == Some(observation.id.as_str())
+                        == Some(canonical.id.as_str())
                         && current.get("kind").and_then(Value::as_str)
-                            == Some(observation.kind.as_str());
+                            == Some(canonical.kind.as_str());
                     if same_identity && current != &observation_value {
                         *current = observation_value.clone();
                         replaced = true;
@@ -2669,13 +2685,35 @@ impl AgenticLoopState {
         outcome
     }
 
+    pub fn attach_active_work_registry(
+        &mut self,
+        registry: std::sync::Arc<astra_core::work_unit::ActiveWorkRegistry>,
+    ) {
+        let observations = registry.active_work_observations();
+        self.stall.active_work_registry = Some(registry);
+        for observation in &observations {
+            self.stall.work_unit_observations.observe(observation);
+        }
+        if !observations.is_empty() {
+            self.push_volatile_payload(
+                VolatileKind::ActiveWorkSnapshot,
+                serde_json::json!({
+                    "schema": "active_work_snapshot.v1",
+                    "work_unit_observations": observations,
+                    "instruction": "This is producer-owned session work state at the current model boundary. Use canonical work-unit IDs and lifecycle state; do not infer completion from individual transport events.",
+                    "authority": "active_work_provider",
+                }),
+            );
+        }
+    }
+
     /// Reconcile a submission-time work snapshot with producer truth already
     /// observed by the turn before the snapshot reached its model boundary.
     ///
     /// Active guidance and foreground tool settlement are independent input
     /// lanes. The guidance lane can therefore deliver an older `running`
-    /// projection after the tool lane has delivered `completed`. Terminal
-    /// producer state is absorbing for the work-unit identity, so replace the
+    /// projection after the tool lane has advanced it. Producer revision is
+    /// authoritative for both non-terminal and terminal state, so replace any
     /// delayed projection and retire its textual cache before prompt assembly.
     pub fn reconcile_active_work_context(&mut self, context: &mut Value) {
         let captured = context
@@ -2694,15 +2732,23 @@ impl AgenticLoopState {
                 continue;
             }
             self.observe_work_unit(&observation);
-            let Some(terminal) = self
+            let canonical = self
                 .stall
-                .work_unit_observations
-                .terminal_observation(&observation.id, &observation.kind)
-            else {
+                .active_work_registry
+                .as_ref()
+                .and_then(|registry| {
+                    registry.canonical_observation(&observation.id, &observation.kind)
+                })
+                .or_else(|| {
+                    self.stall
+                        .work_unit_observations
+                        .canonical_observation(&observation.id, &observation.kind)
+                });
+            let Some(canonical) = canonical else {
                 continue;
             };
-            if terminal != &observation {
-                replacements.push((index, terminal.to_value()));
+            if canonical != observation {
+                replacements.push((index, canonical.to_value()));
             }
         }
         if replacements.is_empty() {
@@ -4038,7 +4084,7 @@ pub(crate) mod tests {
             task_id,
             "shell",
             astra_core::work_unit::WorkUnitStatus::Running,
-            "running:0",
+            1,
             astra_core::work_unit::WorkUnitObservationMode::Transition,
         )
         .unwrap()
@@ -4063,7 +4109,7 @@ pub(crate) mod tests {
             group_id,
             "agent_fanout",
             astra_core::work_unit::WorkUnitStatus::Running,
-            "revision-1",
+            1,
             astra_core::work_unit::WorkUnitObservationMode::Transition,
         )
         .unwrap()
@@ -4147,7 +4193,7 @@ pub(crate) mod tests {
             "completed" => astra_core::work_unit::WorkUnitStatus::Completed,
             "failed" => astra_core::work_unit::WorkUnitStatus::Failed,
             "interrupted" => astra_core::work_unit::WorkUnitStatus::Interrupted,
-            "killed" => astra_core::work_unit::WorkUnitStatus::Cancelled,
+            "cancelled" => astra_core::work_unit::WorkUnitStatus::Cancelled,
             _ => astra_core::work_unit::WorkUnitStatus::Unavailable,
         };
         let observation_mode = match mode {
@@ -4160,7 +4206,7 @@ pub(crate) mod tests {
             task_id,
             "shell",
             work_status,
-            format!("{status}:0"),
+            1,
             observation_mode,
         )
         .unwrap()

--- a/crates/runtime/src/turn/agentic_loop/tool_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/tool_phase.rs
@@ -1565,7 +1565,7 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
                 work_unit_id = %observation.id,
                 kind = %observation.kind,
                 status = ?observation.status,
-                version = %observation.version,
+                revision = observation.revision,
                 mode = ?observation.mode,
                 outcome = ?outcome,
                 "recorded producer-owned work-unit observation"
@@ -2117,7 +2117,7 @@ mod tests {
             "work-1",
             "future_background_capability",
             astra_core::work_unit::WorkUnitStatus::Running,
-            "revision-7",
+            7,
             astra_core::work_unit::WorkUnitObservationMode::Current,
         )
         .unwrap();

--- a/crates/runtime/tests/system_matrix_http_e2e/harness.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/harness.rs
@@ -614,6 +614,7 @@ pub async fn wait_for_run_status(
 /// Shared Matrix E2E context after app build + user registration + session creation.
 pub struct MatrixE2eCtx {
     pub app: Router,
+    pub app_state: astra_runtime::AppState,
     pub pool: sqlx::MySqlPool,
     pub shared_pool: SharedPool,
     /// Logical MatrixOne database (includes `ASTRA_DATABASE_PREFIX` + `ASTRA_DATABASE`).
@@ -808,6 +809,14 @@ pub async fn bootstrap() -> BootstrapResult {
             ),
     ));
 
+    // `build_app` is used in-process here, so the real server startup hook that
+    // primes capability health does not run. Mirror that production boundary
+    // once; request handlers must continue to consume the cache without remote
+    // dependency I/O.
+    let _ = state
+        .refresh_memoria_health_if_stale(std::time::Duration::ZERO)
+        .await;
+    let app_state = state.clone();
     let app = build_app(state);
 
     let suffix = Uuid::new_v4().simple().to_string();
@@ -921,6 +930,7 @@ pub async fn bootstrap() -> BootstrapResult {
     BootstrapResult {
         ctx: MatrixE2eCtx {
             app,
+            app_state,
             pool,
             shared_pool: session_lifecycle_pool,
             matrixone_database,

--- a/crates/runtime/tests/system_matrix_http_e2e/journey_meta_matrix.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/journey_meta_matrix.rs
@@ -39,6 +39,11 @@ pub async fn run_meta_root_and_health() {
     // transport reports an outage. The public aggregate must distinguish
     // degraded optional capability from both full health and DB outage.
     b.ctx.memoria.set_fail_forward(true);
+    let _ = b
+        .ctx
+        .app_state
+        .refresh_memoria_health_if_stale(std::time::Duration::ZERO)
+        .await;
     let (st_degraded, degraded) = get_json(app, "/health", None, &[]).await;
     assert_eq!(st_degraded, StatusCode::OK, "degraded health: {degraded}");
     assert_eq!(degraded["status"].as_str(), Some("degraded"));

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -20,6 +20,7 @@ bcrypt.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 fernet.workspace = true
 flate2.workspace = true
+futures-util.workspace = true
 hmac.workspace = true
 jsonwebtoken.workspace = true
 regex.workspace = true

--- a/crates/services/src/runs.rs
+++ b/crates/services/src/runs.rs
@@ -7168,6 +7168,15 @@ pub fn transform_run_event_for_client(event: serde_json::Value) -> serde_json::V
             }
             out
         }
+        "tool_request" => {
+            let mut out = serde_json::json!({ "type": "tool_request" });
+            if let Some(obj) = out.as_object_mut() {
+                for (k, v) in &data {
+                    obj.insert(k.clone(), v.clone());
+                }
+            }
+            out
+        }
         "ask_user_prompted" | "user_prompt_required" => {
             let mut out = serde_json::json!({ "type": "user_prompt_required" });
             if let Some(obj) = out.as_object_mut() {
@@ -9998,6 +10007,18 @@ mod tests {
                 &|o| {
                     assert_eq!(o["type"], "approval_required");
                     assert_eq!(o["approval_id"], "a-2");
+                },
+            ),
+            (
+                "tool_request canonical",
+                make_event(
+                    "tool_request",
+                    json!({"request_id": "call-1", "tool": "bash", "args": {"cmd": "pwd"}}),
+                ),
+                &|o| {
+                    assert_eq!(o["type"], "tool_request");
+                    assert_eq!(o["request_id"], "call-1");
+                    assert_eq!(o["tool"], "bash");
                 },
             ),
             (

--- a/crates/services/src/session_journal.rs
+++ b/crates/services/src/session_journal.rs
@@ -7381,6 +7381,8 @@ mod tests {
 
     #[test]
     fn stall_and_checkpoint_events() {
+        let journal_root = tempfile::TempDir::new().unwrap();
+        let _journal_guard = JournalDirGuard::new(journal_root.path());
         // --- stall_detected field correctness ---
         {
             let evt = JournalEvent::stall_detected(

--- a/crates/services/src/storage.rs
+++ b/crates/services/src/storage.rs
@@ -70,6 +70,417 @@ const CORE_SCHEMA_VISIBILITY_PROBES: &[&str] = &[
     "SELECT 1 FROM config_versions LIMIT 0",
 ];
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CoreSchemaTableSpec {
+    pub name: &'static str,
+    pub owner: &'static str,
+}
+
+/// Canonical inventory for tables created by `ensure_core_schema`.
+///
+/// This is data, not a source-text convention. Bootstrap validates the live
+/// MatrixOne catalog against this inventory before publishing its schema
+/// contract, while tests can assert uniqueness and repeated-bootstrap
+/// behavior without parsing Rust files or SQL formatting.
+pub const CORE_SCHEMA_TABLES: &[CoreSchemaTableSpec] = &[
+    CoreSchemaTableSpec {
+        name: "admin_config",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "agent_agents",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "agent_bindings",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "agent_event_edges",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "agent_events",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "agent_run_events",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "agent_runs",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "agent_session_execution_slots",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "agent_sessions",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "agent_tasks",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "astra_schema_bootstrap_leases",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "astra_schema_contracts",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "auth_audit_logs",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "auth_provider_request_replay",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "auth_refresh_tokens",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "auth_roles",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "auth_tokens",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "auth_user_roles",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "auth_users",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "config_versions",
+        owner: "config_version_cloud",
+    },
+    CoreSchemaTableSpec {
+        name: "context_manifest_items",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "context_manifests",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "conversation_log",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "ctx_decision_audits",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "ctx_snapshots",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "data_versioning_checkpoints",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "edge_agent_registry",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "edge_pending_dispatch",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "eval_calibration_assessments",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "eval_gate_results",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "eval_quality_assessments",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "eval_training_datasets",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "eval_user_feedback",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "harness_citations",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "harness_items",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "harness_runs",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "harness_skill_drafts",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "harness_skill_rules",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "harness_snapshots",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "infra_llm_models",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "infra_sandbox_metadata",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "maintenance_sweep_cursors",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "mcp_bindings",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "mcp_servers",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "mcp_tools",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "model_gateways",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "plan_step_runs",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "plan_templates",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "plans",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "preview_template_registry",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "prompt_deltas",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "prompt_request_records",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "raw_ref_scheme_registry",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "run_checkpoints",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "run_display_projections",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "runtime_llm_trusted_domains",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "semantic_read_observation_budgets",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "semantic_read_observations",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_artifact_references",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_artifacts",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_artifacts_grants",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_checkpoints",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_delegations",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_device_lease_events",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_device_leases",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_history_chunks",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_state_item_events",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_state_items",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_state_revisions",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_todo_counters",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_todo_idempotency",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_todos",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_tool_output_batches",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_tool_outputs",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "session_transcript_items",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "skill_installations",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "skill_metrics",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "skill_resource_bindings",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "skill_selection_events",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "skill_settings",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "skill_user_credentials",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "skills_registry",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "sweeper_leases",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "task_contracts",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "task_leases",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "team_definitions",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "team_execution_history",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "team_snapshots",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "tool_invocation_archive_chunks",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "tool_invocation_ledger",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "transcript_pages",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "user_preferences",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "user_skill_evaluations",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "user_skill_sources",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "user_skill_versions",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "verification_results",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "wf_triggers",
+        owner: "storage",
+    },
+    CoreSchemaTableSpec {
+        name: "workspace_cleanup_debts",
+        owner: "workspace_records",
+    },
+    CoreSchemaTableSpec {
+        name: "workspace_records",
+        owner: "workspace_records",
+    },
+];
+
 pub(crate) fn rows_affected_to_i64(rows: u64, context: &str) -> Result<i64, sqlx::Error> {
     i64::try_from(rows).map_err(|_| {
         sqlx::Error::Protocol(format!("{context}: rows_affected {rows} exceeds i64::MAX"))
@@ -305,6 +716,33 @@ async fn core_schema_contract_is_current(pool: &sqlx::Pool<MySql>) -> Result<boo
         Some(version) => Err(sqlx::Error::Protocol(format!(
             "core schema contract mismatch: database has {version}, binary requires {CORE_SCHEMA_CONTRACT_VERSION}; provision a database with the current canonical schema"
         ))),
+    }
+}
+
+async fn verify_core_schema_catalog(
+    pool: &sqlx::Pool<MySql>,
+    database: &str,
+) -> Result<(), sqlx::Error> {
+    let rows = query("SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = ?")
+        .bind(database)
+        .fetch_all(pool)
+        .await?;
+    let existing = rows
+        .into_iter()
+        .map(|row| row.try_get::<String, _>("TABLE_NAME"))
+        .collect::<Result<BTreeSet<_>, _>>()?;
+    let missing = CORE_SCHEMA_TABLES
+        .iter()
+        .filter(|table| !existing.contains(table.name))
+        .map(|table| format!("{} (owner={})", table.name, table.owner))
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(sqlx::Error::Protocol(format!(
+            "core schema catalog is incomplete after bootstrap: missing {}",
+            missing.join(", ")
+        )))
     }
 }
 
@@ -1377,7 +1815,7 @@ async fn ensure_core_schema_while_leased(
     holder_id: &str,
 ) -> Result<(), sqlx::Error> {
     if core_schema_contract_is_current(&pool).await? {
-        return Ok(());
+        return verify_core_schema_catalog(&pool, &settings.database).await;
     }
 
     // Existing deployments may still have UUID-sized identity columns. Widen
@@ -5560,6 +5998,7 @@ async fn ensure_core_schema_while_leased(
         .execute(&pool)
         .await?;
 
+    verify_core_schema_catalog(&pool, &settings.database).await?;
     mark_core_schema_contract_current(&pool, holder_id).await?;
     Ok(())
 }
@@ -7094,78 +7533,17 @@ mod tests {
     }
 
     #[test]
-    fn production_tables_have_one_schema_owner_across_the_workspace() {
-        fn rust_sources_under(directory: &std::path::Path, output: &mut Vec<std::path::PathBuf>) {
-            let mut entries = std::fs::read_dir(directory)
-                .unwrap_or_else(|error| panic!("read {}: {error}", directory.display()))
-                .collect::<Result<Vec<_>, _>>()
-                .unwrap_or_else(|error| {
-                    panic!("read entry under {}: {error}", directory.display())
-                });
-            entries.sort_by_key(|entry| entry.path());
-            for entry in entries {
-                let path = entry.path();
-                if path.is_dir() {
-                    if path.file_name().is_some_and(|name| name == "tests") {
-                        continue;
-                    }
-                    rust_sources_under(&path, output);
-                } else if path.extension().is_some_and(|extension| extension == "rs") {
-                    output.push(path);
-                }
-            }
+    fn core_schema_catalog_has_unique_owned_table_names() {
+        let mut names = BTreeSet::new();
+        for table in CORE_SCHEMA_TABLES {
+            assert!(!table.name.is_empty());
+            assert!(!table.owner.is_empty());
+            assert!(
+                names.insert(table.name),
+                "core schema catalog has duplicate ownership for {}",
+                table.name
+            );
         }
-
-        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .and_then(std::path::Path::parent)
-            .expect("services crate must live under <workspace>/crates");
-        let crates_root = workspace_root.join("crates");
-        let mut sources = Vec::new();
-        rust_sources_under(&crates_root, &mut sources);
-        let marker = "CREATE TABLE IF NOT EXISTS ";
-        let mut owners = std::collections::BTreeMap::<String, Vec<String>>::new();
-        for path in sources {
-            let source = std::fs::read_to_string(&path)
-                .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
-            // Production modules keep inline tests behind a terminal cfg(test)
-            // module. Test fixtures must not become competing schema owners.
-            let production = source.split("#[cfg(test)]").next().unwrap_or(&source);
-            let uncommented = production
-                .lines()
-                .filter(|line| !line.trim_start().starts_with("//"))
-                .collect::<Vec<_>>()
-                .join("\n");
-            for rest in uncommented.split(marker).skip(1) {
-                let table = rest
-                    .chars()
-                    .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
-                    .collect::<String>();
-                assert!(
-                    !table.is_empty(),
-                    "{} has a CREATE TABLE declaration without a parseable table name",
-                    path.display()
-                );
-                let owner = path
-                    .strip_prefix(workspace_root)
-                    .unwrap_or(&path)
-                    .display()
-                    .to_string();
-                owners.entry(table).or_default().push(owner);
-            }
-        }
-
-        let duplicates: Vec<_> = owners
-            .into_iter()
-            .filter_map(|(table, owners)| {
-                (owners.len() > 1).then_some(format!("{table} => {}", owners.join(", ")))
-            })
-            .collect();
-        assert!(
-            duplicates.is_empty(),
-            "each production table must have exactly one DDL owner; duplicate owners: {}",
-            duplicates.join("; ")
-        );
     }
 
     #[test]

--- a/crates/services/src/storage.rs
+++ b/crates/services/src/storage.rs
@@ -5,9 +5,11 @@ use astra_core::{
     internal_error,
 };
 use axum::{Json, http::StatusCode};
-use sqlx::{Executor, MySql, QueryBuilder, Row, query};
-use std::collections::{BTreeSet, HashMap, HashSet};
-use std::sync::OnceLock;
+use sha2::Digest;
+use sqlx::{Execute, Executor, MySql, QueryBuilder, Row, query};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::ops::Deref;
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use uuid::Uuid;
 
 const CAUSAL_EDGE_KIND: &str = "causal";
@@ -49,7 +51,7 @@ pub const AGENT_ID_LEN: usize = 255;
 pub const AGENT_EVENT_ID_LEN: usize = 128;
 static CORE_SCHEMA_INIT_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 const CORE_SCHEMA_CONTRACT_COMPONENT: &str = "astra-core";
-pub const CORE_SCHEMA_CONTRACT_VERSION: &str = "2026-07-16-v1";
+pub const CORE_SCHEMA_CONTRACT_VERSION: &str = "2026-07-19-v2";
 const CORE_SCHEMA_CONTRACT_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS astra_schema_contracts (
     component VARCHAR(64) NOT NULL PRIMARY KEY,
     contract_version VARCHAR(64) NOT NULL,
@@ -62,6 +64,16 @@ const CORE_SCHEMA_LEASE_TABLE_SQL: &str =
     lease_expires_at DATETIME(6) NOT NULL,
     updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
 )";
+const CORE_SCHEMA_TABLE_CONTRACT_SQL: &str =
+    "CREATE TABLE IF NOT EXISTS astra_schema_table_contracts (
+    table_name VARCHAR(128) NOT NULL PRIMARY KEY,
+    component VARCHAR(64) NOT NULL,
+    owner VARCHAR(128) NOT NULL,
+    contract_version VARCHAR(64) NOT NULL,
+    ddl_sha256 CHAR(64) NOT NULL,
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    INDEX idx_schema_table_contract_component (component, contract_version, table_name)
+)";
 const CORE_SCHEMA_VISIBILITY_PROBES: &[&str] = &[
     "SELECT 1 FROM agent_sessions LIMIT 0",
     "SELECT 1 FROM prompt_deltas LIMIT 0",
@@ -70,416 +82,173 @@ const CORE_SCHEMA_VISIBILITY_PROBES: &[&str] = &[
     "SELECT 1 FROM config_versions LIMIT 0",
 ];
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CoreSchemaTableSpec {
-    pub name: &'static str,
-    pub owner: &'static str,
+    pub name: String,
+    pub owner: String,
+    pub ddl_sha256: String,
 }
 
-/// Canonical inventory for tables created by `ensure_core_schema`.
-///
-/// This is data, not a source-text convention. Bootstrap validates the live
-/// MatrixOne catalog against this inventory before publishing its schema
-/// contract, while tests can assert uniqueness and repeated-bootstrap
-/// behavior without parsing Rust files or SQL formatting.
-pub const CORE_SCHEMA_TABLES: &[CoreSchemaTableSpec] = &[
-    CoreSchemaTableSpec {
-        name: "admin_config",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "agent_agents",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "agent_bindings",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "agent_event_edges",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "agent_events",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "agent_run_events",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "agent_runs",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "agent_session_execution_slots",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "agent_sessions",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "agent_tasks",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "astra_schema_bootstrap_leases",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "astra_schema_contracts",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "auth_audit_logs",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "auth_provider_request_replay",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "auth_refresh_tokens",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "auth_roles",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "auth_tokens",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "auth_user_roles",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "auth_users",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "config_versions",
-        owner: "config_version_cloud",
-    },
-    CoreSchemaTableSpec {
-        name: "context_manifest_items",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "context_manifests",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "conversation_log",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "ctx_decision_audits",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "ctx_snapshots",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "data_versioning_checkpoints",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "edge_agent_registry",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "edge_pending_dispatch",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "eval_calibration_assessments",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "eval_gate_results",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "eval_quality_assessments",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "eval_training_datasets",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "eval_user_feedback",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "harness_citations",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "harness_items",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "harness_runs",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "harness_skill_drafts",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "harness_skill_rules",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "harness_snapshots",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "infra_llm_models",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "infra_sandbox_metadata",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "maintenance_sweep_cursors",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "mcp_bindings",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "mcp_servers",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "mcp_tools",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "model_gateways",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "plan_step_runs",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "plan_templates",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "plans",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "preview_template_registry",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "prompt_deltas",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "prompt_request_records",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "raw_ref_scheme_registry",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "run_checkpoints",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "run_display_projections",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "runtime_llm_trusted_domains",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "semantic_read_observation_budgets",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "semantic_read_observations",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_artifact_references",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_artifacts",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_artifacts_grants",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_checkpoints",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_delegations",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_device_lease_events",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_device_leases",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_history_chunks",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_state_item_events",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_state_items",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_state_revisions",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_todo_counters",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_todo_idempotency",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_todos",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_tool_output_batches",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_tool_outputs",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "session_transcript_items",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "skill_installations",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "skill_metrics",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "skill_resource_bindings",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "skill_selection_events",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "skill_settings",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "skill_user_credentials",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "skills_registry",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "sweeper_leases",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "task_contracts",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "task_leases",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "team_definitions",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "team_execution_history",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "team_snapshots",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "tool_invocation_archive_chunks",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "tool_invocation_ledger",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "transcript_pages",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "user_preferences",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "user_skill_evaluations",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "user_skill_sources",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "user_skill_versions",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "verification_results",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "wf_triggers",
-        owner: "storage",
-    },
-    CoreSchemaTableSpec {
-        name: "workspace_cleanup_debts",
-        owner: "workspace_records",
-    },
-    CoreSchemaTableSpec {
-        name: "workspace_records",
-        owner: "workspace_records",
-    },
-];
+#[derive(Clone, Debug)]
+struct CoreSchemaDeclaration {
+    owner: String,
+    ddl_sha256: String,
+    count: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+struct CoreSchemaAuthority(Arc<StdMutex<BTreeMap<String, CoreSchemaDeclaration>>>);
+
+impl CoreSchemaAuthority {
+    fn observe(&self, owner: &str, sql: &str) {
+        let Some(table_name) = created_table_name(sql) else {
+            return;
+        };
+        let ddl_sha256 = format!("{:x}", sha2::Sha256::digest(sql.trim().as_bytes()));
+        let mut declarations = self.0.lock().unwrap_or_else(|error| error.into_inner());
+        declarations
+            .entry(table_name)
+            .and_modify(|declaration| declaration.count = declaration.count.saturating_add(1))
+            .or_insert_with(|| CoreSchemaDeclaration {
+                owner: owner.to_string(),
+                ddl_sha256,
+                count: 1,
+            });
+    }
+
+    fn declarations(&self) -> Result<Vec<CoreSchemaTableSpec>, sqlx::Error> {
+        let declarations = self.0.lock().unwrap_or_else(|error| error.into_inner());
+        let conflicts = declarations
+            .iter()
+            .filter(|(_, declaration)| declaration.count != 1)
+            .map(|(table, declaration)| format!("{table} (claims={})", declaration.count))
+            .collect::<Vec<_>>();
+        if !conflicts.is_empty() {
+            return Err(sqlx::Error::Protocol(format!(
+                "core schema has multiple lifecycle producers for tables: {}",
+                conflicts.join(", ")
+            )));
+        }
+        Ok(declarations
+            .iter()
+            .map(|(name, declaration)| CoreSchemaTableSpec {
+                name: name.clone(),
+                owner: declaration.owner.clone(),
+                ddl_sha256: declaration.ddl_sha256.clone(),
+            })
+            .collect())
+    }
+}
+
+fn created_table_name(sql: &str) -> Option<String> {
+    let tokens = sql.split_whitespace().collect::<Vec<_>>();
+    if tokens.len() < 3
+        || !tokens[0].eq_ignore_ascii_case("create")
+        || !tokens[1].eq_ignore_ascii_case("table")
+    {
+        return None;
+    }
+    let name_index = if tokens.get(2..5).is_some_and(|tokens| {
+        tokens[0].eq_ignore_ascii_case("if")
+            && tokens[1].eq_ignore_ascii_case("not")
+            && tokens[2].eq_ignore_ascii_case("exists")
+    }) {
+        5
+    } else {
+        2
+    };
+    tokens.get(name_index).map(|name| {
+        name.trim_matches(|character: char| {
+            character == '`' || character == '(' || character == ';'
+        })
+        .to_string()
+    })
+}
+
+#[derive(Clone, Debug)]
+struct CoreSchemaExecutor {
+    pool: sqlx::Pool<MySql>,
+    authority: CoreSchemaAuthority,
+    owner: &'static str,
+}
+
+impl CoreSchemaExecutor {
+    fn new(pool: sqlx::Pool<MySql>) -> Self {
+        Self {
+            pool,
+            authority: CoreSchemaAuthority::default(),
+            owner: "storage",
+        }
+    }
+
+    fn owned_by(&self, owner: &'static str) -> Self {
+        Self {
+            pool: self.pool.clone(),
+            authority: self.authority.clone(),
+            owner,
+        }
+    }
+}
+
+impl Deref for CoreSchemaExecutor {
+    type Target = sqlx::Pool<MySql>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pool
+    }
+}
+
+impl<'c> Executor<'c> for &'c CoreSchemaExecutor {
+    type Database = MySql;
+
+    fn fetch_many<'e, 'q: 'e, E>(
+        self,
+        query: E,
+    ) -> futures_util::stream::BoxStream<
+        'e,
+        Result<sqlx::Either<sqlx::mysql::MySqlQueryResult, sqlx::mysql::MySqlRow>, sqlx::Error>,
+    >
+    where
+        'c: 'e,
+        E: 'q + Execute<'q, Self::Database>,
+    {
+        self.authority.observe(self.owner, query.sql());
+        (&self.pool).fetch_many(query)
+    }
+
+    fn fetch_optional<'e, 'q: 'e, E>(
+        self,
+        query: E,
+    ) -> futures_util::future::BoxFuture<'e, Result<Option<sqlx::mysql::MySqlRow>, sqlx::Error>>
+    where
+        'c: 'e,
+        E: 'q + Execute<'q, Self::Database>,
+    {
+        self.authority.observe(self.owner, query.sql());
+        (&self.pool).fetch_optional(query)
+    }
+
+    fn prepare_with<'e, 'q: 'e>(
+        self,
+        sql: &'q str,
+        parameters: &'e [sqlx::mysql::MySqlTypeInfo],
+    ) -> futures_util::future::BoxFuture<'e, Result<sqlx::mysql::MySqlStatement<'q>, sqlx::Error>>
+    where
+        'c: 'e,
+    {
+        (&self.pool).prepare_with(sql, parameters)
+    }
+
+    fn describe<'e, 'q: 'e>(
+        self,
+        sql: &'q str,
+    ) -> futures_util::future::BoxFuture<'e, Result<sqlx::Describe<MySql>, sqlx::Error>>
+    where
+        'c: 'e,
+    {
+        (&self.pool).describe(sql)
+    }
+}
 
 pub(crate) fn rows_affected_to_i64(rows: u64, context: &str) -> Result<i64, sqlx::Error> {
     i64::try_from(rows).map_err(|_| {
@@ -704,6 +473,7 @@ impl Drop for CoreSchemaDatabaseLease {
 
 async fn core_schema_contract_is_current(pool: &sqlx::Pool<MySql>) -> Result<bool, sqlx::Error> {
     query(CORE_SCHEMA_CONTRACT_TABLE_SQL).execute(pool).await?;
+    query(CORE_SCHEMA_TABLE_CONTRACT_SQL).execute(pool).await?;
     let persisted: Option<String> = sqlx::query_scalar(
         "SELECT contract_version FROM astra_schema_contracts WHERE component = ?",
     )
@@ -713,10 +483,32 @@ async fn core_schema_contract_is_current(pool: &sqlx::Pool<MySql>) -> Result<boo
     match persisted {
         None => Ok(false),
         Some(version) if version == CORE_SCHEMA_CONTRACT_VERSION => Ok(true),
-        Some(version) => Err(sqlx::Error::Protocol(format!(
-            "core schema contract mismatch: database has {version}, binary requires {CORE_SCHEMA_CONTRACT_VERSION}; provision a database with the current canonical schema"
-        ))),
+        Some(_) => Ok(false),
     }
+}
+
+pub async fn load_core_schema_table_contracts(
+    pool: &sqlx::Pool<MySql>,
+) -> Result<Vec<CoreSchemaTableSpec>, sqlx::Error> {
+    query(
+        "SELECT table_name, owner, ddl_sha256
+         FROM astra_schema_table_contracts
+         WHERE component = ? AND contract_version = ?
+         ORDER BY table_name",
+    )
+    .bind(CORE_SCHEMA_CONTRACT_COMPONENT)
+    .bind(CORE_SCHEMA_CONTRACT_VERSION)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(CoreSchemaTableSpec {
+            name: row.try_get("table_name")?,
+            owner: row.try_get("owner")?,
+            ddl_sha256: row.try_get("ddl_sha256")?,
+        })
+    })
+    .collect()
 }
 
 async fn verify_core_schema_catalog(
@@ -731,9 +523,30 @@ async fn verify_core_schema_catalog(
         .into_iter()
         .map(|row| row.try_get::<String, _>("TABLE_NAME"))
         .collect::<Result<BTreeSet<_>, _>>()?;
-    let missing = CORE_SCHEMA_TABLES
+    let contracts = load_core_schema_table_contracts(pool).await?;
+    if contracts.is_empty() {
+        return Err(sqlx::Error::Protocol(
+            "core schema table authority is empty for the current contract".to_string(),
+        ));
+    }
+    let malformed = contracts
         .iter()
-        .filter(|table| !existing.contains(table.name))
+        .filter(|table| {
+            table.name.trim().is_empty()
+                || table.owner.trim().is_empty()
+                || table.ddl_sha256.len() != 64
+        })
+        .map(|table| table.name.clone())
+        .collect::<Vec<_>>();
+    if !malformed.is_empty() {
+        return Err(sqlx::Error::Protocol(format!(
+            "core schema table authority contains malformed claims: {}",
+            malformed.join(", ")
+        )));
+    }
+    let missing = contracts
+        .iter()
+        .filter(|table| !existing.contains(&table.name))
         .map(|table| format!("{} (owner={})", table.name, table.owner))
         .collect::<Vec<_>>();
     if missing.is_empty() {
@@ -746,10 +559,51 @@ async fn verify_core_schema_catalog(
     }
 }
 
+async fn publish_core_schema_table_contracts(
+    pool: &sqlx::Pool<MySql>,
+    declarations: &[CoreSchemaTableSpec],
+) -> Result<(), sqlx::Error> {
+    if declarations.is_empty() {
+        return Err(sqlx::Error::Protocol(
+            "core schema bootstrap produced no table declarations".to_string(),
+        ));
+    }
+    let mut transaction = pool.begin().await?;
+    query("DELETE FROM astra_schema_table_contracts WHERE component = ?")
+        .bind(CORE_SCHEMA_CONTRACT_COMPONENT)
+        .execute(&mut *transaction)
+        .await?;
+    for declaration in declarations {
+        query(
+            "INSERT INTO astra_schema_table_contracts
+             (table_name, component, owner, contract_version, ddl_sha256)
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(&declaration.name)
+        .bind(CORE_SCHEMA_CONTRACT_COMPONENT)
+        .bind(&declaration.owner)
+        .bind(CORE_SCHEMA_CONTRACT_VERSION)
+        .bind(&declaration.ddl_sha256)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|error| {
+            sqlx::Error::Protocol(format!(
+                "schema table {} is already claimed by another lifecycle owner: {error}",
+                declaration.name
+            ))
+        })?;
+    }
+    transaction.commit().await
+}
+
 async fn mark_core_schema_contract_current(
     pool: &sqlx::Pool<MySql>,
     holder_id: &str,
 ) -> Result<(), sqlx::Error> {
+    query("DELETE FROM astra_schema_contracts WHERE component = ?")
+        .bind(CORE_SCHEMA_CONTRACT_COMPONENT)
+        .execute(pool)
+        .await?;
     let result = query(
         "INSERT INTO astra_schema_contracts (component, contract_version) \
          SELECT ?, ? FROM astra_schema_bootstrap_leases \
@@ -1823,6 +1677,18 @@ async fn ensure_core_schema_while_leased(
     // observes the same principal contract during startup.
     migrate_user_identity_column_widths(&pool, &settings.database).await?;
 
+    // The executor observes the exact CREATE TABLE statements that bootstrap
+    // executes. This makes DDL the declaration and the ownership catalog its
+    // generated contract, rather than maintaining a second list of names.
+    let pool = CoreSchemaExecutor::new(pool);
+    for ddl in [
+        CORE_SCHEMA_CONTRACT_TABLE_SQL,
+        CORE_SCHEMA_LEASE_TABLE_SQL,
+        CORE_SCHEMA_TABLE_CONTRACT_SQL,
+    ] {
+        pool.authority.observe("storage", ddl);
+    }
+
     // Auth
     query(
         "CREATE TABLE IF NOT EXISTS auth_users (
@@ -2125,7 +1991,11 @@ async fn ensure_core_schema_while_leased(
         )
         .await?;
     }
-    crate::workspace_records::ensure_workspace_record_tables(&pool).await?;
+    let workspace_schema = pool.owned_by("workspace_records");
+    for ddl in crate::workspace_records::WORKSPACE_RECORD_TABLE_DDLS {
+        query(ddl).execute(&workspace_schema).await?;
+    }
+    crate::workspace_records::verify_workspace_record_tables(&workspace_schema).await?;
 
     // ── Durable web-agent run state (Phase 1 / G15 + G19) ────────────────
     query(
@@ -5995,9 +5865,11 @@ async fn ensure_core_schema_while_leased(
     // that the push / pull pipeline uses.
 
     query(crate::config_version_cloud::CONFIG_VERSIONS_CREATE_SQL)
-        .execute(&pool)
+        .execute(&pool.owned_by("config_version_cloud"))
         .await?;
 
+    let declarations = pool.authority.declarations()?;
+    publish_core_schema_table_contracts(&pool, &declarations).await?;
     verify_core_schema_catalog(&pool, &settings.database).await?;
     mark_core_schema_contract_current(&pool, holder_id).await?;
     Ok(())
@@ -7533,17 +7405,35 @@ mod tests {
     }
 
     #[test]
-    fn core_schema_catalog_has_unique_owned_table_names() {
-        let mut names = BTreeSet::new();
-        for table in CORE_SCHEMA_TABLES {
-            assert!(!table.name.is_empty());
-            assert!(!table.owner.is_empty());
-            assert!(
-                names.insert(table.name),
-                "core schema catalog has duplicate ownership for {}",
-                table.name
-            );
-        }
+    fn core_schema_authority_is_derived_from_executed_ddl() {
+        let authority = CoreSchemaAuthority::default();
+        authority.observe(
+            "storage",
+            "CREATE TABLE IF NOT EXISTS canonical_table (id BIGINT PRIMARY KEY)",
+        );
+        authority.observe(
+            "storage",
+            "ALTER TABLE canonical_table ADD COLUMN value TEXT",
+        );
+
+        let declarations = authority.declarations().unwrap();
+        assert_eq!(declarations.len(), 1);
+        assert_eq!(declarations[0].name, "canonical_table");
+        assert_eq!(declarations[0].owner, "storage");
+        assert_eq!(declarations[0].ddl_sha256.len(), 64);
+    }
+
+    #[test]
+    fn core_schema_authority_rejects_multiple_lifecycle_producers() {
+        let authority = CoreSchemaAuthority::default();
+        authority.observe("storage", "CREATE TABLE duplicate_owner (id BIGINT)");
+        authority.observe(
+            "another_module",
+            "CREATE TABLE IF NOT EXISTS duplicate_owner (id BIGINT)",
+        );
+
+        let error = authority.declarations().unwrap_err().to_string();
+        assert!(error.contains("duplicate_owner (claims=2)"), "{error}");
     }
 
     #[test]

--- a/crates/services/src/workspace_records.rs
+++ b/crates/services/src/workspace_records.rs
@@ -403,23 +403,24 @@ const WORKSPACE_CLEANUP_DEBTS_CREATE_SQL: &str = r#"
             )
             "#;
 
+/// Actual declarations owned by the workspace-record lifecycle. Core schema
+/// bootstrap executes these statements through its authority-tracking
+/// executor; standalone callers use the same slice below.
+pub(crate) const WORKSPACE_RECORD_TABLE_DDLS: &[&str] = &[
+    WORKSPACE_RECORDS_CREATE_SQL,
+    WORKSPACE_CLEANUP_DEBTS_CREATE_SQL,
+];
+
 impl DatabaseWorkspaceRecordStore {
     pub fn new(pool: SharedPool) -> Self {
         Self { pool }
     }
 }
 
-pub(crate) async fn ensure_workspace_record_tables(
+pub(crate) async fn verify_workspace_record_tables(
     pool: &sqlx::Pool<sqlx::MySql>,
 ) -> Result<(), sqlx::Error> {
-    sqlx::query(WORKSPACE_RECORDS_CREATE_SQL)
-        .execute(pool)
-        .await?;
-    verify_workspace_records_source_key_contract(pool).await?;
-    sqlx::query(WORKSPACE_CLEANUP_DEBTS_CREATE_SQL)
-        .execute(pool)
-        .await?;
-    Ok(())
+    verify_workspace_records_source_key_contract(pool).await
 }
 
 async fn verify_workspace_records_source_key_contract(

--- a/crates/services/tests/schema_assertions.rs
+++ b/crates/services/tests/schema_assertions.rs
@@ -1,7 +1,10 @@
 mod common;
 
 use sqlx::Row;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+
+use astra_services::storage::{CORE_SCHEMA_TABLES, ensure_core_schema};
 
 #[test]
 fn service_table_queries_name_columns_explicitly() {
@@ -43,6 +46,47 @@ fn collect_rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
             out.push(path);
         }
     }
+}
+
+#[tokio::test]
+#[ignore = "requires MatrixOne; run with ASTRA_TEST_DB_IT=1"]
+async fn core_schema_catalog_matches_live_idempotent_bootstrap() {
+    let (pool, settings) = common::setup_pool_and_settings().await;
+    let bootstrap_catalog =
+        std::env::var("ASTRA_DATABASE_BOOTSTRAP_CATALOG").unwrap_or_else(|_| "mysql".into());
+    ensure_core_schema(&settings, &bootstrap_catalog)
+        .await
+        .expect("second core schema bootstrap");
+    ensure_core_schema(&settings, &bootstrap_catalog)
+        .await
+        .expect("third core schema bootstrap");
+
+    let schema = current_schema(&pool).await;
+    let existing =
+        sqlx::query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ?")
+            .bind(&schema)
+            .fetch_all(pool.get())
+            .await
+            .expect("load live schema catalog")
+            .into_iter()
+            .map(|row| row.try_get::<String, _>("TABLE_NAME").unwrap())
+            .collect::<BTreeSet<_>>();
+    let missing = CORE_SCHEMA_TABLES
+        .iter()
+        .filter(|table| !existing.contains(table.name))
+        .map(|table| format!("{} ({})", table.name, table.owner))
+        .collect::<Vec<_>>();
+    assert!(missing.is_empty(), "missing catalog tables: {missing:?}");
+
+    let contracts = sqlx::query(
+        "SELECT COUNT(*) AS count FROM astra_schema_contracts WHERE component = 'astra-core'",
+    )
+    .fetch_one(pool.get())
+    .await
+    .expect("count core schema contract rows")
+    .try_get::<i64, _>("count")
+    .unwrap();
+    assert_eq!(contracts, 1, "repeated bootstrap must remain idempotent");
 }
 
 #[tokio::test]

--- a/crates/services/tests/schema_assertions.rs
+++ b/crates/services/tests/schema_assertions.rs
@@ -4,7 +4,7 @@ use sqlx::Row;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use astra_services::storage::{CORE_SCHEMA_TABLES, ensure_core_schema};
+use astra_services::storage::{ensure_core_schema, load_core_schema_table_contracts};
 
 #[test]
 fn service_table_queries_name_columns_explicitly() {
@@ -71,12 +71,21 @@ async fn core_schema_catalog_matches_live_idempotent_bootstrap() {
             .into_iter()
             .map(|row| row.try_get::<String, _>("TABLE_NAME").unwrap())
             .collect::<BTreeSet<_>>();
-    let missing = CORE_SCHEMA_TABLES
+    let contracts = load_core_schema_table_contracts(pool.get())
+        .await
+        .expect("load generated core schema table authority");
+    assert!(
+        contracts.len() >= 90,
+        "bootstrap must publish the complete generated authority, got {} claims",
+        contracts.len()
+    );
+    let missing = contracts
         .iter()
-        .filter(|table| !existing.contains(table.name))
+        .filter(|table| !existing.contains(&table.name))
         .map(|table| format!("{} ({})", table.name, table.owner))
         .collect::<Vec<_>>();
     assert!(missing.is_empty(), "missing catalog tables: {missing:?}");
+    assert!(contracts.iter().all(|table| table.ddl_sha256.len() == 64));
 
     let contracts = sqlx::query(
         "SELECT COUNT(*) AS count FROM astra_schema_contracts WHERE component = 'astra-core'",

--- a/deployment/all-in-one/docker-compose.memoria.yml
+++ b/deployment/all-in-one/docker-compose.memoria.yml
@@ -129,7 +129,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -fsS http://localhost:17001/health | grep -q '\"status\":\"healthy\"'",
+          "curl -fsS http://localhost:17001/ready",
         ]
       interval: 30s
       timeout: 3s

--- a/deployment/all-in-one/docker-compose.prod.yml
+++ b/deployment/all-in-one/docker-compose.prod.yml
@@ -104,7 +104,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -fsS http://localhost:17001/health | grep -q '\"status\":\"healthy\"'",
+          "curl -fsS http://localhost:17001/ready",
         ]
       interval: 30s
       timeout: 10s

--- a/deployment/all-in-one/docker-compose.yml
+++ b/deployment/all-in-one/docker-compose.yml
@@ -156,7 +156,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -fsS http://localhost:17001/health | grep -q '\"status\":\"healthy\"'",
+          "curl -fsS http://localhost:17001/ready",
         ]
       interval: 30s
       timeout: 5s


### PR DESCRIPTION
## What type of PR is this?

- [x] fix (bug fix)
- [x] refactor (architectural consolidation)
- [x] perf (bounded streaming and cached dependency probes)
- [x] test (offline and real-MatrixOne coverage)

## Which issue(s) this PR fixes

N/A — follows up the recent CLI, Server Only, Web, and Edge+Server session-journey regressions.

## What this PR does / why we need it

Astra had multiple partial views of background work: CLI could reconstruct fanout state, Server/Web could not, fanout attention used a notification bypass, stale observations could move lifecycle state backward, and live streams could accumulate unbounded memory. Health reporting also treated an optional Memoria outage as deployment failure, while schema ownership was guarded by source-text scanning rather than runtime truth.

This PR makes those contracts canonical across deployment modes:

- One session-scoped ActiveWorkRegistry feeds the actual CLI and Server/Web model boundaries.
- Producer-owned numeric revisions reject stale nonterminal observations and preserve terminal tombstones.
- Fanout groups canonically aggregate WaitingForInput and use OnAttentionOrTerminal.
- Background shell, direct agent, and fanout producers publish through the same typed work contract.
- Liveness, database readiness, and optional capability health are separated; Memoria probes are cached, singleflight, and background-refreshed.
- Internal live-event delivery is bounded, reports coalesced gaps, repairs from durable state, and drains with a deadline.
- Core schema ownership is declared in a structured catalog and verified against repeated live MatrixOne bootstrap.
- Legacy version and killed test fixtures and recursive source-scanning schema tests are removed.

## Architecture and complexity delta

- Canonical owner changed or extended: ActiveWorkRegistry owns session model-visible work; FanoutGroup owns aggregate attention state; AppState owns cached capability health; CORE_SCHEMA_TABLES owns core table declarations.
- Existing implementations/callers searched: CLI turn runner and TUI snapshots, Server run lifecycle and loop host, shell and agent producers, SSE bridges, health/platform routes, compose healthchecks, schema bootstrap, and online integration tests.
- Superseded code, states, tables, shims, and self-only tests removed: per-turn-only active-work truth, CLI-only fanout reinjection, per-child attention bypass, request-time Memoria probes, unbounded internal Value channels, legacy wire fixtures, and recursive DDL source scanning.
- Net code/state/table delta: one shared active-work registry, one monotonic revision contract, one cached dependency-health state, and one structured catalog; no new database tables.
- Parallel boundary retained intentionally: live SSE is the low-latency lane; durable events are the repair authority after an explicit gap.

## Production wiring and verification

- Public product entrypoint exercised: CLI model boundary, Server/Web model boundary, background shell, direct agent and fanout tools, health/readiness routes, compose readiness, platform snapshot, and root/child live streams.
- Unhappy paths exercised: cross-turn work, stale nonterminal delivery, terminal tombstones, waiting fanout, observer restart, queue saturation, gap repair, bounded drain, Memoria degradation and timeout, concurrent probes, cross-pod control, partial fanout, and repeated bootstrap.
- Database verification: real MatrixOne tests cover schema catalog parity, repeated bootstrap, cursor pagination, recovery leases, cross-pod lifecycle, task concurrency, transcript ownership, and durable replay.
- The local two-way online run exposed shared MatrixOne DDL contention. The migration test passed alone in 4.2 seconds and again inside the complete CI-equivalent serial gate in 4.19 seconds; no timeout exemption or relaxed budget was added.

## Verification

- make test-offline: PASS
  - Rust workspace strict: 19,362 passed
  - bridge-e2e-hooks: 5,146 passed
  - SDK: 213 passed, 1 skipped
  - Web: 365 passed
  - production builds: PASS
- CI-equivalent ASTRA_TEST_DB_IT_TEST_THREADS=1 make test-online: PASS
  - runtime live DB: 52/52
  - turn-core live DB: 12/12
  - services live DB: 184/184
  - integration and performance: 319/319
- Focused lifecycle contract regression: 10/10 PASS
- make check: PASS
- Repository audit:
  - working tree clean and branch fully pushed
  - no files under plans/ included
  - .env and .models.yaml ignored and untracked
  - no strong provider-key/private-key patterns or credential-like added literals found across branch commit history
