### PR TITLE
fix(runtime): unify recall lifecycle ownership

### DIFF
--- a/.agent/skills/analyze_session/SKILL.md
+++ b/.agent/skills/analyze_session/SKILL.md
@@ -61,7 +61,7 @@ the message/tool/prompt snapshot it contains.
 
 ## Phase 2: Trust The Digest Schema
 
-Stable schema: `schema_version = "astra-journal-digest-v1"` from
+Stable schema: `schema_version = "astra-journal-digest-v2"` from
 `crates/astra-cli/src/cli/journal_digest.rs`.
 
 Use these fields directly. Do not invent numbers.
@@ -70,6 +70,7 @@ Use these fields directly. Do not invent numbers.
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `aggregates`                      | Turn count, tokens, duration, tool counts, failures, stalls, compactions                                     |
 | `turns[]`                         | Per-turn tokens, latency, TTFT, context time, visible/used/activated tools, selected skills, budget pressure |
+| `subruns[]`                       | Child-run identities and their own LLM/tool rounds; never merge these into root turns by numeric turn id     |
 | `failed_tool_calls[]`             | Failed call category, tool name, args preview, error preview                                                 |
 | `compaction_events[]`             | When context was compacted and what signal triggered it                                                      |
 | `stalls[]`                        | Stall/circuit-breaker evidence                                                                               |

--- a/.agent/skills/review_changes/SKILL.md
+++ b/.agent/skills/review_changes/SKILL.md
@@ -16,7 +16,7 @@ allowed_tools:
   - grep
   - glob
   - git
-  - agent
+  - agent_fanout
 ---
 
 # Review Changes
@@ -61,11 +61,25 @@ Target resolution:
 
 If the diff is empty after checking staged and unstaged changes, report "No changes found."
 
-Hard rule for `commits:<N>`: fetch all N full diffs before presenting a full review. If only K of N are available, label the review partial before findings.
+Hard rule for `commits:<N>`: cover all N commits before presenting a full review,
+but inspect them in bounded commit/file sections instead of requesting one
+monolithic diff. If only K of N are available, label the review partial before
+findings.
 
-If the user requests parallel reviews or multiple reviewers, use `git worktree` to create
-isolated checkouts — never degrade to serial execution when the user explicitly asked for
-parallelism.
+If the user requests parallel reviews or multiple reviewers, start one fixed-size
+parallel reviewer group immediately after the status/stat/name map. On Astra, use
+the skill-exposed `agent_fanout` directly; do not spend a discovery round searching
+for it and do not replace the group with multiple independent `agent` calls. On
+another host, use its canonical parallel delegation capability or disclose that the
+capability is unavailable. The parent coordinates coverage and validates results;
+it must not perform a duplicate broad review while the reviewers are running.
+Read-only reviewers may share immutable source. Use separate worktrees only when a
+reviewer may mutate files or reviewers need different refs.
+
+Keep review evidence bounded at the source. Prefer per-file hunks and exact line
+ranges over full repository/commit dumps. If a tool returns an artifact reference,
+do not pass `artifact://` to shell/file tools; rerun the evidence query with a
+narrower scope or use the artifact owner supplied by the host.
 
 ## Step 2: Build Review Map
 
@@ -107,6 +121,12 @@ Before reporting a finding:
 - Identify the concrete failure mode and user/system consequence.
 - Check whether an existing test would catch it.
 - Include file and line, using the new file line when possible.
+
+Reviewer output is candidate evidence, not verified truth. Agreement between
+reviewers does not raise confidence by itself. The parent must confirm each finding
+against current source, a reachable failure sequence, and the actual ownership
+boundary before calling it verified. Stop exploring once every changed ownership
+boundary has evidence and every reported finding passes this gate.
 
 Do not report:
 

--- a/.claude/skills/analyze_session/SKILL.md
+++ b/.claude/skills/analyze_session/SKILL.md
@@ -61,7 +61,7 @@ the message/tool/prompt snapshot it contains.
 
 ## Phase 2: Trust The Digest Schema
 
-Stable schema: `schema_version = "astra-journal-digest-v1"` from
+Stable schema: `schema_version = "astra-journal-digest-v2"` from
 `crates/astra-cli/src/cli/journal_digest.rs`.
 
 Use these fields directly. Do not invent numbers.
@@ -70,6 +70,7 @@ Use these fields directly. Do not invent numbers.
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `aggregates`                      | Turn count, tokens, duration, tool counts, failures, stalls, compactions                                     |
 | `turns[]`                         | Per-turn tokens, latency, TTFT, context time, visible/used/activated tools, selected skills, budget pressure |
+| `subruns[]`                       | Child-run identities and their own LLM/tool rounds; never merge these into root turns by numeric turn id     |
 | `failed_tool_calls[]`             | Failed call category, tool name, args preview, error preview                                                 |
 | `compaction_events[]`             | When context was compacted and what signal triggered it                                                      |
 | `stalls[]`                        | Stall/circuit-breaker evidence                                                                               |

--- a/.claude/skills/review_changes/SKILL.md
+++ b/.claude/skills/review_changes/SKILL.md
@@ -60,11 +60,25 @@ Target resolution:
 
 If the diff is empty after checking staged and unstaged changes, report "No changes found."
 
-Hard rule for `commits:<N>`: fetch all N full diffs before presenting a full review. If only K of N are available, label the review partial before findings.
+Hard rule for `commits:<N>`: cover all N commits before presenting a full review,
+but inspect them in bounded commit/file sections instead of requesting one
+monolithic diff. If only K of N are available, label the review partial before
+findings.
 
-If the user requests parallel reviews or multiple reviewers, use `git worktree` to create
-isolated checkouts — never degrade to serial execution when the user explicitly asked for
-parallelism.
+If the user requests parallel reviews or multiple reviewers, start one fixed-size
+parallel reviewer group immediately after the status/stat/name map. On Astra, use
+the skill-exposed `agent_fanout` directly; do not spend a discovery round searching
+for it and do not replace the group with multiple independent `agent` calls. On
+another host, use its canonical parallel delegation capability or disclose that the
+capability is unavailable. The parent coordinates coverage and validates results;
+it must not perform a duplicate broad review while the reviewers are running.
+Read-only reviewers may share immutable source. Use separate worktrees only when a
+reviewer may mutate files or reviewers need different refs.
+
+Keep review evidence bounded at the source. Prefer per-file hunks and exact line
+ranges over full repository/commit dumps. If a tool returns an artifact reference,
+do not pass `artifact://` to shell/file tools; rerun the evidence query with a
+narrower scope or use the artifact owner supplied by the host.
 
 ## Step 2: Build Review Map
 
@@ -106,6 +120,12 @@ Before reporting a finding:
 - Identify the concrete failure mode and user/system consequence.
 - Check whether an existing test would catch it.
 - Include file and line, using the new file line when possible.
