### PR TITLE
fix(cli): keep invocation metadata outside tool arguments

### DIFF
--- a/.agent/skills/analyze_session/SKILL.md
+++ b/.agent/skills/analyze_session/SKILL.md
@@ -21,6 +21,10 @@ allowed_tools:
 
 Use machine-generated evidence first. `astra journal digest` is the primary source;
 raw JSONL parsing is a fallback only when digest is unavailable or missing a field.
+Before synthesizing session metrics or causes, run the digest command for the
+resolved session. Generic reflection/introspection output does not satisfy this
+evidence boundary. If no executable can produce a digest, report that limitation
+instead of estimating or filling in metrics.
 
 ## Task
 

--- a/.claude/skills/analyze_session/SKILL.md
+++ b/.claude/skills/analyze_session/SKILL.md
@@ -21,6 +21,10 @@ allowed_tools:
 
 Use machine-generated evidence first. `astra journal digest` is the primary source;
 raw JSONL parsing is a fallback only when digest is unavailable or missing a field.
+Before synthesizing session metrics or causes, run the digest command for the
+resolved session. Generic reflection/introspection output does not satisfy this
+evidence boundary. If no executable can produce a digest, report that limitation
+instead of estimating or filling in metrics.
 
 ## Task
 

--- a/crates/astra-cli/src/cli/session/session_todo_client.rs
+++ b/crates/astra-cli/src/cli/session/session_todo_client.rs
@@ -165,7 +165,7 @@ pub async fn execute_todo_action(
     action: &str,
     args: &Value,
 ) -> Result<String, String> {
-    execute_todo_request(cloud_base, token, session_id, action, args)
+    execute_todo_request(cloud_base, token, session_id, action, args, None)
         .await
         .map(|response| response.output)
 }
