### PR TITLE
fix(runtime): preserve fanout cancellation truth

### DIFF
--- a/crates/astra-cli/src/cli/session/session_side_effects.rs
+++ b/crates/astra-cli/src/cli/session/session_side_effects.rs
@@ -221,9 +221,13 @@ pub(crate) fn build_bridge_pipeline_journal_events(
         ..Default::default()
     };
     for ratio in &prior_ratios {
-        stats.record_cache_read_share_observation(model_id, *ratio);
+        stats.record_cache_read_share_observation(model_id, "bridge_inprocess", *ratio);
     }
-    stats.record_cache_read_share_observation(model_id, feedback.cache_hit_ratio);
+    stats.record_cache_read_share_observation(
+        model_id,
+        "bridge_inprocess",
+        feedback.cache_hit_ratio,
+    );
 
     let feedback_evt = astra_turn_core::pipeline_journal::PipelineJournalEvent::from_feedback(
         turn, model_id, &feedback,
@@ -240,6 +244,7 @@ pub(crate) fn build_bridge_pipeline_journal_events(
     for alert in astra_turn_core::trace_alert::evaluate_alerts(
         turn,
         model_id,
+        "bridge_inprocess",
         &feedback,
         &stats,
         &astra_turn_core::recovery_state::RecoveryState::default(),

--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -2141,6 +2141,18 @@ impl ToolExecutor {
         if self.tool_has_runtime_binding_for_call(name, args) {
             return None;
         }
+        // Terminal fanout evidence is durable session data, not a live
+        // spawner mutation. Admit this one read action only when the requested
+        // group is actually recoverable from the current session journal.
+        if name == "agent_fanout"
+            && args.get("action").and_then(Value::as_str) == Some("get_results")
+            && let Some(group_id) = args.get("group_id").and_then(Value::as_str)
+            && self
+                .journal_fanout_task_output_snapshot(group_id, 0, 1)
+                .is_some()
+        {
+            return None;
+        }
         if self.tool_can_validate_without_runtime_binding(name, args) {
             return None;
         }
@@ -2155,6 +2167,15 @@ impl ToolExecutor {
     }
 
     fn tool_admission_denial(&self, name: &str, args: &Value) -> Option<EdgeToolRun> {
+        if name == "agent_fanout"
+            && args.get("action").and_then(Value::as_str) == Some("get_results")
+            && let Some(group_id) = args.get("group_id").and_then(Value::as_str)
+            && self
+                .journal_fanout_task_output_snapshot(group_id, 0, 1)
+                .is_some()
+        {
+            return None;
+        }
         // ── Phase 1: Structural binding (no locks) ───────────────────────
         //
         // First principles: "does this tool have an executor attached?" is
@@ -4031,6 +4052,7 @@ impl ToolExecutor {
         match self
             .fanout_group_task_output_snapshot(task_id, offset, max_bytes)
             .await
+            .or_else(|| self.journal_fanout_task_output_snapshot(task_id, offset, max_bytes))
         {
             Some(projection) => {
                 let observation_mode = match read_mode {
@@ -4174,6 +4196,127 @@ impl ToolExecutor {
                 total_lines: output.lines().count() as u64,
                 status,
                 output_ref: format!("agent_fanout:{}", group.group_id),
+            },
+        })
+    }
+
+    /// Recover a settled fanout after a new root turn no longer has the old
+    /// in-memory spawner binding. The journal is the durable producer record:
+    /// it contains immutable slot identity, terminal state, and any child
+    /// transcript evidence. This path is read-only and deliberately never
+    /// recreates a group or claims a live control handle.
+    fn journal_fanout_task_output_snapshot(
+        &self,
+        task_id: &str,
+        offset: u64,
+        max_bytes: usize,
+    ) -> Option<FanoutTaskOutputProjection> {
+        let session_id = self.active_session_id()?.trim().to_string();
+        let events = astra_services::session_journal::read_journal(&session_id).ok()?;
+        let mut recovered = Vec::new();
+        let mut group_id = None;
+        let mut target_count = 0usize;
+        for event in &events {
+            if event.event_type != astra_services::session_journal::JournalEventType::AgentSpawned {
+                continue;
+            }
+            let Some(metadata) = event.metadata.as_ref() else {
+                continue;
+            };
+            let Some(fanout_slot) = metadata.get("fanout_slot") else {
+                continue;
+            };
+            let Ok(slot) = serde_json::from_value::<
+                astra_turn_core::orchestration_fanout_group::AgentFanoutSlotIdentity,
+            >(fanout_slot.clone()) else {
+                continue;
+            };
+            let Some(agent_id) = metadata.get("agent_id").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(run_id) = metadata.get("run_id").and_then(Value::as_str) else {
+                continue;
+            };
+            if slot.group_id != task_id && agent_id != task_id && run_id != task_id {
+                continue;
+            }
+            group_id = Some(slot.group_id.clone());
+            target_count = target_count.max(slot.target_count);
+            let terminal = events.iter().rev().find_map(|candidate| {
+                (candidate.event_type
+                    == astra_services::session_journal::JournalEventType::AgentTerminated)
+                    .then_some(candidate.metadata.as_ref())
+                    .flatten()
+                    .filter(|meta| meta.get("run_id").and_then(Value::as_str) == Some(run_id))
+            });
+            let result = events.iter().rev().find_map(|candidate| {
+                let item = candidate.transcript_item.as_ref()?;
+                (item.run_id == run_id
+                    && item.message.get("role").and_then(Value::as_str) == Some("assistant"))
+                .then(|| item.message.get("content").and_then(Value::as_str))
+                .flatten()
+                .filter(|content| !content.trim().is_empty())
+            });
+            recovered.push(json!({
+                "slot_index": slot.slot_index,
+                "id": slot.slot_id,
+                "agent_id": agent_id,
+                "run_id": run_id,
+                "status": terminal.and_then(|meta| meta.get("status")).and_then(Value::as_str).unwrap_or("unknown_after_resume"),
+                "terminal_reason": terminal.and_then(|meta| meta.get("finish_reason")).and_then(Value::as_str),
+                "metrics_completeness": terminal.and_then(|meta| meta.get("metrics_completeness")).and_then(Value::as_str).unwrap_or("recorded"),
+                "result": result,
+            }));
+        }
+        let group_id = group_id?;
+        recovered.sort_by_key(|slot| {
+            slot.get("slot_index")
+                .and_then(Value::as_u64)
+                .unwrap_or(u64::MAX)
+        });
+        let all_terminal = recovered.iter().all(|slot| {
+            matches!(
+                slot.get("status").and_then(Value::as_str),
+                Some("completed" | "failed" | "cancelled" | "interrupted")
+            )
+        });
+        let all_completed = recovered
+            .iter()
+            .all(|slot| slot.get("status").and_then(Value::as_str) == Some("completed"));
+        let status = if all_terminal && all_completed {
+            WorkUnitStatus::Completed
+        } else {
+            WorkUnitStatus::CompletedWithIssues
+        };
+        let output = json!({
+            "type": "agent_fanout_group",
+            "group_id": group_id,
+            "title": group_id,
+            "status": status.as_str(),
+            "target_count": target_count,
+            "recovered_slots": recovered,
+            "recovery": {
+                "source": "session_journal",
+                "runtime_binding_required": false,
+                "task_output_call": format!("task_output(task_id='{group_id}')"),
+                "do_not_rerun_when_user_asks_for_results": true,
+            },
+            "hint": "Recovered from the durable session journal; this is a settled historical observation, not a live fanout control handle.",
+        }).to_string();
+        let start = output.floor_char_boundary((offset as usize).min(output.len()));
+        let end = output.floor_char_boundary((start + max_bytes).min(output.len()));
+        Some(FanoutTaskOutputProjection {
+            group_id: group_id.clone(),
+            revision: 1,
+            snapshot: BgTaskOutputSnapshot {
+                kind: "agent fanout".into(),
+                title: Some(group_id.clone()),
+                output: output[start..end].to_string(),
+                end_offset: end as u64,
+                total_bytes: output.len() as u64,
+                total_lines: output.lines().count() as u64,
+                status,
+                output_ref: format!("agent_fanout:{group_id}"),
             },
         })
     }
@@ -5566,8 +5709,17 @@ impl ToolExecutor {
                     }
                 }
                 "agent_fanout" => {
-                    agent_spawning::handle_agent_fanout_tool(args, self.spawn_context.as_ref())
-                        .await
+                    if self.spawn_context.is_none()
+                        && args.get("action").and_then(Value::as_str) == Some("get_results")
+                        && let Some(group_id) = args.get("group_id").and_then(Value::as_str)
+                        && let Some(projection) =
+                            self.journal_fanout_task_output_snapshot(group_id, 0, 65_536)
+                    {
+                        projection.snapshot.output
+                    } else {
+                        agent_spawning::handle_agent_fanout_tool(args, self.spawn_context.as_ref())
+                            .await
+                    }
                 }
                 // ── Consolidated session tool ──────────────────────────────
                 "session" => {
@@ -7209,6 +7361,78 @@ mod tests {
         assert_eq!(
             alias_fields.as_ref().unwrap()["requested_task_output_id"],
             child_id
+        );
+    }
+
+    #[tokio::test]
+    async fn task_output_recovers_terminal_fanout_from_journal_without_runtime_binding() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _guard = astra_services::session_journal::JournalDirGuard::new(tmp.path());
+        let session_id = "journal-fanout-recovery";
+        let writer = astra_services::session_journal::JournalWriter::new(session_id).unwrap();
+        let fanout_slot = serde_json::json!({
+            "group_id": "review-fanout",
+            "target_count": 1,
+            "slot_index": 0,
+            "slot_id": "review"
+        });
+        writer
+            .append(
+                &astra_services::session_journal::JournalEvent::agent_spawned_with_fanout(
+                    Some(session_id),
+                    "reviewer",
+                    "child-run",
+                    "parent-run",
+                    "general-purpose",
+                    "Review the change",
+                    None,
+                    false,
+                    Some(&fanout_slot),
+                    None,
+                ),
+            )
+            .unwrap();
+        writer
+            .append(
+                &astra_services::session_journal::JournalEvent::agent_terminated(
+                    Some(session_id),
+                    "reviewer",
+                    "child-run",
+                    "general-purpose",
+                    "cancelled",
+                    Some("user requested stop"),
+                    None,
+                    0,
+                    0,
+                    0,
+                    10,
+                    None,
+                ),
+            )
+            .unwrap();
+
+        let executor = test_executor().with_active_session_id(session_id);
+        let output = executor
+            .task_output(&serde_json::json!({"task_id": "review-fanout"}))
+            .await;
+        assert!(output.contains("session_journal"), "{output}");
+        assert!(output.contains("review-fanout"), "{output}");
+        assert!(output.contains("cancelled"), "{output}");
+        assert!(
+            !output.contains("Background task unavailable"),
+            "a durable group must not pretend it needs the vanished runtime binding: {output}"
+        );
+
+        let recovered = executor
+            .execute(
+                "agent_fanout",
+                &serde_json::json!({"action": "get_results", "group_id": "review-fanout"}),
+            )
+            .await;
+        assert!(recovered.contains("session_journal"), "{recovered}");
+        assert!(
+            !recovered.contains("multi-agent runtime is not connected"),
+            "durable get_results must not be rejected after the parent turn: {recovered}"
         );
     }
 

--- a/crates/astra-cli/src/tui/bg_task_rendering.rs
+++ b/crates/astra-cli/src/tui/bg_task_rendering.rs
@@ -942,7 +942,12 @@ pub(crate) fn render_background_task_rows_xml(
         } else {
             "completed"
         };
-        let live_control = if members
+        // Control availability is a property of the group lifecycle first.
+        // A child row can retain an old handle after it is terminal, but that
+        // never makes a settled fanout stoppable again.
+        let live_control = if active == 0 {
+            LiveControlState::StaleHandle
+        } else if members
             .iter()
             .any(|row| row.live_control == LiveControlState::Available)
         {
@@ -995,4 +1000,53 @@ pub(crate) fn render_background_task_rows_xml(
     }
     out.push_str("\n</background_tasks>");
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::bottom_pane::background_task_view::{
+        BackgroundTaskFanoutMembership, BackgroundTaskKind, BackgroundTaskRow,
+        BackgroundTaskRowInit, LiveControlState,
+    };
+
+    #[test]
+    fn terminal_fanout_never_advertises_live_control_from_stale_child_handles() {
+        let fanout = BackgroundTaskFanoutMembership {
+            group_id: "review".into(),
+            group_title: "Review".into(),
+            target_count: 2,
+            slot_index: 0,
+            slot_label: "one".into(),
+        };
+        let rows = vec![
+            BackgroundTaskRow::new(BackgroundTaskRowInit::new(
+                "agent-one",
+                BackgroundTaskKind::LocalAgent,
+                "cancelled",
+                10,
+                "one",
+            ))
+            .with_fanout(fanout.clone())
+            .with_live_control(LiveControlState::Available),
+            BackgroundTaskRow::new(BackgroundTaskRowInit::new(
+                "agent-two",
+                BackgroundTaskKind::LocalAgent,
+                "completed",
+                10,
+                "two",
+            ))
+            .with_fanout(BackgroundTaskFanoutMembership {
+                slot_index: 1,
+                slot_label: "two".into(),
+                ..fanout
+            })
+            .with_live_control(LiveControlState::Available),
+        ];
+
+        let xml = render_background_task_rows_xml(&rows);
+        assert!(xml.contains("status=\"completed_with_issues\""), "{xml}");
+        assert!(xml.contains("live_control=\"stale_handle\""), "{xml}");
+        assert!(!xml.contains("live_control=\"available\""), "{xml}");
+    }
 }

--- a/crates/astra-turn-core/src/pipeline/stats.rs
+++ b/crates/astra-turn-core/src/pipeline/stats.rs
@@ -203,14 +203,22 @@ impl ModelCacheReadShareStats {
     }
 }
 
+/// Stable in-memory key for a cache baseline. The unit separator avoids
+/// accidental ambiguity between model and execution-source names while keeping
+/// the persisted shape backward compatible as a string-keyed map.
+fn cache_read_share_scope_key(model: &str, source: &str) -> String {
+    format!("{}\u{1f}{}", model.trim(), source.trim())
+}
+
 /// Cross-turn accumulated statistics.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PipelineStats {
     pub turns_executed: u32,
     pub avg_cache_hit_ratio: f64,
-    /// Model-scoped prompt-cache read share. Provider/model cache namespaces
-    /// are not interchangeable; cross-model averages create false regressions.
+    /// Prompt-cache read share scoped by the provider model and execution
+    /// source. Cache namespaces and prompt shapes are not interchangeable
+    /// across either boundary; cross-source averages create false regressions.
     pub cache_read_share_by_model: HashMap<String, ModelCacheReadShareStats>,
     pub compact_events: Vec<CompactEvent>,
     pub cache_breaks: Vec<CacheBreakEvent>,
@@ -342,7 +350,7 @@ impl PipelineStats {
         let alpha = if self.turns_executed <= 1 { 1.0 } else { 0.1 };
         self.avg_cache_hit_ratio =
             (1.0 - alpha) * self.avg_cache_hit_ratio + alpha * feedback.cache_hit_ratio;
-        self.record_cache_read_share_observation(model, feedback.cache_hit_ratio);
+        self.record_cache_read_share_observation(model, source, feedback.cache_hit_ratio);
         let model = model.trim();
 
         // Feed response token estimator
@@ -362,19 +370,20 @@ impl PipelineStats {
         }
     }
 
-    pub fn model_cache_regression_baseline(&self, model: &str) -> Option<f64> {
+    pub fn model_cache_regression_baseline(&self, model: &str, source: &str) -> Option<f64> {
         self.cache_read_share_by_model
-            .get(model)
+            .get(&cache_read_share_scope_key(model, source))
             .and_then(ModelCacheReadShareStats::regression_baseline)
     }
 
-    pub fn record_cache_read_share_observation(&mut self, model: &str, value: f64) {
+    pub fn record_cache_read_share_observation(&mut self, model: &str, source: &str, value: f64) {
         let model = model.trim();
-        if model.is_empty() || !value.is_finite() {
+        let source = source.trim();
+        if model.is_empty() || source.is_empty() || !value.is_finite() {
             return;
         }
         self.cache_read_share_by_model
-            .entry(model.to_string())
+            .entry(cache_read_share_scope_key(model, source))
             .or_default()
             .record(value.clamp(0.0, 1.0));
     }

--- a/crates/astra-turn-core/src/trace_alert.rs
+++ b/crates/astra-turn-core/src/trace_alert.rs
@@ -33,6 +33,7 @@ pub struct TraceAlert {
 pub fn evaluate_alerts(
     turn: u32,
     model_id: &str,
+    execution_source: &str,
     feedback: &ContextFeedback,
     stats: &PipelineStats,
     recovery: &RecoveryState,
@@ -68,7 +69,7 @@ pub fn evaluate_alerts(
 
     // Rule 3: Cache regression against at least three prior observations for
     // the same model. Cache namespaces and reuse profiles are model-specific.
-    if let Some(session_avg) = stats.model_cache_regression_baseline(model_id) {
+    if let Some(session_avg) = stats.model_cache_regression_baseline(model_id, execution_source) {
         let recent_ratio = feedback.cache_hit_ratio;
         if session_avg - recent_ratio > 0.10 {
             alerts.push(TraceAlert {
@@ -153,7 +154,7 @@ mod tests {
         let f = make_feedback(0, 5000);
         let stats = PipelineStats::default();
         let recovery = RecoveryState::default();
-        let alerts = evaluate_alerts(2, "model-a", &f, &stats, &recovery);
+        let alerts = evaluate_alerts(2, "model-a", "test", &f, &stats, &recovery);
         assert!(alerts.iter().any(|a| a.rule == "cache_cold_start"));
     }
 
@@ -164,6 +165,7 @@ mod tests {
         let alerts = evaluate_alerts(
             3,
             "model-a",
+            "test",
             &f,
             &PipelineStats::default(),
             &RecoveryState::default(),
@@ -177,7 +179,7 @@ mod tests {
         let f = make_feedback(0, 5000);
         let stats = PipelineStats::default();
         let recovery = RecoveryState::default();
-        let alerts = evaluate_alerts(1, "model-a", &f, &stats, &recovery);
+        let alerts = evaluate_alerts(1, "model-a", "test", &f, &stats, &recovery);
         assert!(!alerts.iter().any(|a| a.rule == "cache_cold_start"));
     }
 
@@ -191,7 +193,7 @@ mod tests {
         };
         let recovery = RecoveryState::default();
 
-        let alerts = evaluate_alerts(5, "model-a", &f, &stats, &recovery);
+        let alerts = evaluate_alerts(5, "model-a", "test", &f, &stats, &recovery);
 
         assert!(
             alerts.is_empty(),
@@ -208,7 +210,7 @@ mod tests {
         }
         stats.record("model-a", "test", &f);
         let recovery = RecoveryState::default();
-        let alerts = evaluate_alerts(5, "model-a", &f, &stats, &recovery);
+        let alerts = evaluate_alerts(5, "model-a", "test", &f, &stats, &recovery);
         let alert = alerts
             .iter()
             .find(|alert| alert.rule == "cache_regression")
@@ -231,12 +233,37 @@ mod tests {
         let alerts = evaluate_alerts(
             5,
             "model-b",
+            "test",
             &model_b_feedback,
             &stats,
             &RecoveryState::default(),
         );
 
         assert!(!alerts.iter().any(|alert| alert.rule == "cache_regression"));
+    }
+
+    #[test]
+    fn cache_regression_does_not_compare_different_execution_sources() {
+        let mut stats = PipelineStats::default();
+        for _ in 0..4 {
+            stats.record("model-a", "root_agentic_loop", &make_feedback(900, 100));
+        }
+        let child_feedback = make_feedback(100, 900);
+        stats.record("model-a", "fanout_child", &child_feedback);
+
+        let alerts = evaluate_alerts(
+            5,
+            "model-a",
+            "fanout_child",
+            &child_feedback,
+            &stats,
+            &RecoveryState::default(),
+        );
+
+        assert!(
+            !alerts.iter().any(|alert| alert.rule == "cache_regression"),
+            "a fanout child has a distinct prompt/cache surface: {alerts:?}"
+        );
     }
 
     #[test]
@@ -250,7 +277,7 @@ mod tests {
         stats.turns_executed = 6;
         stats.record_compaction(2000);
         let recovery = RecoveryState::default();
-        let alerts = evaluate_alerts(7, "model-a", &f, &stats, &recovery);
+        let alerts = evaluate_alerts(7, "model-a", "test", &f, &stats, &recovery);
         assert!(alerts.iter().any(|a| a.rule == "compaction_cascade"));
     }
 
@@ -261,7 +288,7 @@ mod tests {
         let mut recovery = RecoveryState::default();
         recovery.record_ptl_error();
         recovery.record_ptl_error();
-        let alerts = evaluate_alerts(5, "model-a", &f, &stats, &recovery);
+        let alerts = evaluate_alerts(5, "model-a", "test", &f, &stats, &recovery);
         assert!(alerts.iter().any(|a| a.rule == "recovery_loop"));
         assert!(alerts.iter().any(|a| a.severity == AlertSeverity::Error));
     }
@@ -275,7 +302,7 @@ mod tests {
             ..Default::default()
         };
         let recovery = RecoveryState::default();
-        let alerts = evaluate_alerts(4, "model-a", &f, &stats, &recovery);
+        let alerts = evaluate_alerts(4, "model-a", "test", &f, &stats, &recovery);
         assert!(alerts.iter().any(|a| a.rule == "predictive_miss"));
     }
 }

--- a/crates/astra-turn-core/tests/context_pipeline_e2e.rs
+++ b/crates/astra-turn-core/tests/context_pipeline_e2e.rs
@@ -362,7 +362,7 @@ fn pipeline_trace_alerts_on_recovery() {
     let feedback = ContextFeedback::from_usage(0, 0, 5000, 100, false);
     let stats = PipelineStats::default();
 
-    let alerts = evaluate_alerts(5, "model-a", &feedback, &stats, &recovery);
+    let alerts = evaluate_alerts(5, "model-a", "test", &feedback, &stats, &recovery);
     assert!(
         alerts.iter().any(|a| a.rule == "recovery_loop"),
         "2 PTL errors should trigger recovery_loop alert"

--- a/crates/astra-turn-core/tests/pipeline_observability_phase13.rs
+++ b/crates/astra-turn-core/tests/pipeline_observability_phase13.rs
@@ -91,7 +91,7 @@ fn cascade_responder_emits_alert() {
 
     let feedback = ContextFeedback::from_usage(0, 800, 200, 300, false);
     let recovery = RecoveryState::default();
-    let alerts = evaluate_alerts(7, "model-a", &feedback, &stats, &recovery);
+    let alerts = evaluate_alerts(7, "model-a", "test", &feedback, &stats, &recovery);
 
     assert!(
         alerts.iter().any(|a| a.rule == "compaction_cascade"),

--- a/crates/runtime/src/orchestration/spawner.rs
+++ b/crates/runtime/src/orchestration/spawner.rs
@@ -2742,7 +2742,10 @@ impl DynamicAgentSpawner {
 
         // Emit agent_spawned journal event for unified timeline.
         if let Some(sid) = self.current_session_id() {
-            let evt = astra_services::session_journal::JournalEvent::agent_spawned(
+            let fanout_slot = fanout_slot
+                .as_ref()
+                .and_then(|slot| serde_json::to_value(slot).ok());
+            let evt = astra_services::session_journal::JournalEvent::agent_spawned_with_fanout(
                 Some(&sid),
                 &agent_id,
                 &run_id,
@@ -2751,6 +2754,7 @@ impl DynamicAgentSpawner {
                 &input.description,
                 run_config.model.as_deref(),
                 run_config.inherited_prefix.is_some(),
+                fanout_slot.as_ref(),
                 run_config.execution_metadata.as_ref(),
             );
             let writer = match context.trace_context.as_ref() {
@@ -3399,7 +3403,14 @@ impl DynamicAgentSpawner {
             .elapsed()
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
-        let event = astra_services::session_journal::JournalEvent::agent_terminated(
+        // Forced cancellation aborts the executor future before it can return
+        // its terminal counter snapshot. Preserve the numeric fields for wire
+        // shape stability, but explicitly mark them unknown rather than
+        // allowing consumers to mistake their default zeroes for observed
+        // work. Normal finalization receives a complete SpawnRunResult.
+        let metrics_completeness =
+            (status == "cancelled").then_some("unknown_after_forced_cancellation");
+        let event = astra_services::session_journal::JournalEvent::agent_terminated_with_metric_completeness(
             Some(sid.as_str()),
             &state.agent_id,
             &state.run_id,
@@ -3411,6 +3422,7 @@ impl DynamicAgentSpawner {
             state.metrics.prompt_tokens,
             state.metrics.completion_tokens,
             duration_ms,
+            metrics_completeness,
             state.execution_metadata.as_ref(),
         );
         if let Err(e) = writer.append(&event) {
@@ -7146,6 +7158,44 @@ mod tests {
                 "Agent cancelled: turn budget exhausted".to_string()
             )],
             "shutdown aggregation must surface cancellation instead of silently dropping it"
+        );
+    }
+
+    #[tokio::test]
+    async fn forced_cancellation_marks_default_metrics_as_unknown_in_journal() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _guard = astra_services::session_journal::JournalDirGuard::new(tmp.path());
+        let factory = BlockingExecutorFactory::new();
+        let spawner = DynamicAgentSpawner::new(mock_router())
+            .with_session("cancel-metrics".to_string())
+            .with_executor(factory as Arc<dyn SpawnAgentExecutor>);
+
+        let launched = spawner
+            .spawn(make_bg_input(), &make_bg_context())
+            .await
+            .unwrap();
+        let agent_id = match launched {
+            SpawnAgentOutput::Launched { agent_id, .. } => agent_id,
+            other => panic!("expected Launched, got {other:?}"),
+        };
+        assert!(spawner.cancel_agent(&agent_id, "user cancelled").await);
+
+        let events = astra_services::session_journal::read_journal("cancel-metrics").unwrap();
+        let terminated = events
+            .iter()
+            .find(|event| {
+                event.event_type
+                    == astra_services::session_journal::JournalEventType::AgentTerminated
+            })
+            .expect("cancellation must persist a terminal event");
+        assert_eq!(
+            terminated
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("metrics_completeness"))
+                .and_then(serde_json::Value::as_str),
+            Some("unknown_after_forced_cancellation"),
+            "default counters must never be interpreted as measured cancellation work"
         );
     }
 

--- a/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -1539,6 +1539,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                 let alerts = astra_turn_core::trace_alert::evaluate_alerts(
                     turn,
                     model_id,
+                    "agentic_loop",
                     &feedback,
                     &pipeline_sess.stats,
                     &pipeline_sess.recovery,

--- a/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/crates/runtime/src/turn/bridge/inprocess.rs
@@ -4301,6 +4301,7 @@ impl InProcessChatTurnBridge {
                     for alert in astra_turn_core::trace_alert::evaluate_alerts(
                         current_turn,
                         capture_model,
+                        BRIDGE_CACHE_SOURCE,
                         &feedback,
                         &bridge_pipeline_baseline.stats,
                         &astra_turn_core::recovery_state::RecoveryState::default(),

--- a/crates/services/src/session_journal.rs
+++ b/crates/services/src/session_journal.rs
@@ -5138,6 +5138,43 @@ impl JournalEvent {
         evt
     }
 
+    /// Spawn event with the immutable fanout slot identity needed to recover a
+    /// group after the parent turn's in-memory runtime binding has gone away.
+    #[allow(clippy::too_many_arguments)]
+    pub fn agent_spawned_with_fanout(
+        session_id: Option<&str>,
+        agent_id: &str,
+        run_id: &str,
+        parent_run_id: &str,
+        agent_type: &str,
+        description: &str,
+        model: Option<&str>,
+        inherit_prefix: bool,
+        fanout_slot: Option<&serde_json::Value>,
+        execution_metadata: Option<&serde_json::Value>,
+    ) -> Self {
+        let mut event = Self::agent_spawned(
+            session_id,
+            agent_id,
+            run_id,
+            parent_run_id,
+            agent_type,
+            description,
+            model,
+            inherit_prefix,
+            execution_metadata,
+        );
+        if let Some(fanout_slot) = fanout_slot
+            && let Some(metadata) = event
+                .metadata
+                .as_mut()
+                .and_then(serde_json::Value::as_object_mut)
+        {
+            metadata.insert("fanout_slot".to_string(), fanout_slot.clone());
+        }
+        event
+    }
+
     /// Agent terminated event — persists final state of a spawned agent.
     #[allow(clippy::too_many_arguments)]
     pub fn agent_terminated(
@@ -5152,6 +5189,41 @@ impl JournalEvent {
         prompt_tokens: u64,
         completion_tokens: u64,
         duration_ms: u64,
+        execution_metadata: Option<&serde_json::Value>,
+    ) -> Self {
+        Self::agent_terminated_with_metric_completeness(
+            session_id,
+            agent_id,
+            run_id,
+            agent_type,
+            status,
+            finish_reason,
+            turns_completed,
+            tool_calls,
+            prompt_tokens,
+            completion_tokens,
+            duration_ms,
+            None,
+            execution_metadata,
+        )
+    }
+
+    /// Persist a terminal spawned-agent fact without treating unavailable
+    /// cancellation-time counters as measured zeroes.
+    #[allow(clippy::too_many_arguments)]
+    pub fn agent_terminated_with_metric_completeness(
+        session_id: Option<&str>,
+        agent_id: &str,
+        run_id: &str,
+        agent_type: &str,
+        status: &str,
+        finish_reason: Option<&str>,
+        turns_completed: Option<u32>,
+        tool_calls: u32,
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        duration_ms: u64,
+        metrics_completeness: Option<&str>,
         execution_metadata: Option<&serde_json::Value>,
     ) -> Self {
         let mut evt = Self::base(JournalEventType::AgentTerminated, session_id);
@@ -5170,6 +5242,13 @@ impl JournalEvent {
         }
         if let Some(finish_reason) = finish_reason.filter(|reason| !reason.is_empty()) {
             metadata["finish_reason"] = serde_json::Value::String(finish_reason.to_string());
+        }
+        if let Some(metrics_completeness) = metrics_completeness
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            metadata["metrics_completeness"] =
+                serde_json::Value::String(metrics_completeness.to_string());
         }
         merge_execution_boundary_metadata(&mut metadata, execution_metadata);
         evt.metadata = Some(metadata);


### PR DESCRIPTION
## Summary
- persist fanout slot identity and recover `get_results`/`task_output` from the session journal after a parent turn loses its in-memory runtime binding
- distinguish unknown forced-cancellation metrics from measured zeroes and prevent terminal fanouts from advertising live controls
- scope prompt-cache regression baselines by model and execution source

## Verification
- `make check`
- `make test-offline`
- DeepSeek Flash harness: `fanout_completion_truth` with `--force-model deepseek-v4-flash` (passed; 3/3 slot evidence, judger 1.00)