+
+Reviewer output is candidate evidence, not verified truth. Agreement between
+reviewers does not raise confidence by itself. The parent must confirm each finding
+against current source, a reachable failure sequence, and the actual ownership
+boundary before calling it verified. Stop exploring once every changed ownership
+boundary has evidence and every reported finding passes this gate.
 
 Do not report:
 

--- a/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
+++ b/crates/astra-cli/src/cli/chat_stream/sse_loop/cli_loop_host.rs
@@ -546,6 +546,10 @@ fn append_permission_mode_change_audit(
 
 #[async_trait]
 impl AgenticLoopHost for CliAgenticLoopHost<'_> {
+    fn memory_recall_scope(&self, _state: &AgenticLoopState) -> Option<(String, String)> {
+        self.executor.memory_recall_scope()
+    }
+
     fn agent_live_event_sink(
         &self,
     ) -> Option<astra_turn_core::agent_live_event::SharedAgentLiveEventSink> {

--- a/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -316,8 +316,9 @@ pub(crate) async fn stream_chat_sse(
     // not advance its resumable timeline.
     let persist_session_artifacts = p.file_journal.is_some() || p.session_state_journal.is_some();
     let mut executor = {
-        let ex =
-            edge_tools::ToolExecutor::new(&project_root).with_cloud(p.api.api_origin(), p.token);
+        let ex = edge_tools::ToolExecutor::new(&project_root)
+            .with_cloud(p.api.api_origin(), p.token)
+            .with_memory_attribution_id(parent_turn_run_id.clone());
         let ex = if let Some(session_id) = p.session_id {
             ex.with_active_session_id(session_id.to_string())
         } else {

--- a/crates/astra-cli/src/cli/delegate_subrun.rs
+++ b/crates/astra-cli/src/cli/delegate_subrun.rs
@@ -307,7 +307,8 @@ impl SubRunExecutor for CliDelegateSubRunExecutor {
         );
 
         let executor = edge_tools::ToolExecutor::new(&effective_root)
-            .with_cloud(self.api.api_origin(), &self.token);
+            .with_cloud(self.api.api_origin(), &self.token)
+            .with_memory_attribution_id(config.run_id.clone());
         executor.set_cli_local_provider_schemas(all_schemas.clone());
         if !config.session_id.trim().is_empty() {
             executor.set_active_session_id(config.session_id.clone());

--- a/crates/astra-cli/src/cli/session/session_side_effects.rs
+++ b/crates/astra-cli/src/cli/session/session_side_effects.rs
@@ -109,27 +109,6 @@ pub(crate) fn enqueue_ingestion_for_immediate_drain_pub(
     enqueue_ingestion_batch_without_runtime(std::slice::from_ref(event));
 }
 
-pub(crate) fn drop_unattributed_memory_recalls_at_turn_end(
-    session_id: Option<&str>,
-    producer_id: &str,
-) -> usize {
-    let Some(session_id) = session_id.filter(|sid| !sid.trim().is_empty()) else {
-        return 0;
-    };
-    if producer_id.trim().is_empty() {
-        return 0;
-    }
-    // A completed turn is not proof that a surfaced memory helped. Successful
-    // tool-result hooks already close causally adjacent recalls; anything left
-    // here is unattributed and must be dropped without reinforcing its rank.
-    astra_tools::memoria::MemoriaToolGateway::drain_recalls_for_producer(
-        session_id,
-        producer_id,
-        None,
-    )
-    .len()
-}
-
 #[derive(Clone)]
 struct JournalPromptTurn {
     model_id: String,
@@ -491,42 +470,12 @@ fn journal_prompt_snapshot_from_messages(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        append_one_shot_journal_events, build_bridge_pipeline_journal_events,
-        drop_unattributed_memory_recalls_at_turn_end,
-    };
+    use super::{append_one_shot_journal_events, build_bridge_pipeline_journal_events};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::time::Instant;
 
     use astra_services::session_journal;
-
-    #[test]
-    fn turn_end_drops_unattributed_recalls_without_sending_positive_feedback() {
-        let session_id = "chat-turn-close-feedback";
-        astra_tools::memoria::MemoriaToolGateway::reset_session_process_state(session_id);
-        astra_tools::memoria::MemoriaToolGateway::record_recall_for_producer(
-            session_id,
-            "cli-turn:4",
-            4,
-            vec!["m1".into()],
-        );
-        astra_tools::memoria::MemoriaToolGateway::record_recall_for_producer(
-            session_id,
-            "concurrent-run",
-            4,
-            vec!["m2".into()],
-        );
-
-        let dropped = drop_unattributed_memory_recalls_at_turn_end(Some(session_id), "cli-turn:4");
-
-        assert_eq!(dropped, 1);
-        assert_eq!(
-            astra_tools::memoria::MemoriaToolGateway::pending_recall_count(session_id),
-            1
-        );
-        astra_tools::memoria::MemoriaToolGateway::reset_session_process_state(session_id);
-    }
 
     #[test]
     fn build_bridge_pipeline_journal_events_surfaces_unreadable_journal() {

--- a/crates/astra-cli/src/cli/skill_subrun.rs
+++ b/crates/astra-cli/src/cli/skill_subrun.rs
@@ -350,6 +350,10 @@ fn attach_runtime_volatile_injections(
 
 #[async_trait]
 impl AgenticLoopHost for SubRunHost {
+    fn memory_recall_scope(&self, _state: &AgenticLoopState) -> Option<(String, String)> {
+        self.executor.memory_recall_scope()
+    }
+
     async fn execute_turn(
         &mut self,
         state: &mut AgenticLoopState,
@@ -743,6 +747,15 @@ impl SkillSubRunExecutor for CliSkillSubRunExecutor {
 
         let all_schemas = edge_tools::local_tool_schemas();
         let valid_tool_names = tool_names_from_schemas(&all_schemas);
+        let safe_name = astra_skills::loader::sanitize_for_path(skill_name);
+        let subrun_session_id = format!(
+            "subrun-{}-{}",
+            safe_name,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_micros()
+        );
 
         // Issue #326 P5b: skill subruns are headless — never read
         // project allow rules. Deny rules and the user-level rule
@@ -754,7 +767,8 @@ impl SkillSubRunExecutor for CliSkillSubRunExecutor {
         let permission_context = perm_manager.runtime_permission_handle();
 
         let executor = edge_tools::ToolExecutor::new(&self.project_root)
-            .with_cloud(self.api.api_origin(), &self.token);
+            .with_cloud(self.api.api_origin(), &self.token)
+            .with_memory_attribution_id(subrun_session_id.clone());
         executor.set_cli_local_provider_schemas(all_schemas.clone());
         if let Some(session_id) = self.active_session_id.as_deref() {
             executor.set_active_session_id(session_id.to_string());
@@ -823,15 +837,6 @@ impl SkillSubRunExecutor for CliSkillSubRunExecutor {
         };
 
         let task_profile = infer_task_execution_profile(task_context);
-        let safe_name = astra_skills::loader::sanitize_for_path(skill_name);
-        let subrun_session_id = format!(
-            "subrun-{}-{}",
-            safe_name,
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_micros()
-        );
         let user_id = cli_user_id();
         let step_recorder = StepRecorder::with_persistence(
             &user_id,

--- a/crates/astra-cli/src/cli/spawn_subrun.rs
+++ b/crates/astra-cli/src/cli/spawn_subrun.rs
@@ -673,7 +673,8 @@ impl SpawnAgentExecutor for CliSpawnAgentExecutor {
         let effective_model = self.resolve_effective_model(config.model.as_deref());
 
         let mut executor = edge_tools::ToolExecutor::new(&effective_root)
-            .with_cloud(self.api.api_origin(), &token);
+            .with_cloud(self.api.api_origin(), &token)
+            .with_memory_attribution_id(config.run_id.clone());
         executor.set_cli_local_provider_schemas(all_schemas.clone());
         if let Some(ref cmds) = self.bg_task_commands {
             executor = executor.with_bg_task_commands(cmds.clone());

--- a/crates/astra-cli/src/cli/turn/turn_post_commit.rs
+++ b/crates/astra-cli/src/cli/turn/turn_post_commit.rs
@@ -8,7 +8,6 @@ use crate::cli::session::session_projection::{
     CslCheckpointFields, build_full_session_state_compact,
 };
 use crate::cli::session::session_runtime;
-use crate::cli::session::session_side_effects::drop_unattributed_memory_recalls_at_turn_end;
 use crate::cli::session::session_state::SessionState;
 use crate::cli::stream::streaming_types::StreamResult;
 
@@ -58,18 +57,6 @@ pub(crate) fn prepare_turn_post_commit_job(
     csl_checkpoint_fields: CslCheckpointFields,
     turn_start: Instant,
 ) -> TurnPostCommitJob {
-    let producer_id = format!("cli-turn:{}", state.turn);
-    let dropped =
-        drop_unattributed_memory_recalls_at_turn_end(state.session_id.as_deref(), &producer_id);
-    if dropped > 0 {
-        tracing::debug!(
-            session_id = ?state.session_id,
-            producer_id,
-            dropped,
-            "dropped unattributed memory recalls without changing their rank"
-        );
-    }
-
     let csl_state = state
         .csl_manager
         .as_ref()
@@ -540,39 +527,5 @@ mod tests {
             Instant::now(),
         );
         assert!(state.csl_manager.is_some());
-    }
-
-    #[tokio::test]
-    #[serial_test::serial]
-    async fn turn_commit_drops_unattributed_recall_without_positive_feedback() {
-        let (_tmp, _g) = crate::tests::isolated_sessions_dir();
-        let mut state = SessionState::default();
-        let session_id = "sess-memory-drain";
-        state.session_id = Some(session_id.to_string());
-        state.turn = 1;
-        astra_tools::memoria::MemoriaToolGateway::reset_session_process_state(session_id);
-        astra_tools::memoria::MemoriaToolGateway::record_recall_for_producer(
-            session_id,
-            "cli-turn:1",
-            1,
-            vec!["m1".into()],
-        );
-        let api = test_api();
-        let _job = prepare_turn_post_commit_job(
-            &mut state,
-            &api,
-            None,
-            Vec::new(),
-            extract_csl_fields_from_result(&crate::tests::stub_stream_result(
-                "The turn completed without attributable memory usage.",
-            )),
-            Instant::now(),
-        );
-
-        assert_eq!(
-            astra_tools::memoria::MemoriaToolGateway::pending_recall_count(session_id),
-            0,
-            "turn completion must synchronously drop unattributed recall state"
-        );
     }
 }

--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -1321,6 +1321,10 @@ pub struct ToolExecutor {
     /// Whether the user has been notified about Memoria being down.
     /// Prevents spamming the same warning every turn.
     memoria_notified_down: std::sync::atomic::AtomicBool,
+    /// Canonical executor identity used to attribute memory recalls and their
+    /// eventual feedback. Isolated sub-runs use their host-owned identity even
+    /// when they intentionally have no durable `AgenticLoopState` run id.
+    memory_attribution_id: Option<String>,
     /// File state tracker: records mtime after each read/write/edit.
     /// Used for staleness detection (prevent overwriting user edits)
     /// and dedup (skip re-reading unchanged files).
@@ -1539,6 +1543,7 @@ impl ToolExecutor {
             build_test_tracker: std::sync::Mutex::new(build_test::BuildTestTracker::new()),
             memoria_circuit: astra_tools::memoria::MemoryCircuitBreaker::default(),
             memoria_notified_down: std::sync::atomic::AtomicBool::new(false),
+            memory_attribution_id: None,
             file_state: std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
             aggregate_output_bytes: std::sync::atomic::AtomicUsize::new(0),
             bash_progress_sink: std::sync::RwLock::new(None),
@@ -1754,6 +1759,30 @@ impl ToolExecutor {
             self.install_default_test_visible_surface();
         }
         self
+    }
+
+    /// Bind memory lifecycle events to one host-owned producer identity. Tool
+    /// execution and the loop run boundary then close the same queue.
+    pub fn with_memory_attribution_id(mut self, producer_id: impl Into<String>) -> Self {
+        let producer_id = producer_id.into();
+        self.memory_attribution_id = (!producer_id.trim().is_empty()).then_some(producer_id);
+        self
+    }
+
+    /// Return the exact recall ledger scope used by this executor.
+    pub(crate) fn memory_recall_scope(&self) -> Option<(String, String)> {
+        let session_id = self.active_session_id()?.trim().to_string();
+        if session_id.is_empty() {
+            return None;
+        }
+        let producer_id = self
+            .memory_attribution_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|producer_id| !producer_id.is_empty())
+            .unwrap_or("session")
+            .to_string();
+        Some((session_id, producer_id))
     }
 
     /// Install schemas declared by CLI-side providers so
@@ -2480,28 +2509,17 @@ impl ToolExecutor {
     }
 
     fn memory_args_with_context(&self, args: &Value) -> Value {
-        let mut clean_args = args.clone();
-        if let Some(obj) = clean_args.as_object_mut() {
-            obj.remove("action");
-            // Inject the active session id so memory targets and session-scoped
-            // recalls work. CLI does not own a user_id — leave it to the
-            // cloud proxy / Memoria server to fill in via the bearer token.
-            if let Some(sid) = self.active_session_id().filter(|sid| !sid.is_empty()) {
-                obj.insert("session_id".to_string(), serde_json::Value::String(sid));
-            }
-            let turn = self
-                .journal_turn_index
-                .load(std::sync::atomic::Ordering::Acquire);
-            obj.insert(
-                "turn".to_string(),
-                serde_json::Value::Number(serde_json::Number::from(turn)),
-            );
-            obj.insert(
-                "_attribution_id".to_string(),
-                serde_json::Value::String(format!("cli-turn:{turn}")),
-            );
-        }
-        clean_args
+        let session_id = self.active_session_id();
+        let turn = self
+            .journal_turn_index
+            .load(std::sync::atomic::Ordering::Acquire);
+        astra_tools::memoria::MemoriaToolGateway::args_with_runtime_context(
+            args,
+            session_id.as_deref(),
+            None,
+            turn,
+            self.memory_attribution_id.as_deref().unwrap_or("session"),
+        )
     }
 
     /// P3.1 seam: stash cross-session lessons loaded at session bootstrap.
@@ -5599,30 +5617,37 @@ impl ToolExecutor {
             && !cli_tool_output_is_error(&output)
             && let Some(session_id) = self.active_session_id().filter(|sid| !sid.is_empty())
         {
-            let turn = self
-                .journal_turn_index
-                .load(std::sync::atomic::Ordering::Acquire);
-            let producer_id = format!("cli-turn:{turn}");
-            let client = astra_tools::memoria::MemoriaToolGateway::new(
-                self.cloud_base.clone(),
-                self.cloud_token(),
+            let producer_id = self
+                .memory_attribution_id
+                .clone()
+                .unwrap_or_else(|| "session".to_string());
+            let snapshots = astra_tools::memoria::MemoriaToolGateway::drain_recalls_for_producer(
+                &session_id,
+                &producer_id,
+                None,
             );
-            let ctx = format!("cli-tool:{name}");
-            tokio::spawn(async move {
-                let report = client
-                    .feedback_pending_recalls(&session_id, &producer_id, "useful", &ctx)
-                    .await;
-                if report.attempted > 0 {
-                    tracing::debug!(
-                        session_id = %session_id,
-                        context = %ctx,
-                        attempted = report.attempted,
-                        succeeded = report.succeeded,
-                        failed = report.failed,
-                        "closed recall feedback after successful cli tool"
-                    );
-                }
-            });
+            if !snapshots.is_empty() {
+                let client = astra_tools::memoria::MemoriaToolGateway::new(
+                    self.cloud_base.clone(),
+                    self.cloud_token(),
+                );
+                let ctx = format!("cli-tool:{name}");
+                tokio::spawn(async move {
+                    let report = client
+                        .feedback_recall_snapshots(snapshots, "useful", &ctx)
+                        .await;
+                    if report.attempted > 0 {
+                        tracing::debug!(
+                            session_id = %session_id,
+                            context = %ctx,
+                            attempted = report.attempted,
+                            succeeded = report.succeeded,
+                            failed = report.failed,
+                            "closed recall feedback after successful cli tool"
+                        );
+                    }
+                });
+            }
         }
         self.record_output_size(output.len());
         output
@@ -9478,7 +9503,9 @@ mod tests {
 
     #[test]
     fn memory_args_include_session_and_current_turn() {
-        let executor = test_executor().with_active_session_id("mem-session");
+        let executor = test_executor()
+            .with_active_session_id("mem-session")
+            .with_memory_attribution_id("run-memory-9");
         executor
             .journal_turn_index
             .store(9, std::sync::atomic::Ordering::Release);
@@ -9486,12 +9513,19 @@ mod tests {
         let args = executor.memory_args_with_context(&serde_json::json!({
             "action": "recall",
             "query": "memory loop",
+            "session_id": "prompt-session",
+            "turn": 100,
+            "_attribution_id": "prompt-producer",
         }));
 
         assert!(args.get("action").is_none());
         assert_eq!(args["session_id"].as_str(), Some("mem-session"));
         assert_eq!(args["turn"].as_u64(), Some(9));
-        assert_eq!(args["_attribution_id"].as_str(), Some("cli-turn:9"));
+        assert_eq!(args["_attribution_id"].as_str(), Some("run-memory-9"));
+        assert_eq!(
+            executor.memory_recall_scope(),
+            Some(("mem-session".to_string(), "run-memory-9".to_string()))
+        );
     }
 
     #[tokio::test]

--- a/crates/astra-skills/src/providers/local.rs
+++ b/crates/astra-skills/src/providers/local.rs
@@ -288,7 +288,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn review_changes_skill_keeps_agent_available_for_parallel_reviews() {
+    async fn review_changes_skill_exposes_fixed_fanout_for_parallel_reviews() {
         let repo_skills = astra_core::test_paths::workspace_path(".agent/skills")
             .canonicalize()
             .expect("repo skills dir should resolve in workspace tests");
@@ -299,8 +299,16 @@ mod tests {
                 .manifest
                 .allowed_tools
                 .iter()
+                .any(|tool| tool == "agent_fanout"),
+            "review-changes must expose fixed fanout without a discovery round"
+        );
+        assert!(
+            !loaded
+                .manifest
+                .allowed_tools
+                .iter()
                 .any(|tool| tool == "agent"),
-            "review-changes must keep the agent tool visible so user-requested parallel reviews do not degrade to serial execution"
+            "review-changes must not expose a competing per-agent lifecycle"
         );
     }
 }

--- a/crates/astra-skills/tests/skill_diagnosis_contract.rs
+++ b/crates/astra-skills/tests/skill_diagnosis_contract.rs
@@ -284,53 +284,6 @@ fn skill_md_example_blocks_are_parseable() {
 }
 
 #[test]
-fn review_changes_skill_requires_parallel_fallback_and_self_critique_gate() {
-    let path = astra_core::test_paths::workspace_path(".agent/skills")
-        .join("review_changes")
-        .join("SKILL.md");
-    let text =
-        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-
-    assert!(
-        text.contains("worktree") && text.contains("degrade"),
-        "review_changes must explicitly disclose worktree/parallel fallback"
-    );
-    assert!(
-        text.contains("Self-critique gate") && text.contains("git diff --check"),
-        "review_changes must run a self-critique lint gate before the final report"
-    );
-    assert!(
-        text.contains("ownership delta")
-            && text.contains("real CLI/server/web/edge entrypoint")
-            && text.contains("Were replaced implementations"),
-        "review_changes must reject parallel or unwired subsystem growth"
-    );
-}
-
-#[test]
-fn astra_dev_skill_requires_one_owner_and_retirement_evidence() {
-    let path = astra_core::test_paths::workspace_path(".agent/skills")
-        .join("astra-dev")
-        .join("SKILL.md");
-    let text =
-        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-
-    for required in [
-        "One Owner, One Wired Path",
-        "real product entrypoint",
-        "authority, deployment, security, or resource-lifecycle boundary",
-        "delete the old implementation",
-        "complexity delta",
-        "real configured database",
-    ] {
-        assert!(
-            text.contains(required),
-            "astra-dev is missing systemic cleanup constraint: {required}"
-        );
-    }
-}
-
-#[test]
 fn project_claude_and_agent_skill_bodies_stay_in_sync() {
     let agent_root = astra_core::test_paths::workspace_path(".agent/skills");
     let claude_root = astra_core::test_paths::workspace_path(".claude/skills");
@@ -367,7 +320,7 @@ fn project_claude_and_agent_skill_bodies_stay_in_sync() {
                     .filter(|tool| !claude_tools.contains(tool))
                     .map(String::as_str)
                     .collect::<Vec<_>>(),
-                ["agent"],
+                ["agent_fanout"],
                 "review_changes may expose only the Agent-host parallelism capability as a root-specific delta"
             );
         } else {

--- a/crates/astra-tools/src/memoria.rs
+++ b/crates/astra-tools/src/memoria.rs
@@ -725,6 +725,42 @@ impl MemoriaToolGateway {
         }
     }
 
+    /// Project caller arguments into the runtime-owned Memoria execution
+    /// context. Identity fields are authoritative runtime data: prompt/tool
+    /// arguments may not preserve, omit, or spoof them.
+    pub fn args_with_runtime_context(
+        args: &Value,
+        session_id: Option<&str>,
+        user_id: Option<&str>,
+        turn: u32,
+        producer_id: &str,
+    ) -> Value {
+        let mut projected = args.clone();
+        let Some(object) = projected.as_object_mut() else {
+            return projected;
+        };
+
+        for key in ["action", "session_id", "user_id", "turn", "_attribution_id"] {
+            object.remove(key);
+        }
+        if let Some(session_id) = session_id.map(str::trim).filter(|id| !id.is_empty()) {
+            object.insert("session_id".into(), Value::String(session_id.into()));
+        }
+        if let Some(user_id) = user_id.map(str::trim).filter(|id| !id.is_empty()) {
+            object.insert("user_id".into(), Value::String(user_id.into()));
+        }
+        object.insert("turn".into(), Value::Number(turn.into()));
+        let producer_id = match producer_id.trim() {
+            "" => "session",
+            producer_id => producer_id,
+        };
+        object.insert(
+            "_attribution_id".into(),
+            Value::String(producer_id.to_string()),
+        );
+        projected
+    }
+
     /// Record a `focus` hint for the given session. Returns the synthetic
     /// response the LLM sees (mirrors the v2 FocusResponse shape).
     pub fn focus_set(&self, session_id: &str, args: &Value) -> String {
@@ -967,24 +1003,18 @@ impl MemoriaToolGateway {
         astra_memoria::memoria_runtime_state().reset_session(session_id);
     }
 
-    /// Drain pending recalls and push one feedback signal for every
-    /// surfaced memory id. Intended for tool-result lifecycle hooks:
-    /// when a non-memory tool succeeds after a recall, the recall gets
-    /// prompt feedback immediately instead of waiting for session-end.
-    ///
-    /// Best-effort: the recall ledger is consumed exactly once, and failed
-    /// feedback attempts are counted + logged so loss is observable.
-    pub async fn feedback_pending_recalls(
+    /// Submit feedback for snapshots whose ownership has already moved out of
+    /// the in-process recall ledger. Lifecycle hooks use this form so the
+    /// synchronous ownership transfer cannot race turn finalization.
+    pub async fn feedback_recall_snapshots(
         &self,
-        session_id: &str,
-        producer_id: &str,
+        snapshots: Vec<RecallSnapshot>,
         signal: &str,
         context_prefix: &str,
     ) -> FeedbackDrainReport {
-        if session_id.is_empty() || producer_id.is_empty() || signal.is_empty() {
+        if signal.is_empty() {
             return FeedbackDrainReport::default();
         }
-        let snapshots = Self::drain_recalls_for_producer(session_id, producer_id, None);
         let mut report = FeedbackDrainReport::default();
         for snap in snapshots {
             for id in snap.memory_ids {
@@ -3405,6 +3435,31 @@ mod memoria_http_client_tests {
     use super::*;
 
     #[test]
+    fn runtime_context_replaces_prompt_owned_identity_fields() {
+        let projected = MemoriaToolGateway::args_with_runtime_context(
+            &json!({
+                "action": "recall",
+                "query": "relevant decisions",
+                "session_id": "spoofed-session",
+                "user_id": "spoofed-user",
+                "turn": 999,
+                "_attribution_id": "spoofed-producer"
+            }),
+            Some(" session-1 "),
+            Some(" user-1 "),
+            7,
+            "run-1",
+        );
+
+        assert!(projected.get("action").is_none());
+        assert_eq!(projected["query"], "relevant decisions");
+        assert_eq!(projected["session_id"], "session-1");
+        assert_eq!(projected["user_id"], "user-1");
+        assert_eq!(projected["turn"], 7);
+        assert_eq!(projected["_attribution_id"], "run-1");
+    }
+
+    #[test]
     fn purge_session_id_not_supported() {
         // Memoria PurgeRequest only accepts memory_ids and topic.
         // session_id is NOT a valid filter — it would cause 422.
@@ -4239,8 +4294,18 @@ mod memoria_http_client_tests {
     }
 
     #[tokio::test]
-    async fn feedback_pending_recalls_drains_queue_once() {
+    async fn owned_recall_snapshots_submit_feedback_once() {
         use super::*;
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/memory/feedback/(m1|m2)$"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(2)
+            .mount(&server)
+            .await;
         let session_id = "r5-feedback-drain";
         MemoriaToolGateway::reset_session_process_state(session_id);
         MemoriaToolGateway::record_recall_for_producer(
@@ -4249,18 +4314,20 @@ mod memoria_http_client_tests {
             7,
             vec!["m1".into(), "m2".into()],
         );
-        let client =
-            MemoriaToolGateway::new(Some("http://127.0.0.1:9".into()), Some("token".into()));
+        let client = MemoriaToolGateway::new(Some(server.uri()), Some("token".into()));
+        let snapshots = MemoriaToolGateway::drain_recalls_for_producer(session_id, "session", None);
         let attempted = client
-            .feedback_pending_recalls(session_id, "session", "useful", "unit-test")
+            .feedback_recall_snapshots(snapshots, "useful", "unit-test")
             .await;
         assert_eq!(attempted.attempted, 2);
         assert_eq!(attempted.failed, 2);
         assert_eq!(attempted.succeeded, 0);
         assert_eq!(MemoriaToolGateway::pending_recall_count(session_id), 0);
-        let attempted_again = client
-            .feedback_pending_recalls(session_id, "session", "useful", "unit-test")
-            .await;
-        assert_eq!(attempted_again.attempted, 0);
+        assert!(
+            MemoriaToolGateway::drain_recalls_for_producer(session_id, "session", None).is_empty(),
+            "ledger ownership must transfer exactly once"
+        );
+        server.verify().await;
+        MemoriaToolGateway::reset_session_process_state(session_id);
     }
 }

--- a/crates/runtime/src/server/runtime_tool_executor.rs
+++ b/crates/runtime/src/server/runtime_tool_executor.rs
@@ -98,6 +98,15 @@ use astra_turn_core::file_edit_journal::FileEditJournal;
 
 mod tool_handlers;
 
+pub(super) const DEFAULT_MEMORY_PRODUCER_ID: &str = "server-run";
+
+pub(super) fn memory_producer_id(run_id: Option<&str>) -> &str {
+    run_id
+        .map(str::trim)
+        .filter(|run_id| !run_id.is_empty())
+        .unwrap_or(DEFAULT_MEMORY_PRODUCER_ID)
+}
+
 #[cfg(test)]
 fn resolved_server_tool_names(
     capabilities: &astra_turn_core::capability::CapabilitySet,
@@ -601,6 +610,16 @@ impl RuntimeToolExecutor {
             semantic_read_observation_store: None,
             edge_admitted_tools: HashSet::new(),
         }
+    }
+
+    /// Return the exact ledger scope used by server-local memory calls.
+    /// Agentic-loop cleanup asks the executor instead of reconstructing the
+    /// session or fallback producer from unrelated loop state.
+    pub(crate) fn memory_recall_scope(&self, run_id: Option<&str>) -> (String, String) {
+        (
+            self.session_id.clone(),
+            memory_producer_id(run_id).to_string(),
+        )
     }
 
     pub fn task_manager(&self) -> Arc<TaskManager> {
@@ -2781,7 +2800,7 @@ impl RuntimeToolExecutor {
 
         let lifecycle = LocalToolExecutionLifecycle {
             session_id: &self.session_id,
-            producer_id: non_empty_identity(&request.run_id).unwrap_or("server-run"),
+            producer_id: memory_producer_id(Some(&request.run_id)),
             aggregate_output_bytes: &self.aggregate_output_bytes,
             memoria_client: &self.memoria_client,
             progress_callback: self.progress_callback.as_deref(),

--- a/crates/runtime/src/server/runtime_tool_executor/tool_handlers.rs
+++ b/crates/runtime/src/server/runtime_tool_executor/tool_handlers.rs
@@ -11,7 +11,7 @@ use astra_tools::tool_engine::{
     DynamicToolHandler, NotifyToolHandler, ToolEngine, ToolHandler, ToolInvocationMetadata,
 };
 
-use super::RuntimeToolExecutor;
+use super::{RuntimeToolExecutor, memory_producer_id};
 use crate::server::tool_agent_info::{AgentInfoIdentity, render_agent_info};
 use crate::server::tool_agent_runtime::{execute_agent_fanout_tool, execute_agent_tool};
 use crate::server::tool_database_snapshots::{execute_mo_query, rollback_database_snapshots};
@@ -208,13 +208,12 @@ impl MemoryToolHandler {
             };
         }
         let turn = context.journal_turn_index.load(Ordering::Relaxed);
-        let fallback_producer = format!("server-turn:{turn}");
         let isolated_args = memory_args_with_context(
             args,
             &context.session_id,
             &context.user_id,
             turn,
-            producer_id.unwrap_or(&fallback_producer),
+            memory_producer_id(producer_id),
         );
         let output = context
             .memoria_client

--- a/crates/runtime/src/server/tool_local_execution.rs
+++ b/crates/runtime/src/server/tool_local_execution.rs
@@ -135,24 +135,13 @@ pub(crate) fn memory_args_with_context(
     turn_index: u32,
     producer_id: &str,
 ) -> Value {
-    let mut isolated_args = args.clone();
-    if let Some(obj) = isolated_args.as_object_mut() {
-        obj.remove("action");
-        obj.insert(
-            "session_id".to_string(),
-            Value::String(session_id.to_string()),
-        );
-        obj.insert("user_id".to_string(), Value::String(user_id.to_string()));
-        obj.insert(
-            "turn".to_string(),
-            Value::Number(serde_json::Number::from(turn_index)),
-        );
-        obj.insert(
-            "_attribution_id".to_string(),
-            Value::String(producer_id.to_string()),
-        );
-    }
-    isolated_args
+    astra_tools::memoria::MemoriaToolGateway::args_with_runtime_context(
+        args,
+        Some(session_id),
+        Some(user_id),
+        turn_index,
+        producer_id,
+    )
 }
 
 pub(crate) fn normalize_local_tool_result_output(
@@ -183,8 +172,15 @@ pub(crate) fn spawn_memory_recall_feedback_after_success(
         return false;
     }
 
+    let snapshots = astra_tools::memoria::MemoriaToolGateway::drain_recalls_for_producer(
+        session_id,
+        producer_id,
+        None,
+    );
+    if snapshots.is_empty() {
+        return false;
+    }
     let session_id = session_id.to_string();
-    let producer_id = producer_id.to_string();
     let context = format!("server-tool:{name}");
     let client = astra_tools::memoria::MemoriaToolGateway::new(
         memoria_client.cloud_base.clone(),
@@ -193,7 +189,7 @@ pub(crate) fn spawn_memory_recall_feedback_after_success(
     tokio::spawn(
         async move {
             let report = client
-                .feedback_pending_recalls(&session_id, &producer_id, "useful", &context)
+                .feedback_recall_snapshots(snapshots, "useful", &context)
                 .await;
             if report.attempted > 0 {
                 tracing::debug!(
@@ -367,5 +363,35 @@ mod tests {
             &failed,
             &client,
         ));
+    }
+
+    #[tokio::test]
+    async fn memory_recall_feedback_takes_ledger_ownership_before_returning() {
+        let session_id = format!("feedback-ownership-transfer-{}", uuid::Uuid::new_v4());
+        astra_tools::memoria::MemoriaToolGateway::reset_session_process_state(&session_id);
+        astra_tools::memoria::MemoriaToolGateway::record_recall_for_producer(
+            &session_id,
+            "run-1",
+            1,
+            vec!["memory-1".into()],
+        );
+        let client = astra_tools::memoria::MemoriaToolGateway::new(
+            Some("http://127.0.0.1:1".into()),
+            Some("test-token".into()),
+        );
+
+        assert!(spawn_memory_recall_feedback_after_success(
+            &session_id,
+            "run-1",
+            "bash",
+            &astra_tools::ToolResult::text("ok".into()),
+            &client,
+        ));
+        assert_eq!(
+            astra_tools::memoria::MemoriaToolGateway::pending_recall_count(&session_id),
+            0,
+            "run-boundary cleanup must not race the feedback worker for ledger ownership"
+        );
+        astra_tools::memoria::MemoriaToolGateway::reset_session_process_state(&session_id);
     }
 }

--- a/crates/runtime/src/turn/agentic_loop/finalization.rs
+++ b/crates/runtime/src/turn/agentic_loop/finalization.rs
@@ -460,6 +460,43 @@ pub(crate) fn try_write_heavy_checkpoint(state: &mut AgenticLoopState) {
     state.stall.last_heavy_checkpoint = Some(cp);
 }
 
+/// Producer-scoped cleanup that also runs when the loop future is cancelled.
+struct UnattributedRecallRunBoundary {
+    scope: Option<(String, String)>,
+}
+
+impl UnattributedRecallRunBoundary {
+    fn new(scope: Option<(String, String)>) -> Self {
+        Self { scope }
+    }
+
+    fn settle(&mut self) {
+        let Some((session_id, producer_id)) = self.scope.take() else {
+            return;
+        };
+        let dropped = astra_tools::memoria::MemoriaToolGateway::drain_recalls_for_producer(
+            &session_id,
+            &producer_id,
+            None,
+        )
+        .len();
+        if dropped > 0 {
+            tracing::debug!(
+                session_id,
+                producer_id,
+                dropped,
+                "dropped unattributed memory recalls without changing their rank"
+            );
+        }
+    }
+}
+
+impl Drop for UnattributedRecallRunBoundary {
+    fn drop(&mut self) {
+        self.settle();
+    }
+}
+
 /// Run the multi-turn agentic loop using the provided host.
 ///
 /// This is the runtime-portable entry point. The host handles all
@@ -469,6 +506,9 @@ pub async fn run_agentic_loop_with_host<H: AgenticLoopHost>(
     host: &mut H,
     state: &mut AgenticLoopState,
 ) -> Result<AgenticLoopOutcome, astra_core::ClassifiedError> {
+    // Owned before the first await so task cancellation and panic unwinding
+    // settle the same producer queue as normal and error returns.
+    let _recall_run_boundary = UnattributedRecallRunBoundary::new(host.memory_recall_scope(state));
     let result = run_agentic_loop_impl(host, state).await;
 
     // Ensure SessionEnd fires even on error returns that skip finalize_and_render.
@@ -586,7 +626,6 @@ pub(crate) async fn finalize_and_render<H: AgenticLoopHost>(
     }
 
     finalize_turn_trace(state).await;
-    drop_unattributed_memory_recalls_at_turn_end(state);
 
     // Background session-memory extraction. Fire-and-forget; service
     // handles LLM vs. rule-based decision, event emission, UX broker,
@@ -974,34 +1013,6 @@ fn maybe_run_memory_extraction(state: &mut AgenticLoopState) {
         crate::session_memory::SpawnDecision::Spawned => {}
         crate::session_memory::SpawnDecision::Queued => {}
         crate::session_memory::SpawnDecision::Skipped => {}
-    }
-}
-
-fn drop_unattributed_memory_recalls_at_turn_end(state: &mut AgenticLoopState) {
-    let Some(session_id) = state
-        .current_session_id
-        .as_deref()
-        .filter(|sid| !sid.is_empty())
-    else {
-        return;
-    };
-    let producer_id = state
-        .current_run_id
-        .clone()
-        .unwrap_or_else(|| format!("cli-turn:{}", session_turn_number(state)));
-    let dropped = astra_tools::memoria::MemoriaToolGateway::drain_recalls_for_producer(
-        session_id,
-        &producer_id,
-        None,
-    )
-    .len();
-    if dropped > 0 {
-        tracing::debug!(
-            session_id = %session_id,
-            producer_id,
-            dropped,
-            "dropped unattributed memory recalls without changing their rank"
-        );
     }
 }
 
@@ -2291,10 +2302,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finalize_and_render_drains_pending_recall_feedback_for_server_executor() {
+    async fn run_boundary_uses_executor_owned_scope_after_host_error() {
         let mut host = MockHost::new(Vec::new());
         let mut state = make_state();
-        let session_id = format!("server-finalize-feedback-{}", uuid::Uuid::new_v4());
+        let parent_session_id = format!("parent-session-{}", uuid::Uuid::new_v4());
+        let session_id = format!("executor-session-{}", uuid::Uuid::new_v4());
         let workspace = tempfile::TempDir::new().unwrap();
         let executor = crate::server::runtime_tool_executor::RuntimeToolExecutor::new(
             workspace.path().to_path_buf(),
@@ -2303,25 +2315,106 @@ mod tests {
             None,
             None,
         );
+        let (_, producer_id) = executor.memory_recall_scope(None);
+        state.runtime_tool_executor = Some(std::sync::Arc::new(executor));
         astra_tools::memoria::MemoriaToolGateway::reset_session_process_state(&session_id);
         astra_tools::memoria::MemoriaToolGateway::record_recall_for_producer(
             &session_id,
-            "run-1",
+            &producer_id,
             1,
             vec!["m1".into()],
         );
-        state.current_session_id = Some(session_id.clone());
-        state.current_run_id = Some("run-1".to_string());
-        state.runtime_tool_executor = Some(std::sync::Arc::new(executor));
-        state.final_text = "Done.".into();
+        astra_tools::memoria::MemoriaToolGateway::record_recall_for_producer(
+            &session_id,
+            "concurrent-run",
+            1,
+            vec!["m2".into()],
+        );
+        state.current_session_id = Some(parent_session_id);
+        state.current_run_id = None;
 
-        finalize_and_render(&mut host, &mut state).await;
+        let result = run_agentic_loop_with_host(&mut host, &mut state).await;
+
+        assert!(result.is_err(), "empty host must exercise the error exit");
+        assert_eq!(
+            astra_tools::memoria::MemoriaToolGateway::pending_recall_count(&session_id),
+            1,
+            "run boundary must use the executor session and canonical fallback producer without touching concurrent work"
+        );
+        astra_tools::memoria::MemoriaToolGateway::reset_session_process_state(&session_id);
+    }
+
+    #[tokio::test]
+    async fn aborting_loop_future_drains_its_producer_recall_queue() {
+        struct PendingHost {
+            entered: Option<tokio::sync::oneshot::Sender<()>>,
+            valid_tool_names: std::collections::HashSet<String>,
+        }
+
+        #[async_trait::async_trait]
+        impl AgenticLoopHost for PendingHost {
+            fn emit_headless_line(
+                &mut self,
+                _style: astra_turn_core::headless_tool_body_preview::HeadlessStderrStyle,
+                _line: String,
+            ) {
+            }
+
+            fn is_quiet(&self) -> bool {
+                true
+            }
+
+            fn valid_tool_names(&self) -> &std::collections::HashSet<String> {
+                &self.valid_tool_names
+            }
+
+            async fn execute_turn(
+                &mut self,
+                _state: &mut AgenticLoopState,
+            ) -> Result<crate::turn::agentic_loop::host::HostTurnResult, astra_core::ClassifiedError>
+            {
+                if let Some(entered) = self.entered.take() {
+                    let _ = entered.send(());
+                }
+                std::future::pending().await
+            }
+        }
+
+        let mut state = make_state();
+        let session_id = format!("cancelled-run-feedback-{}", uuid::Uuid::new_v4());
+        state.current_session_id = Some(session_id.clone());
+        state.current_run_id = Some("cancelled-run".to_string());
+        astra_tools::memoria::MemoriaToolGateway::record_recall_for_producer(
+            &session_id,
+            "cancelled-run",
+            1,
+            vec!["m1".into()],
+        );
+
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            let mut host = PendingHost {
+                entered: Some(entered_tx),
+                valid_tool_names: std::collections::HashSet::new(),
+            };
+            run_agentic_loop_with_host(&mut host, &mut state).await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(5), entered_rx)
+            .await
+            .expect("loop must reach the cancellable host await")
+            .expect("host must signal before blocking");
+        task.abort();
+        let join_error = task
+            .await
+            .expect_err("aborted loop must not complete normally");
+        assert!(join_error.is_cancelled());
 
         assert_eq!(
             astra_tools::memoria::MemoriaToolGateway::pending_recall_count(&session_id),
             0,
-            "server finalization must drain pending recall feedback on memory-only turns"
+            "cancelling the loop future must release its producer-owned recall queue"
         );
+        astra_tools::memoria::MemoriaToolGateway::reset_session_process_state(&session_id);
     }
 
     // I11 test removed in rebase: the branch wired a now-deleted

--- a/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/crates/runtime/src/turn/agentic_loop/host.rs
@@ -194,6 +194,30 @@ pub use astra_turn_core::interaction_types::{
 /// streams SSE to client, executes tools via ledger.
 #[async_trait]
 pub trait AgenticLoopHost: Send {
+    /// Exact process-local recall ledger scope owned by this loop.
+    ///
+    /// The default covers ordinary CLI and server runs. Hosts whose tool
+    /// executor intentionally uses a different session (for example an
+    /// isolated skill sub-run) override this rather than making finalization
+    /// infer tool ownership from prompt or transcript state.
+    fn memory_recall_scope(&self, state: &AgenticLoopState) -> Option<(String, String)> {
+        if let Some(executor) = state.runtime_tool_executor.as_deref() {
+            return Some(executor.memory_recall_scope(state.current_run_id.as_deref()));
+        }
+        let session_id = state
+            .current_session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|session_id| !session_id.is_empty())?;
+        let producer_id = state
+            .current_run_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|producer_id| !producer_id.is_empty())
+            .unwrap_or("session");
+        Some((session_id.to_string(), producer_id.to_string()))
+    }
+
     /// Execute one LLM turn: prepare payload → POST → consume SSE.
     ///
     /// The host is responsible for all CLI/server-specific logic:


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [x] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [x] test (adding or updating tests)
- [x] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

N/A — found while tracing session lifecycle failures and recall-feedback ownership across CLI and server execution paths.

## What this PR does / why we need it

Memory recall lifecycle identity was reconstructed independently by CLI tools, server tools, and turn finalization. That allowed the same run to be recorded under different producer IDs (`server-turn:N`, `server-run`, `session`, or a CLI turn label). It also left cleanup in a normal finalization path that error returns and cancelled futures could skip. A detached feedback worker previously acquired recall-ledger ownership asynchronously, racing turn cleanup.

This PR:

- makes the actual tool host/executor expose the authoritative `(session, producer)` recall scope;
- uses the same producer for memory execution, successful-tool feedback, and run-boundary cleanup;
- assigns isolated CLI skill sub-runs their own producer identity so concurrent sub-runs cannot consume each other's recalls;
- installs a producer-scoped RAII run boundary before the first await, covering normal completion, host errors, panic unwinding, and future cancellation;
- transfers recall snapshots out of the ledger synchronously before starting best-effort feedback delivery;
- removes the duplicate CLI post-commit cleanup path and the drain-and-send API that could reintroduce the race;
- centralizes runtime-owned Memoria argument projection so prompt/tool arguments cannot spoof session, user, turn, or attribution identity;
- updates session-analysis/review skills to understand digest v2 sub-runs and to use one fixed fanout group rather than competing per-agent lifecycles;
- removes brittle source-text contract tests in favor of manifest/runtime behavior checks.

## Architecture and complexity delta

- Canonical owner changed or extended: the Memoria runtime ledger remains the state owner; `ToolExecutor` / `RuntimeToolExecutor` now own scope projection, and `AgenticLoopHost::memory_recall_scope` is the single loop-boundary port.
- Existing implementations/callers searched: CLI root chat, skill sub-run, delegate sub-run, spawned sub-run, server-local execution, memory tool handlers, tool-result feedback, turn finalization, and session post-commit cleanup.
- Superseded code, states, tables, shims, and self-only tests removed: duplicate CLI turn-end cleanup, `feedback_pending_recalls`, server turn-number fallback identity, competing `agent` exposure in the review skill, and source-text matching skill tests.
- Net code/state/table delta: +483/-304 across 20 files; no database tables, migrations, compatibility shims, or new background supervisors.
- If parallel implementations remain, the external boundary and retirement condition: `.agent` and `.claude` skill roots remain host-compatibility manifests; their instruction bodies are parity-tested, with only the Astra-specific `agent_fanout` capability allowed to differ.

## Production wiring and verification

- Public product entrypoint exercised: CLI chat construction, CLI skill/delegate/spawn executor construction, server-local tool execution, and the shared agentic-loop boundary compile through their real production wiring.
- Unhappy paths exercised: host error before finalization, actual Tokio task abort while the loop is awaiting the host, concurrent producer isolation, synchronous feedback ownership transfer, and deterministic Memoria 503 responses through WireMock.
- Database schema/query/transaction/migration verified against a real database, or `N/A` with reason: N/A — this change does not modify or execute database schema, query, transaction, or migration logic.

## Verification run

- `cargo check --workspace`
- `cargo test -p astra-runtime server::tool_local_execution::tests --lib`
- `cargo test -p astra-runtime run_boundary_uses_executor_owned_scope_after_host_error --lib`
- `cargo test -p astra-runtime aborting_loop_future_drains_its_producer_recall_queue --lib`
- `cargo test -p astra-tools owned_recall_snapshots_submit_feedback_once --lib`
- `cargo test -p astra-tools memoria_http_client_tests::runtime_context_replaces_prompt_owned_identity_fields --lib`
- `cargo test -p astra-cli memory_args_include_session_and_current_turn --lib`
- `cargo test -p astra-skills review_changes_skill_exposes_fixed_fanout_for_parallel_reviews --lib`
- `cargo test -p astra-skills --test skill_diagnosis_contract project_claude_and_agent_skill_bodies_stay_in_sync`
- `git diff HEAD^ --check`