@@ -178,8 +178,9 @@ pub(crate) async fn execute_todo_action_typed(
     session_id: &str,
     action: &str,
     args: &Value,
+    tool_call_id: Option<&str>,
 ) -> Result<ExecuteTodoResponse, String> {
-    execute_todo_request(cloud_base, token, session_id, action, args).await
+    execute_todo_request(cloud_base, token, session_id, action, args, tool_call_id).await
 }
 
 async fn execute_todo_request(
@@ -188,25 +189,24 @@ async fn execute_todo_request(
     session_id: &str,
     action: &str,
     args: &Value,
+    tool_call_id: Option<&str>,
 ) -> Result<ExecuteTodoResponse, String> {
     let url = format!(
         "{}/sessions/{}/todos:execute",
         cloud_base.trim_end_matches('/'),
         session_id
     );
-    // Runtime-only fields carry execution identity and observability context;
-    // they are not part of the public task-board contract and must never cross
-    // the REST boundary as task data.  The call id still gives create a stable
-    // idempotency identity, so a lost response followed by replay cannot create
-    // a duplicate task.  Direct callers without a runtime identity retain the
-    // old per-invocation UUID behavior, which deliberately does not collapse
-    // two legitimate tasks merely because their public fields are identical.
+    // Model/provider arguments stay public-schema-pure. Trusted invocation
+    // identity travels beside them and is used only for transport concerns
+    // such as idempotency. Direct callers without an invocation identity retain
+    // per-invocation UUID behavior, which deliberately does not collapse two
+    // legitimate tasks merely because their public fields are identical.
     let public_args = astra_tools::task_tool_contract::strip_runtime_private_task_fields(args);
     let body = if action == "create" {
         json!({
             "action": action,
             "args": public_args,
-            "idempotency_key": todo_create_idempotency_key(session_id, args),
+            "idempotency_key": todo_create_idempotency_key(session_id, tool_call_id),
         })
     } else {
         json!({ "action": action, "args": public_args })
@@ -251,13 +251,8 @@ async fn execute_todo_request(
     Err("execute_todo_action: retry loop exhausted".to_string())
 }
 
-fn todo_create_idempotency_key(session_id: &str, args: &Value) -> String {
-    let Some(tool_call_id) = args
-        .get("_tool_call_id")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-    else {
+fn todo_create_idempotency_key(session_id: &str, tool_call_id: Option<&str>) -> String {
+    let Some(tool_call_id) = tool_call_id.map(str::trim).filter(|id| !id.is_empty()) else {
         return format!("todo-create:{}", uuid::Uuid::new_v4());
     };
 
@@ -288,6 +283,7 @@ pub(crate) async fn copy_todos_for_fork(
         &json!({
             "source_session_id": source_session_id,
         }),
+        None,
     )
     .await?;
     let result = response.fork_copy.ok_or_else(|| {
@@ -643,34 +639,27 @@ impl TaskStore for HttpTaskStore {
 #[cfg(test)]
 mod tests {
     use super::todo_create_idempotency_key;
-    use serde_json::json;
 
     #[test]
     fn create_idempotency_uses_stable_runtime_execution_identity() {
-        let args = json!({
-            "action": "create",
-            "title": "ship",
-            "_tool_call_id": "call-1"
-        });
-        let first = todo_create_idempotency_key("session-1", &args);
-        let replay = todo_create_idempotency_key("session-1", &args);
+        let first = todo_create_idempotency_key("session-1", Some("call-1"));
+        let replay = todo_create_idempotency_key("session-1", Some("call-1"));
         assert_eq!(first, replay);
-        assert_ne!(first, todo_create_idempotency_key("session-2", &args));
-
-        let other_call = json!({
-            "action": "create",
-            "title": "ship",
-            "_tool_call_id": "call-2"
-        });
-        assert_ne!(first, todo_create_idempotency_key("session-1", &other_call));
+        assert_ne!(
+            first,
+            todo_create_idempotency_key("session-2", Some("call-1"))
+        );
+        assert_ne!(
+            first,
+            todo_create_idempotency_key("session-1", Some("call-2"))
+        );
     }
 
     #[test]
     fn equal_public_creates_without_execution_identity_remain_distinct() {
-        let args = json!({"action": "create", "title": "ship"});
         assert_ne!(
-            todo_create_idempotency_key("session-1", &args),
-            todo_create_idempotency_key("session-1", &args)
+            todo_create_idempotency_key("session-1", None),
+            todo_create_idempotency_key("session-1", None)
         );
     }
 }
@@ -704,7 +693,7 @@ mod tests {
 mod wiring_e2e {
     use super::{
         ForkTaskBoardCopyStatus, HttpTaskStore, copy_todos_for_fork, execute_todo_action,
-        health_for_http_status, list_user_todos,
+        execute_todo_action_typed, health_for_http_status, list_user_todos,
     };
     use crate::cli::cli_config::cli_utils::{CredentialsFile, Profile, save_credentials};
     use crate::lock_recovery::LockRecovery;
@@ -1159,11 +1148,9 @@ mod wiring_e2e {
         let server = MockServer::start().await;
         let args = json!({
             "action": "create",
-            "title": "ship",
-            "_tool_call_id": "call-create-1",
-            "_run_id": "run-1"
+            "title": "ship"
         });
-        let expected_key = super::todo_create_idempotency_key("session-1", &args);
+        let expected_key = super::todo_create_idempotency_key("session-1", Some("call-create-1"));
         Mock::given(method("POST"))
             .and(path("/sessions/session-1/todos:execute"))
             .respond_with(move |request: &Request| {
@@ -1183,10 +1170,17 @@ mod wiring_e2e {
             .mount(&server)
             .await;
 
-        let output = execute_todo_action(&server.uri(), None, "session-1", "create", &args)
-            .await
-            .expect("create request");
-        assert_eq!(output, "created");
+        let response = execute_todo_action_typed(
+            &server.uri(),
+            None,
+            "session-1",
+            "create",
+            &args,
+            Some("call-create-1"),
+        )
+        .await
+        .expect("create request");
+        assert_eq!(response.output, "created");
     }
 
     #[tokio::test]

--- a/crates/astra-cli/src/cli/stream/stream_render.rs
+++ b/crates/astra-cli/src/cli/stream/stream_render.rs
@@ -3592,11 +3592,15 @@ impl SseStreamHost for CliSseStreamHost<'_> {
             } else {
                 let _pending_tool_request_guard =
                     crate::cli::edge_lifecycle::PendingToolRequestGuard::acquire();
-                let execution_args = args_with_runtime_tool_call_id(tool, args, request_id);
-                let mut outcome = execute_with_metadata_responsive(
+                let invocation = astra_tools::tool_engine::ToolInvocationMetadata {
+                    tool_call_id: Some(request_id),
+                    ..Default::default()
+                };
+                let mut outcome = execute_with_invocation_metadata_responsive(
                     std::sync::Arc::clone(&self.executor),
                     tool.to_string(),
-                    execution_args,
+                    args.clone(),
+                    invocation,
                     self.cancel_token.cloned(),
                 )
                 .await;
@@ -3783,10 +3787,11 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                                         "post-approval expansion rejected: {e}"
                                     );
                                 }
-                                outcome = execute_with_metadata_responsive(
+                                outcome = execute_with_invocation_metadata_responsive(
                                     std::sync::Arc::clone(&self.executor),
                                     tool.to_string(),
                                     args.clone(),
+                                    invocation,
                                     self.cancel_token.cloned(),
                                 )
                                 .await;
@@ -4457,14 +4462,19 @@ impl SseStreamHost for CliSseStreamHost<'_> {
                         // (it lives only for this batch), so acquire() won't fail; the
                         // `ok()` fallback is defensive.
                         let _permit = sem.acquire_owned().await.ok();
-                        let execution_args =
-                            args_with_runtime_tool_call_id(&tool, &effective_args, &request_id);
-                        let exec = catch_tool_execution_panic(execute_with_metadata_responsive(
-                            std::sync::Arc::clone(&executor),
-                            tool.clone(),
-                            execution_args,
-                            cancel_token_for_tool,
-                        ));
+                        let invocation = astra_tools::tool_engine::ToolInvocationMetadata {
+                            tool_call_id: Some(&request_id),
+                            ..Default::default()
+                        };
+                        let exec = catch_tool_execution_panic(
+                            execute_with_invocation_metadata_responsive(
+                                std::sync::Arc::clone(&executor),
+                                tool.clone(),
+                                effective_args.clone(),
+                                invocation,
+                                cancel_token_for_tool,
+                            ),
+                        );
                         let (outcome, dur) = if let Some(token) = cancel_token {
                             tokio::select! {
                                 biased;
@@ -4669,12 +4679,15 @@ impl SseStreamHost for CliSseStreamHost<'_> {
             if let Some(pm) = &mut self.perm_manager {
                 pm.record_approval(&sandbox_tool_key, Some(&args), true);
             }
-            let execution_args = args_with_runtime_tool_call_id(&tool, &args, &req.request_id);
             let (retried, retry_dur) =
-                catch_tool_execution_panic(execute_with_metadata_responsive(
+                catch_tool_execution_panic(execute_with_invocation_metadata_responsive(
                     std::sync::Arc::clone(&self.executor),
                     tool.clone(),
-                    execution_args,
+                    args,
+                    astra_tools::tool_engine::ToolInvocationMetadata {
+                        tool_call_id: Some(&req.request_id),
+                        ..Default::default()
+                    },
                     self.cancel_token.cloned(),
                 ))
                 .await;
@@ -4888,11 +4901,14 @@ fn build_streaming_tool_exec(
                         other => other.clone(),
                     })
                     .unwrap_or_else(|| serde_json::json!({}));
-                let execution_args = args_with_runtime_tool_call_id(&tool_name, &args, &call_id);
-                let outcome = execute_with_metadata_responsive(
+                let outcome = execute_with_invocation_metadata_responsive(
                     executor,
                     tool_name.clone(),
-                    execution_args,
+                    args,
+                    astra_tools::tool_engine::ToolInvocationMetadata {
+                        tool_call_id: Some(&call_id),
+                        ..Default::default()
+                    },
                     None,
                 )
                 .await;
@@ -4902,23 +4918,6 @@ fn build_streaming_tool_exec(
     Some(std::sync::Arc::new(
         astra_turn_core::streaming_tool_exec::StreamingToolExecutor::new(fn_exec),
     ))
-}
-
-/// Attach caller-owned execution identity only to tools whose runtime contract
-/// explicitly accepts private fields.  Public model arguments remain unchanged
-/// for permission checks, hooks, rendering, and deduplication.
-fn args_with_runtime_tool_call_id(tool: &str, args: &Value, tool_call_id: &str) -> Value {
-    if tool != astra_tools::task_tool_contract::TASK_BOARD_TOOL_NAME {
-        return args.clone();
-    }
-    let mut execution_args = args.clone();
-    if let Some(object) = execution_args.as_object_mut() {
-        object.insert(
-            "_tool_call_id".to_string(),
-            Value::String(tool_call_id.to_string()),
-        );
-    }
-    execution_args
 }
 
 // ─── Turn result from one /chat/turn SSE stream ───────────────────────────────
@@ -6328,6 +6327,23 @@ pub(crate) async fn execute_with_metadata_responsive(
     args: Value,
     cancel_token: Option<tokio_util::sync::CancellationToken>,
 ) -> crate::edge_tools::ToolExecutionOutcome {
+    execute_with_invocation_metadata_responsive(
+        executor,
+        tool_name,
+        args,
+        astra_tools::tool_engine::ToolInvocationMetadata::default(),
+        cancel_token,
+    )
+    .await
+}
+
+pub(crate) async fn execute_with_invocation_metadata_responsive(
+    executor: std::sync::Arc<crate::edge_tools::ToolExecutor>,
+    tool_name: String,
+    args: Value,
+    invocation: astra_tools::tool_engine::ToolInvocationMetadata<'_>,
+    cancel_token: Option<tokio_util::sync::CancellationToken>,
+) -> crate::edge_tools::ToolExecutionOutcome {
     if tool_name == "bash"
         && let Some(outcome) = executor
             .bash_detachable_with_metadata(&args, cancel_token.as_ref())
@@ -6338,7 +6354,12 @@ pub(crate) async fn execute_with_metadata_responsive(
 
     if !should_offload_blocking_tool(&tool_name) {
         return executor
-            .execute_with_metadata_cancelable(&tool_name, &args, cancel_token.as_ref())
+            .execute_with_invocation_metadata_cancelable(
+                &tool_name,
+                &args,
+                invocation,
+                cancel_token.as_ref(),
+            )
             .await;
     }
 
@@ -6366,7 +6387,12 @@ pub(crate) async fn execute_with_metadata_responsive(
         // unreachable; fall back to the async path defensively.
         Ok(None) => {
             executor
-                .execute_with_metadata_cancelable(&tool_name, &args, cancel_token.as_ref())
+                .execute_with_invocation_metadata_cancelable(
+                    &tool_name,
+                    &args,
+                    invocation,
+                    cancel_token.as_ref(),
+                )
                 .await
         }
         Err(join_error) => crate::edge_tools::ToolExecutionOutcome::error(format!(
@@ -6835,14 +6861,14 @@ mod tests {
         append_skill_loaded_marker, apply_edge_auth_failure_result, approval_batch_group_key,
         approval_default_always_scope, approval_memory_action, approval_memory_preview,
         approval_scope_context_for_tool, approval_stale_revalidation_error,
-        args_with_runtime_tool_call_id, catch_tool_execution_panic, dispatch_turn_event_block,
-        edge_tool_is_cacheable_read, edge_tool_outcome_status, execute_with_metadata_responsive,
-        extract_cli_diff_block, format_terminal_tool_summary, format_tool_display_from_preview,
-        is_edge_auth_failure, merge_edge_tool_rounds, normalize_sandbox_denied_outcome,
-        path_mtime_ms, reusable_speculative_output, sanitize_final_stream_text,
-        style_tool_description, sync_incremental_accum_state, sync_incremental_tool_result_state,
-        task_preview_from_args, theme, tool_completion_icon, tool_dedup_signature,
-        tool_output_event_text, turn_has_tool_work,
+        catch_tool_execution_panic, dispatch_turn_event_block, edge_tool_is_cacheable_read,
+        edge_tool_outcome_status, execute_with_invocation_metadata_responsive,
+        execute_with_metadata_responsive, extract_cli_diff_block, format_terminal_tool_summary,
+        format_tool_display_from_preview, is_edge_auth_failure, merge_edge_tool_rounds,
+        normalize_sandbox_denied_outcome, path_mtime_ms, reusable_speculative_output,
+        sanitize_final_stream_text, style_tool_description, sync_incremental_accum_state,
+        sync_incremental_tool_result_state, task_preview_from_args, theme, tool_completion_icon,
+        tool_dedup_signature, tool_output_event_text, turn_has_tool_work,
     };
     use crate::cli::chat_stream;
     use crate::cli::cli_config::cli_utils::{CredentialsFile, Profile, save_credentials};
@@ -6910,19 +6936,80 @@ mod tests {
         assert!(RenderPolicy::Silent.suppress_final_text());
     }
 
-    #[test]
-    fn runtime_call_identity_is_attached_only_to_task_board_execution() {
-        let public = serde_json::json!({"action": "create", "title": "ship"});
-        let task_args = args_with_runtime_tool_call_id("task_board", &public, "call-1");
-        assert_eq!(task_args["_tool_call_id"], "call-1");
-        assert!(public.get("_tool_call_id").is_none());
-
-        let bash_args = args_with_runtime_tool_call_id(
-            "bash",
-            &serde_json::json!({"command": "echo ok"}),
-            "call-2",
+    #[tokio::test]
+    async fn task_board_invocation_identity_stays_outside_public_schema_and_reaches_transport() {
+        let server = MockServer::start().await;
+        let request_keys = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let observed_keys = std::sync::Arc::clone(&request_keys);
+        Mock::given(method("POST"))
+            .and(path("/sessions/session-1/todos:execute"))
+            .respond_with(move |request: &wiremock::Request| {
+                let body: Value = serde_json::from_slice(&request.body).expect("request json");
+                assert_eq!(
+                    body["args"],
+                    serde_json::json!({
+                        "action": "create",
+                        "title": "ship"
+                    })
+                );
+                let key = body["idempotency_key"]
+                    .as_str()
+                    .expect("create idempotency key")
+                    .to_string();
+                observed_keys.lock().expect("request keys").push(key);
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "output": "created",
+                    "mutation": {
+                        "status": "applied",
+                        "data": {"task_id": "task-1"}
+                    }
+                }))
+            })
+            .mount(&server)
+            .await;
+        let dir = tempdir().expect("tempdir");
+        let executor = std::sync::Arc::new(
+            crate::edge_tools::ToolExecutor::new(dir.path())
+                .with_cloud(server.uri(), "token")
+                .with_active_session_id("session-1"),
         );
-        assert!(bash_args.get("_tool_call_id").is_none());
+        let public_args = serde_json::json!({"action": "create", "title": "ship"});
+
+        let outcome = execute_with_invocation_metadata_responsive(
+            std::sync::Arc::clone(&executor),
+            "task_board".to_string(),
+            public_args.clone(),
+            astra_tools::tool_engine::ToolInvocationMetadata {
+                tool_call_id: Some("call-1"),
+                ..Default::default()
+            },
+            None,
+        )
+        .await;
+
+        assert!(!outcome.is_error, "{}", outcome.output);
+        assert_eq!(outcome.output, "created");
+
+        let replay = execute_with_invocation_metadata_responsive(
+            executor,
+            "task_board".to_string(),
+            public_args.clone(),
+            astra_tools::tool_engine::ToolInvocationMetadata {
+                tool_call_id: Some("call-1"),
+                ..Default::default()
+            },
+            None,
+        )
+        .await;
+
+        assert!(!replay.is_error, "{}", replay.output);
+        let keys = request_keys.lock().expect("request keys");
+        assert_eq!(keys.len(), 2, "one HTTP request per logical execution");
+        assert_eq!(
+            keys[0], keys[1],
+            "replaying the same tool-call identity must reuse its idempotency key"
+        );
+        assert!(public_args.get("_tool_call_id").is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -2829,7 +2829,7 @@ impl ToolExecutor {
     // ─── Task management methods (delegated to task_mgmt module) ────────────
 
     fn validate_task_tool_args_for_action(action: &str, args: &Value) -> Result<(), String> {
-        astra_tools::task_tool_contract::validate_runtime_task_tool_args_for_action(action, args)
+        astra_tools::task_tool_contract::validate_public_task_tool_args_for_action(action, args)
     }
 
     fn task_action_mutates_board(action: &str) -> bool {
@@ -2933,6 +2933,16 @@ impl ToolExecutor {
     /// touches MO directly. Falls back to the in-memory manager only
     /// when no cloud is wired (one-shot CLI, headless tests).
     async fn route_task_action(&self, action: &str, args: &Value) -> Option<RoutedTaskAction> {
+        self.route_task_action_with_call_id(action, args, None)
+            .await
+    }
+
+    async fn route_task_action_with_call_id(
+        &self,
+        action: &str,
+        args: &Value,
+        tool_call_id: Option<&str>,
+    ) -> Option<RoutedTaskAction> {
         let cloud_base = self.cloud_base.clone()?;
         let session_id = self.active_session_id()?;
         if session_id.is_empty() {
@@ -2945,6 +2955,7 @@ impl ToolExecutor {
             &session_id,
             action,
             args,
+            tool_call_id,
         )
         .await
         {
@@ -3336,7 +3347,18 @@ impl ToolExecutor {
     }
 
     async fn task_action_create(&self, args: &Value) -> String {
-        if let Some(routed) = self.route_task_action("create", args).await {
+        self.task_action_create_with_invocation(args, None).await
+    }
+
+    async fn task_action_create_with_invocation(
+        &self,
+        args: &Value,
+        tool_call_id: Option<&str>,
+    ) -> String {
+        if let Some(routed) = self
+            .route_task_action_with_call_id("create", args, tool_call_id)
+            .await
+        {
             if let Some(mutation) = routed
                 .mutation
                 .as_ref()
@@ -3382,14 +3404,17 @@ impl ToolExecutor {
         outcome.output
     }
 
-    async fn execute_task_tool_args(&self, args: &Value) -> String {
+    async fn execute_task_tool_args(&self, args: &Value, tool_call_id: Option<&str>) -> String {
         let action = match astra_tools::task_tool_contract::task_action_from_args(args) {
             Ok(action) => action,
             Err(error) => return format!("Error: {error}"),
         };
         match action {
             "create" => match Self::validate_task_tool_args_for_action("create", args) {
-                Ok(()) => self.task_action_create(args).await,
+                Ok(()) => {
+                    self.task_action_create_with_invocation(args, tool_call_id)
+                        .await
+                }
                 Err(error) => format!("Error: {error}"),
             },
             "list" => match Self::validate_task_tool_args_for_action("list", args) {
@@ -4970,17 +4995,36 @@ impl ToolExecutor {
         args: &Value,
         cancel_token: Option<&tokio_util::sync::CancellationToken>,
     ) -> ToolExecutionOutcome {
-        // Admission gate (fail-closed). Every public execution entry point
-        // must pass through `tool_admission_denial` before any tool runs —
-        // including the cancel-aware shell path and metadata-tagged paths,
-        // which otherwise bypass `execute_run`'s gate.
-        if let Some(denied) = self.tool_admission_denial(name, args) {
-            return denied.into_outcome();
+        self.execute_with_invocation_metadata_cancelable(
+            name,
+            args,
+            astra_tools::tool_engine::ToolInvocationMetadata::default(),
+            cancel_token,
+        )
+        .await
+    }
+
+    pub async fn execute_with_invocation_metadata_cancelable(
+        &self,
+        name: &str,
+        args: &Value,
+        invocation: astra_tools::tool_engine::ToolInvocationMetadata<'_>,
+        cancel_token: Option<&tokio_util::sync::CancellationToken>,
+    ) -> ToolExecutionOutcome {
+        // The sync shell path bypasses `execute_run`, so it owns admission.
+        // Every other tool falls through to the invocation-aware async path,
+        // which validates and admits exactly once.
+        let is_blocking_shell = name == "bash" || (cfg!(windows) && name == "powershell");
+        if is_blocking_shell {
+            if let Some(denied) = self.tool_admission_denial(name, args) {
+                return denied.into_outcome();
+            }
+            if let Some(outcome) = self.execute_blocking_shell_tool(name, args, cancel_token) {
+                return outcome;
+            }
         }
-        if let Some(outcome) = self.execute_blocking_shell_tool(name, args, cancel_token) {
-            return outcome;
-        }
-        self.execute_with_metadata(name, args).await
+        self.execute_with_invocation_metadata(name, args, invocation)
+            .await
     }
 
     /// Synchronous core for `bash` / `powershell` execution. Returns
@@ -4995,12 +5039,12 @@ impl ToolExecutor {
         args: &Value,
         cancel_token: Option<&tokio_util::sync::CancellationToken>,
     ) -> Option<ToolExecutionOutcome> {
-        // Deferred activation must be consumed exactly once per tool call.
-        // The other public entry points (execute_with_metadata, execute) also
-        // call consume, but they do NOT call this function — so this is the
-        // only consume site for shell-tool paths.
-        self.consume_activated_deferred_tool_if_called(name);
         if name == "bash" {
+            // Deferred activation must be consumed exactly once, and only
+            // after this sync dispatcher has claimed the call. Non-shell
+            // names fall through to the async dispatcher, which owns their
+            // activation lifecycle.
+            self.consume_activated_deferred_tool_if_called(name);
             let mut outcome = self.bash_outcome_with_cancel(args, cancel_token);
             outcome.output = self.finalize_tool_output(outcome.output, name);
             self.record_output_size(outcome.output.len());
@@ -5008,6 +5052,7 @@ impl ToolExecutor {
         }
         #[cfg(windows)]
         if name == "powershell" {
+            self.consume_activated_deferred_tool_if_called(name);
             let output =
                 self.finalize_tool_output(self.powershell_with_cancel(args, cancel_token), name);
             self.record_output_size(output.len());
@@ -5019,6 +5064,20 @@ impl ToolExecutor {
     }
 
     pub async fn execute_with_metadata(&self, name: &str, args: &Value) -> ToolExecutionOutcome {
+        self.execute_with_invocation_metadata(
+            name,
+            args,
+            astra_tools::tool_engine::ToolInvocationMetadata::default(),
+        )
+        .await
+    }
+
+    pub async fn execute_with_invocation_metadata(
+        &self,
+        name: &str,
+        args: &Value,
+        invocation: astra_tools::tool_engine::ToolInvocationMetadata<'_>,
+    ) -> ToolExecutionOutcome {
         // Admission gate (fail-closed). This is a public entry point called
         // directly by the server executor; without this gate, `mo_query`
         // and `git` metadata-tagged paths would bypass `execute_run`'s gate.
@@ -5084,15 +5143,28 @@ impl ToolExecutor {
                 }
             }
         }
-        self.execute_run(name, args).await.into_outcome()
+        self.execute_run(name, args, invocation)
+            .await
+            .into_outcome()
     }
 
     pub async fn execute(&self, name: &str, args: &Value) -> String {
         self.consume_activated_deferred_tool_if_called(name);
-        self.execute_run(name, args).await.output
+        self.execute_run(
+            name,
+            args,
+            astra_tools::tool_engine::ToolInvocationMetadata::default(),
+        )
+        .await
+        .output
     }
 
-    async fn execute_run(&self, name: &str, args: &Value) -> EdgeToolRun {
+    async fn execute_run(
+        &self,
+        name: &str,
+        args: &Value,
+        invocation: astra_tools::tool_engine::ToolInvocationMetadata<'_>,
+    ) -> EdgeToolRun {
         if let Err(error) = astra_tools::schemas::validate_tool_arguments(name, args) {
             let evidence = error.failure_evidence();
             return EdgeToolRun::failure_evidence(format!("Error: {error}"), evidence);
@@ -5106,7 +5178,9 @@ impl ToolExecutor {
             return EdgeToolRun::failure_evidence(error.message, error.evidence);
         }
         let mut tool_result_fields = None;
-        let output = self.execute_raw(name, args, &mut tool_result_fields).await;
+        let output = self
+            .execute_raw(name, args, invocation, &mut tool_result_fields)
+            .await;
         let embedded_work_observation = embedded_work_unit_observation(&output);
         // Structural error propagation: `execute_raw` returns a plain String,
         // discarding any structured error kind at the source. Recover it here
@@ -5141,6 +5215,7 @@ impl ToolExecutor {
         &self,
         name: &str,
         args: &Value,
+        invocation: astra_tools::tool_engine::ToolInvocationMetadata<'_>,
         tool_result_fields: &mut Option<serde_json::Map<String, Value>>,
     ) -> String {
         let output = if let Err(error) =
@@ -5544,7 +5619,10 @@ impl ToolExecutor {
                         }
                     }
                 }
-                "task_board" => self.execute_task_tool_args(args).await,
+                "task_board" => {
+                    self.execute_task_tool_args(args, invocation.tool_call_id)
+                        .await
+                }
                 "task_output" => self.task_output_with_fields(args, tool_result_fields).await,
                 "task_stop" => self.task_kill_bg(args).await,
                 "task_list" => self.task_list_bg().await,

--- a/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/crates/runtime/src/turn/agentic_loop/host.rs
@@ -966,10 +966,11 @@ pub struct SkillState {
     pub effort: Option<crate::skills::manifest::EffortLevel>,
     /// Agent type hint from the most recently activated skill.
     pub agent_type: Option<String>,
-    /// Tool allow-list from the most recently activated skill.
-    /// This is enforced only by runtime tool interception. Hosts must not use
-    /// it to prune prompt-visible tool schemas, because that would churn the
-    /// provider prompt-cache prefix every time a skill is loaded.
+    /// Tool guidance from the most recently activated skill.
+    /// This does not override request policy or prune prompt-visible schemas;
+    /// changing the schema set after activation would churn the provider
+    /// prompt-cache prefix. The inline skill result exposes the guidance to the
+    /// model while request constraints remain the authorization boundary.
     pub allowed_tools: Option<HashSet<String>>,
     /// Request-scoped tool/skill constraints supplied by the external caller.
     /// Nested runs inherit these constraints unchanged.

--- a/crates/runtime/src/turn/agentic_loop/lifecycle.rs
+++ b/crates/runtime/src/turn/agentic_loop/lifecycle.rs
@@ -2911,6 +2911,12 @@ mod tests {
         assert!(
             state.tool_results[0]["result"]
                 .as_str()
+                .is_some_and(|content| content.contains("Declared workflow tools: `read_file`")),
+            "auto-routed skills must expose their typed workflow guidance at the model boundary"
+        );
+        assert!(
+            state.tool_results[0]["result"]
+                .as_str()
                 .is_some_and(|content| {
                     content.contains(
                         "only these request-allowlisted non-skill tools are callable: read_file",

--- a/crates/runtime/src/turn/skill_tool.rs
+++ b/crates/runtime/src/turn/skill_tool.rs
@@ -743,6 +743,24 @@ pub fn append_skill_loaded_marker(result: &str, skill_name: &str) -> String {
     format!("{result}\n\n<skill-loaded name=\"{safe_name}\"/>")
 }
 
+fn declared_skill_tool_guidance(allowed_tools: &[String]) -> Option<String> {
+    let mut tools = astra_turn_core::tool_allowlist::normalize_tool_names(allowed_tools)
+        .into_iter()
+        .collect::<Vec<_>>();
+    if tools.is_empty() {
+        return None;
+    }
+    tools.sort();
+    Some(format!(
+        "Declared workflow tools: {}. Prefer this set for the skill's normal path. This is workflow guidance, not an authorization boundary; other available tools may still be used when needed for recovery or verification.",
+        tools
+            .iter()
+            .map(|tool| format!("`{tool}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
 // ─── Skill execution ─────────────────────────────────────────────────────────
 
 /// Activation effects from a skill invocation.
@@ -753,8 +771,9 @@ pub fn append_skill_loaded_marker(result: &str, skill_name: &str) -> String {
 pub struct SkillActivation {
     /// Model override for subsequent turns (e.g. `"claude-sonnet-4-20250514"`).
     pub model_override: Option<String>,
-    /// Tool allow-list — only these tools should be available.
-    /// Empty means no restriction (all tools allowed).
+    /// Tools declared by the skill for its normal workflow.
+    /// This is model guidance and nested-execution configuration, not a new
+    /// authorization boundary for the current turn. Empty means no guidance.
     pub allowed_tools: Vec<String>,
     /// Effort level override for subsequent turns.
     pub effort: Option<EffortLevel>,
@@ -1964,11 +1983,15 @@ fn execute_skill<'a>(
                 let mut output = format!(
                     "# Skill: {}\n\n\
                  You are now executing the **{}** skill. \
-                 Follow the instructions below carefully.\n\n\
-                 ---\n\n\
-                 {}",
-                    skill.name, skill.name, instructions
+                 Follow the instructions below carefully.",
+                    skill.name, skill.name
                 );
+                if let Some(guidance) = declared_skill_tool_guidance(&skill.allowed_tools) {
+                    output.push_str("\n\n");
+                    output.push_str(&guidance);
+                }
+                output.push_str("\n\n---\n\n");
+                output.push_str(&instructions);
 
                 if !task_hint.is_empty() {
                     output.push_str(&format!("\n\n---\n\n**Task context:** {}", task_hint));
@@ -4004,12 +4027,18 @@ mod tests {
             &SkillContext::default(),
         )
         .await;
-        // allowed_tools must NOT appear as restrictive text in the prompt
+        // The declaration is visible as workflow feedback, without turning a
+        // skill hint into a new authorization boundary.
         assert!(
             !r.output.contains("Allowed tools"),
             "skill output must not contain restrictive 'Allowed tools' hint"
         );
-        // activation carries allowed_tools for additive schema injection
+        assert!(
+            r.output
+                .contains("Declared workflow tools: `bash`, `read_file`")
+        );
+        assert!(r.output.contains("not an authorization boundary"));
+        // Activation retains the typed declaration for hosts and nested runs.
         let act = r.activation.unwrap();
         assert_eq!(act.allowed_tools, vec!["bash", "read_file"]);
         assert!(act.model_override.is_none());


### PR DESCRIPTION
## Summary

- carry CLI tool-call identity through typed invocation metadata instead of mutating provider-authored `task_board` arguments
- preserve stable task-create idempotency across sequential, parallel, retry, and speculative execution paths
- expose skill-declared workflow tools at the model boundary and require digest-backed session analysis

## Root cause

The CLI injected `_tool_call_id` into strict public `task_board` arguments. The generic schema validator correctly rejected the mutated payload before task routing, so retrying could never succeed. Runtime execution identity and public tool arguments had become two competing contracts.

The session also showed a separate feedback-path gap: `analyze-session` was auto-routed, but its declared workflow tools were not surfaced at the model boundary and its instructions did not prohibit substituting weaker reflection data for the journal digest.

## Design

- invocation identity remains out of band through `ToolInvocationMetadata`
- public task arguments stay schema-valid and transport payloads contain no runtime-private fields
- task-create idempotency derives from the typed invocation identity
- skill tool declarations are explicit model guidance; request policy remains the authorization boundary
- session metrics and causal claims require the structured digest
- mirrored project skill roots retain one shared instruction contract

## Verification

- `cargo check -p astra-cli`
- `cargo test -p astra-cli task_board_invocation_identity_stays_outside_public_schema_and_reaches_transport -- --nocapture`
- `cargo test -p astra-cli create_idempotency_uses_stable_runtime_execution_identity -- --nocapture`
- `cargo test -p astra-cli create_uses_call_identity_but_does_not_leak_private_args -- --nocapture`
- `cargo test -p astra-cli edge_tools::tests::task_tests -- --nocapture`
- `cargo test -p astra-runtime execute_skill_returns_activation_with_allowed_tools -- --nocapture`
- `cargo test -p astra-runtime prepare_turn_iteration_pre_routes_judged_skill_requests -- --nocapture`
- `cargo test -p astra-skills --test skill_diagnosis_contract -- --nocapture`
- `git diff --check`

## Scope notes

- strict validation remains authoritative; no compatibility alias was added for invalid arguments
- no hard stop was added for skill workflow divergence; the model gets explicit feedback while existing policy continues to govern authorization
- no `plans/` files or local credentials are included
