### PR TITLE
fix(runtime): harden stream and tool truth boundaries

### DIFF
--- a/crates/astra-cli/src/cli/turn/turn_success.rs
+++ b/crates/astra-cli/src/cli/turn/turn_success.rs
@@ -426,6 +426,8 @@ fn apply_turn_success_primary_sync(
         return primary_commit;
     }
 
+    persist_tool_health_after_durable_turn(state, profile);
+
     if let Some(session_id) = result_session_id.as_deref() {
         persist_profile_last_session_or_warn(
             profile,
@@ -455,6 +457,26 @@ fn apply_turn_success_primary_sync(
     primary_commit
 }
 
+/// Cross-session learning is a derived snapshot: it must never survive a
+/// failed primary turn, and a snapshot write failure must never roll back a
+/// turn that is already durable in its journal.
+fn persist_tool_health_after_durable_turn(state: &mut SessionState, profile: Option<&str>) {
+    let profile_name = profile.unwrap_or("default");
+    if let Err(error) = astra_turn_core::tool_health_persistence::save_learning_state(
+        profile_name,
+        &state.tool_health_entries,
+    ) {
+        let message = format!("persist tool-health snapshot for profile `{profile_name}`: {error}");
+        tracing::warn!(
+            target: "astra_cli::turn_settlement",
+            profile = profile_name,
+            error = %error,
+            "turn is durable but cross-session tool-health persistence failed"
+        );
+        state.session_persistence_error = Some(message);
+    }
+}
+
 #[cfg(test)]
 fn apply_turn_success_sync(
     state: &mut SessionState,
@@ -481,9 +503,10 @@ mod tests {
     use crate::cli::turn::turn_post_commit::{
         apply_turn_post_commit_completion, execute_turn_post_commit_job,
     };
-    use crate::tests::heavy_checkpoint_with_runtime_state;
+    use crate::tests::{HomeGuard, heavy_checkpoint_with_runtime_state};
     use astra_runtime::tool_registry::ToolRegistry;
     use astra_services::session_journal;
+    use astra_turn_core::tool_health_persistence::{ToolHealthEntry, load_tool_health};
     use std::time::Instant;
 
     #[test]
@@ -548,6 +571,44 @@ mod tests {
         apply_turn_success(&mut state, None, "apply the fix", result, Instant::now());
 
         assert_eq!(state.recent_tools, vec!["str_replace".to_string()]);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn apply_turn_success_persists_tool_health_after_the_primary_turn_is_durable() {
+        let (_sessions, _sessions_guard) = crate::tests::isolated_sessions_dir();
+        let _home = HomeGuard::temp();
+        let profile = format!("turn-success-health-{}", uuid::Uuid::new_v4());
+        let sid = format!("turn-success-health-durable-{}", uuid::Uuid::new_v4());
+        let mut state = SessionState::default();
+        let mut result = crate::tests::stub_stream_result("Done.");
+        result.session_id = Some(sid.clone());
+        result.tool_health_export = vec![ToolHealthEntry {
+            name: "git".to_string(),
+            total_calls: 7,
+            total_failures: 2,
+            input_validation_failures: 3,
+            failure_rate: 2.0 / 7.0,
+            last_updated_epoch: 42,
+            recent_outcomes: Vec::new(),
+        }];
+
+        apply_turn_success(
+            &mut state,
+            Some(&profile),
+            "review the change",
+            result,
+            Instant::now(),
+        );
+
+        assert_eq!(state.tool_health_entries.len(), 1);
+        assert!(state.session_persistence_error.is_none());
+        assert!(
+            session_journal::journal_file_path(&sid).is_file(),
+            "the primary turn must be durable before its health snapshot is saved"
+        );
+        let restored = load_tool_health(&profile);
+        assert_eq!(restored, state.tool_health_entries);
     }
 
     #[test]
@@ -783,6 +844,41 @@ mod tests {
                 .unwrap_or_default()
                 .contains("append turn event")
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn failed_primary_turn_does_not_persist_tool_health_snapshot() {
+        let (_sessions, _sessions_guard) = crate::tests::isolated_sessions_dir();
+        let _home = HomeGuard::temp();
+        let profile = format!("turn-success-health-failed-{}", uuid::Uuid::new_v4());
+        let sid = format!("turn-success-health-journal-fail-{}", uuid::Uuid::new_v4());
+        std::fs::create_dir_all(session_journal::journal_file_path(&sid)).unwrap();
+
+        let mut state = SessionState::default();
+        let mut result = crate::tests::stub_stream_result("new response");
+        result.session_id = Some(sid);
+        result.tool_health_export = vec![ToolHealthEntry {
+            name: "git".to_string(),
+            total_calls: 1,
+            total_failures: 1,
+            input_validation_failures: 0,
+            failure_rate: 1.0,
+            last_updated_epoch: 7,
+            recent_outcomes: Vec::new(),
+        }];
+
+        let outcome = apply_turn_success_sync(
+            &mut state,
+            Some(&profile),
+            "new question",
+            result,
+            Instant::now(),
+        );
+
+        assert!(!outcome.turn_persisted);
+        assert!(state.tool_health_entries.is_empty());
+        assert!(load_tool_health(&profile).is_empty());
     }
 
     #[tokio::test]

--- a/crates/astra-text-utils/src/semantic_dedup.rs
+++ b/crates/astra-text-utils/src/semantic_dedup.rs
@@ -232,14 +232,34 @@ fn semantic_git_key(args: &Value) -> Option<String> {
             let base_ref = arg_str(args, "base_ref").unwrap_or("");
             let staged = arg_bool(args, "staged").unwrap_or(false);
             let stat_only = arg_bool(args, "stat_only").unwrap_or(false);
-            let path = arg_str(args, "path").unwrap_or("");
+            let mut path_filters: Vec<String> = args
+                .get("paths")
+                .and_then(Value::as_array)
+                .map(|paths| {
+                    paths
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .map(normalize_path)
+                        .collect()
+                })
+                .unwrap_or_else(|| {
+                    arg_str(args, "path")
+                        .map(normalize_path)
+                        .into_iter()
+                        .collect()
+                });
+            // Pathspec order does not affect diff output. Canonicalizing the
+            // set prevents equivalent multi-file reviews from missing cache
+            // hits while preserving every output-shaping filter.
+            path_filters.sort();
+            path_filters.dedup();
             Some(format!(
-                "git:diff:{}..{}:staged={}:stat_only={}:path={}",
+                "git:diff:{}..{}:staged={}:stat_only={}:paths={}",
                 base_ref,
                 git_ref,
                 staged,
                 stat_only,
-                normalize_path(path)
+                serde_json::to_string(&path_filters).expect("path filters serialize")
             ))
         }
         "log" => {
@@ -318,17 +338,17 @@ fn semantic_bash_git_key(args: &Value) -> Option<String> {
             Some("git:status".to_string())
         }
         ["git", "diff"] | ["git", "diff", "HEAD"] => {
-            Some("git:diff:..HEAD:staged=false:stat_only=false:path=".to_string())
+            Some("git:diff:..HEAD:staged=false:stat_only=false:paths=[]".to_string())
         }
         ["git", "diff", "--stat"] => {
-            Some("git:diff:..HEAD:staged=false:stat_only=true:path=".to_string())
+            Some("git:diff:..HEAD:staged=false:stat_only=true:paths=[]".to_string())
         }
         ["git", "diff", "--cached"] | ["git", "diff", "--staged"] => {
-            Some("git:diff:..HEAD:staged=true:stat_only=false:path=".to_string())
+            Some("git:diff:..HEAD:staged=true:stat_only=false:paths=[]".to_string())
         }
         ["git", "diff", "--", path] => Some(format!(
-            "git:diff:..HEAD:staged=false:stat_only=false:path={}",
-            normalize_path(path)
+            "git:diff:..HEAD:staged=false:stat_only=false:paths={}",
+            serde_json::to_string(&vec![normalize_path(path)]).expect("path filter serializes")
         )),
         _ => None,
     }
@@ -1038,6 +1058,19 @@ mod tests {
         assert_ne!(
             k1, k2,
             "path-scoped diff must not share a semantic cache key with repo-wide diff"
+        );
+    }
+
+    #[test]
+    fn git_action_diff_multiple_path_filters_differ_from_repo_wide_diff() {
+        let filtered = semantic_call_key(
+            "git",
+            &json!({"action": "diff", "paths": ["src/a.rs", "src/b.rs"]}),
+        );
+        let repository_wide = semantic_call_key("git", &json!({"action": "diff"}));
+        assert_ne!(
+            filtered, repository_wide,
+            "multi-path diff filters must be part of the semantic cache key"
         );
     }
 

--- a/crates/astra-tools/src/git_gix.rs
+++ b/crates/astra-tools/src/git_gix.rs
@@ -305,6 +305,63 @@ fn optional_exact_string<'a>(
     Ok(Some(value))
 }
 
+/// Parse the canonical multi-path filter shape without accepting shell-like
+/// whitespace splitting. A file name containing spaces remains one string;
+/// callers that need more than one filter must use the JSON array explicitly.
+fn optional_exact_string_array<'a>(
+    args: &'a Value,
+    field: &str,
+) -> Result<Option<Vec<&'a str>>, GitRequestValidationError> {
+    let Some(value) = args.get(field) else {
+        return Ok(None);
+    };
+    let Some(values) = value.as_array() else {
+        return Err(GitRequestValidationError::invalid_arguments(format!(
+            "Error: git field `{field}` must be a non-empty array of exact strings"
+        )));
+    };
+    if values.is_empty() {
+        return Err(GitRequestValidationError::invalid_arguments(format!(
+            "Error: git field `{field}` must be a non-empty array of exact strings"
+        )));
+    }
+
+    let mut parsed = Vec::with_capacity(values.len());
+    for value in values {
+        let Some(value) = value.as_str() else {
+            return Err(GitRequestValidationError::invalid_arguments(format!(
+                "Error: git field `{field}` must be a non-empty array of exact strings"
+            )));
+        };
+        if value.is_empty() || value.trim() != value || value.chars().any(char::is_control) {
+            return Err(GitRequestValidationError::invalid_arguments(format!(
+                "Error: git field `{field}` must be a non-empty array of exact strings"
+            )));
+        }
+        parsed.push(value);
+    }
+    Ok(Some(parsed))
+}
+
+/// Resolve and validate the one canonical diff filter shape. This is used by
+/// the executor too, because unit and embedded callers can bypass the tool
+/// registry's structural validation.
+fn diff_path_filters<'a>(args: &'a Value, project_root: &Path) -> Result<Vec<&'a str>, String> {
+    let path = optional_exact_string(args, "path").map_err(|error| error.message)?;
+    let paths = optional_exact_string_array(args, "paths").map_err(|error| error.message)?;
+    if path.is_some() && paths.is_some() {
+        return Err(
+            "Error: git(action=diff) accepts either `path` or `paths`, not both".to_string(),
+        );
+    }
+    let filters = paths.unwrap_or_else(|| path.into_iter().collect());
+    for filter in &filters {
+        reject_path_traversal(filter, project_root)?;
+        validate_diff_path_exists(project_root, filter)?;
+    }
+    Ok(filters)
+}
+
 fn required_exact_string<'a>(
     args: &'a Value,
     field: &str,
@@ -331,8 +388,23 @@ pub fn validate_git_request(
         .map_err(|error| GitRequestValidationError::invalid_arguments(format!("Error: {error}")))?;
 
     let path = optional_exact_string(args, "path")?;
+    let paths = optional_exact_string_array(args, "paths")?;
     let file = optional_exact_string(args, "file")?;
-    for candidate in [path, file].into_iter().flatten() {
+    if path.is_some() && paths.is_some() {
+        return Err(GitRequestValidationError::invalid_arguments(
+            "Error: git(action=diff) accepts either `path` or `paths`, not both",
+        ));
+    }
+    if paths.is_some() && action != crate::git_tool_contract::GitAction::Diff {
+        return Err(GitRequestValidationError::invalid_arguments(
+            "Error: git field `paths` is only valid for git(action=diff)",
+        ));
+    }
+    for candidate in [path, file]
+        .into_iter()
+        .flatten()
+        .chain(paths.iter().flatten().copied())
+    {
         reject_path_traversal(candidate, project_root)
             .map_err(GitRequestValidationError::invalid_arguments)?;
     }
@@ -359,7 +431,7 @@ pub fn validate_git_request(
                     "Error: git(action=diff) accepts either `staged=true` or `ref`, not both",
                 ));
             }
-            if let Some(path) = path {
+            for path in path.into_iter().chain(paths.into_iter().flatten()) {
                 validate_diff_path_exists(project_root, path)
                     .map_err(GitRequestValidationError::missing_path)?;
             }
@@ -1362,18 +1434,13 @@ fn diff_stat_cli(project_root: &Path, args: &Value, limit: usize) -> String {
     let staged = args.get("staged").and_then(Value::as_bool).unwrap_or(false);
     let git_ref = args.get("ref").and_then(Value::as_str);
     let base_ref = args.get("base_ref").and_then(Value::as_str);
-    let path_filter = args.get("path").and_then(Value::as_str);
+    let path_filters = match diff_path_filters(args, project_root) {
+        Ok(filters) => filters,
+        Err(error) => return error,
+    };
 
     if staged && git_ref.is_some() {
         return "Error: git(action=diff): use either staged:true or ref, not both".to_string();
-    }
-    if let Some(p) = path_filter {
-        if let Err(e) = reject_path_traversal(p, project_root) {
-            return e;
-        }
-        if let Err(e) = validate_diff_path_exists(project_root, p) {
-            return e;
-        }
     }
 
     let mut parts: Vec<String> = vec!["diff".into()];
@@ -1387,16 +1454,16 @@ fn diff_stat_cli(project_root: &Path, args: &Value, limit: usize) -> String {
         parts.push("--cached".into());
     } else if let Some(r) = git_ref {
         parts.push(r.to_string());
-        if path_filter.is_none() {
+        if path_filters.is_empty() {
             parts.push("HEAD".into());
         }
     } else {
         parts.push("HEAD".into());
     }
     parts.extend(["--stat".into(), "--no-color".into()]);
-    if let Some(p) = path_filter {
+    if !path_filters.is_empty() {
         parts.push("--".into());
-        parts.push(p.to_string());
+        parts.extend(path_filters.iter().map(|path| (*path).to_string()));
     }
 
     let cmd_refs: Vec<&str> = parts.iter().map(|s| s.as_str()).collect();
@@ -1426,15 +1493,10 @@ pub fn diff(project_root: &Path, args: &Value, pressure: f64, aggregate_bytes: u
     let staged = args.get("staged").and_then(Value::as_bool).unwrap_or(false);
     let git_ref = args.get("ref").and_then(Value::as_str);
     let base_ref = args.get("base_ref").and_then(Value::as_str);
-    let path_filter = args.get("path").and_then(Value::as_str);
-    if let Some(p) = path_filter {
-        if let Err(e) = reject_path_traversal(p, project_root) {
-            return e;
-        }
-        if let Err(e) = validate_diff_path_exists(project_root, p) {
-            return e;
-        }
-    }
+    let path_filters = match diff_path_filters(args, project_root) {
+        Ok(filters) => filters,
+        Err(error) => return error,
+    };
 
     // Range diff: base_ref..ref (e.g., HEAD~5..HEAD)
     if let Some(base) = base_ref {
@@ -1443,11 +1505,9 @@ pub fn diff(project_root: &Path, args: &Value, pressure: f64, aggregate_bytes: u
             Err(error) => return error,
         };
         let mut cli_args = vec!["diff", &range, "--no-ext-diff", "--no-color"];
-        let path_owned;
-        if let Some(p) = path_filter {
+        if !path_filters.is_empty() {
             cli_args.push("--");
-            path_owned = p.to_string();
-            cli_args.push(&path_owned);
+            cli_args.extend(path_filters.iter().copied());
         }
         return diff_via_git_cli_or_error(project_root, &cli_args, limit);
     }
@@ -1474,35 +1534,36 @@ pub fn diff(project_root: &Path, args: &Value, pressure: f64, aggregate_bytes: u
                 );
             }
             let mut cli_args = vec!["diff", ref_str, "--no-ext-diff", "--no-color"];
-            if let Some(p) = path_filter {
+            if !path_filters.is_empty() {
                 cli_args.push("--");
-                cli_args.push(p);
+                cli_args.extend(path_filters.iter().copied());
             }
             return diff_via_git_cli_or_error(project_root, &cli_args, limit);
         }
-        // With path filter, use CLI for tree-to-tree as well
-        if let Some(p) = path_filter {
-            match diff_via_git_cli_result(
-                project_root,
-                &["diff", ref_str, "--no-ext-diff", "--no-color", "--", p],
-                limit,
-            )
-            .output_or_else(|| diff_tree_to_tree_str(&repo, ref_str, limit))
-            {
-                Ok(result) => return result,
-                Err(error) => return error,
-            }
+        // gix's tree fallback cannot apply pathspec filtering. Preserve the
+        // requested scope by using the CLI result directly whenever filters
+        // are present instead of silently widening the diff.
+        if !path_filters.is_empty() {
+            let mut cli_args = vec!["diff", ref_str, "--no-ext-diff", "--no-color", "--"];
+            cli_args.extend(path_filters.iter().copied());
+            return diff_via_git_cli_or_error(project_root, &cli_args, limit);
         }
         return diff_tree_to_tree_str(&repo, ref_str, limit);
     }
 
     // If staged, do index-to-HEAD diff
     if staged {
-        let cli_args: Vec<&str> = if let Some(p) = path_filter {
-            vec!["diff", "--cached", "--no-ext-diff", "--no-color", "--", p]
-        } else {
-            vec!["diff", "--cached", "--no-ext-diff", "--no-color"]
-        };
+        let mut cli_args = vec!["diff", "--cached", "--no-ext-diff", "--no-color"];
+        if !path_filters.is_empty() {
+            cli_args.push("--");
+            cli_args.extend(path_filters.iter().copied());
+            let result = diff_via_git_cli_or_error(project_root, &cli_args, limit);
+            return if result == "No changes" {
+                "No staged changes".to_string()
+            } else {
+                result
+            };
+        }
         let result = match diff_via_git_cli_result(project_root, &cli_args, limit)
             .output_or_else(|| diff_index_to_head(&repo, limit))
         {
@@ -1517,11 +1578,12 @@ pub fn diff(project_root: &Path, args: &Value, pressure: f64, aggregate_bytes: u
 
     // Default: show full local patch vs HEAD so review flows don't need to fall
     // back to bash just to recover actual diff hunks from summary-only output.
-    let cli_args: Vec<&str> = if let Some(p) = path_filter {
-        vec!["diff", "HEAD", "--no-ext-diff", "--no-color", "--", p]
-    } else {
-        vec!["diff", "HEAD", "--no-ext-diff", "--no-color"]
-    };
+    let mut cli_args = vec!["diff", "HEAD", "--no-ext-diff", "--no-color"];
+    if !path_filters.is_empty() {
+        cli_args.push("--");
+        cli_args.extend(path_filters.iter().copied());
+        return diff_via_git_cli_or_error(project_root, &cli_args, limit);
+    }
     match diff_via_git_cli_result(project_root, &cli_args, limit)
         .output_or_else(|| diff_worktree(&repo, limit))
     {
@@ -2949,6 +3011,22 @@ mod tests {
     }
 
     #[test]
+    fn git_request_validation_rejects_ambiguous_single_and_multiple_diff_paths() {
+        let dir = TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join("one.rs"), "one\n").unwrap();
+        std::fs::write(dir.path().join("two.rs"), "two\n").unwrap();
+
+        let error = validate_git_request(
+            dir.path(),
+            &json!({"action": "diff", "path": "one.rs", "paths": ["two.rs"]}),
+        )
+        .expect_err("one canonical path field must be selected");
+
+        assert_eq!(error.evidence.kind, astra_core::ErrorKind::ToolInvalidArgs);
+        assert!(error.message.contains("either `path` or `paths`"));
+    }
+
+    #[test]
     fn reject_path_traversal_allows_plain_relative_under_root() {
         let dir = TempDir::new().expect("tempdir");
         let root = dir.path();
@@ -3345,6 +3423,59 @@ mod tests {
         assert!(
             !result.starts_with("Error:"),
             "default diff should work: {result}"
+        );
+    }
+
+    #[test]
+    fn git_dispatch_diff_limits_output_to_all_requested_paths() {
+        let dir = init_temp_repo();
+        let root = dir.path();
+        for name in ["first.txt", "second.txt", "excluded.txt"] {
+            std::fs::write(root.join(name), format!("initial {name}\n")).unwrap();
+        }
+        run_git(root, &["add", "first.txt", "second.txt", "excluded.txt"]);
+        run_git(root, &["commit", "-m", "add diff filter fixtures"]);
+        for name in ["first.txt", "second.txt", "excluded.txt"] {
+            std::fs::write(root.join(name), format!("changed {name}\n")).unwrap();
+        }
+
+        let outcome = git_dispatch(
+            root,
+            &json!({"action": "diff", "paths": ["first.txt", "second.txt"]}),
+        );
+        assert!(!outcome.is_error, "{}", outcome.output);
+        let result = outcome.output;
+
+        assert!(result.contains("a/first.txt"), "{result}");
+        assert!(result.contains("a/second.txt"), "{result}");
+        assert!(
+            !result.contains("excluded.txt"),
+            "multi-path diff must not widen to unrequested files: {result}"
+        );
+
+        let stat_outcome = git_dispatch(
+            root,
+            &json!({
+                "action": "diff",
+                "stat_only": true,
+                "paths": ["first.txt", "second.txt"]
+            }),
+        );
+        assert!(!stat_outcome.is_error, "{}", stat_outcome.output);
+        assert!(
+            stat_outcome.output.contains("first.txt"),
+            "{}",
+            stat_outcome.output
+        );
+        assert!(
+            stat_outcome.output.contains("second.txt"),
+            "{}",
+            stat_outcome.output
+        );
+        assert!(
+            !stat_outcome.output.contains("excluded.txt"),
+            "multi-path diff stat must not widen to unrequested files: {}",
+            stat_outcome.output
         );
     }
 

--- a/crates/astra-tools/src/schemas.rs
+++ b/crates/astra-tools/src/schemas.rs
@@ -1029,7 +1029,13 @@ fn all_tool_schemas_core() -> Vec<Value> {
                         },
                         "path": {
                             "type": "string",
-                            "description": "Repository-relative file or directory path. Used by: diff, log, blame, checkout_file, contributors."
+                            "description": "Repository-relative file or directory path. Used by: diff (one filter only), log, blame, checkout_file, contributors. For a diff over more than one path, use `paths`; never concatenate multiple paths into this string."
+                        },
+                        "paths": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "minItems": 1,
+                            "description": "Canonical multi-path filter for git(action=diff) only. Pass one repository-relative path per array item (for example [\"src/a.rs\", \"src/b.rs\"]); mutually exclusive with `path`."
                         },
                         "file": {
                             "type": "string",
@@ -2249,6 +2255,27 @@ mod tests {
         );
         validate_tool_arguments("git", &json!({"action": "diff", "stat_only": true}))
             .expect("advertised stat_only diff must validate");
+    }
+
+    #[test]
+    fn git_schema_exposes_canonical_multi_path_diff_filters() {
+        let schemas = all_tool_schemas();
+        let git = find_schema(&schemas, "git").expect("git schema");
+        assert_eq!(
+            git.pointer("/function/parameters/properties/paths/type")
+                .and_then(Value::as_str),
+            Some("array")
+        );
+        validate_tool_arguments(
+            "git",
+            &json!({
+                "action": "diff",
+                "base_ref": "main",
+                "ref": "HEAD",
+                "paths": ["src/one.rs", "src/two.rs"]
+            }),
+        )
+        .expect("advertised canonical multi-path diff filters must validate");
     }
 
     #[test]

--- a/crates/astra-turn-core/src/sse/stream_host.rs
+++ b/crates/astra-turn-core/src/sse/stream_host.rs
@@ -418,6 +418,7 @@ pub async fn consume_sse_stream_cancellable<H: SseStreamHost>(
                 break;
             }
         };
+        let mut terminal_marker_seen = false;
         for event_str in event_blocks {
             let _ = process_sse_event_block(
                 &event_str,
@@ -428,6 +429,10 @@ pub async fn consume_sse_stream_cancellable<H: SseStreamHost>(
                 &mut reported_session_id,
             )
             .await;
+            if accum.stream_complete {
+                terminal_marker_seen = true;
+                break;
+            }
         }
 
         // Parallel tool calls often arrive as several adjacent SSE
@@ -437,7 +442,7 @@ pub async fn consume_sse_stream_cancellable<H: SseStreamHost>(
         // requests that are already classified as concurrency-safe, and only
         // for a tiny window; side-effectful tools still execute inline to avoid
         // the bridge/result deadlock guarded by `tool_request_executes_inline_not_deferred`.
-        while pending_is_coalescible_tool_batch(&pending) {
+        while !terminal_marker_seen && pending_is_coalescible_tool_batch(&pending) {
             let next = if let Some(token) = cancel_token {
                 tokio::select! {
                     biased;
@@ -483,8 +488,12 @@ pub async fn consume_sse_stream_cancellable<H: SseStreamHost>(
                             &mut reported_session_id,
                         )
                         .await;
+                        if accum.stream_complete {
+                            terminal_marker_seen = true;
+                            break;
+                        }
                     }
-                    if saw_event && !all_events_extended_batch {
+                    if terminal_marker_seen || (saw_event && !all_events_extended_batch) {
                         break;
                     }
                 }
@@ -509,6 +518,9 @@ pub async fn consume_sse_stream_cancellable<H: SseStreamHost>(
             &mut approval_results,
         )
         .await;
+        if terminal_marker_seen {
+            break;
+        }
     }
 
     // Tombstone on abort (timeout or cancellation).
@@ -561,7 +573,7 @@ pub async fn consume_sse_stream_cancellable<H: SseStreamHost>(
         }
     };
     let ttft_ms = framer.ttft_ms;
-    if abort.is_none() && !tail.trim().is_empty() {
+    if abort.is_none() && !accum.stream_complete && !tail.trim().is_empty() {
         let _ = process_sse_event_block(
             &tail,
             host,
@@ -624,6 +636,13 @@ async fn process_sse_event_block<H: SseStreamHost>(
     first_sse_frame_seen: &mut bool,
     reported_session_id: &mut Option<String>,
 ) -> bool {
+    // `[DONE]` establishes the only terminal transport boundary.  The
+    // consumer normally stops before this function can be called again, but
+    // retain the guard here so a future caller cannot forward late typed agent
+    // events before the dispatcher gets a chance to ignore them.
+    if accum.stream_complete {
+        return false;
+    }
     if !*first_sse_frame_seen {
         *first_sse_frame_seen = true;
         host.on_first_sse_frame();
@@ -1176,6 +1195,81 @@ mod tests {
         assert!(result.accum.stream_complete);
         assert!(result.tool_results.is_empty());
         assert!(result.approval_results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn done_marker_terminates_consumption_without_waiting_for_source_eof() {
+        let source = stream::iter(vec![Ok(b"data: [DONE]\n\n".to_vec())])
+            .chain(stream::pending::<Result<Vec<u8>, String>>());
+        let mut stream = source;
+        let mut host = RecordingSseStreamHost::new();
+
+        let completed = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            consume_sse_stream(
+                &mut stream,
+                &mut host,
+                std::time::Duration::from_millis(STREAM_IDLE_TIMEOUT_MS),
+            ),
+        )
+        .await
+        .expect("[DONE] is a terminal transport signal, not a request to await EOF");
+
+        assert!(completed.1.is_none());
+        assert!(completed.0.accum.stream_complete);
+        assert!(host.stream_completed);
+    }
+
+    #[tokio::test]
+    async fn done_marker_flushes_preceding_edge_work_before_returning() {
+        let events = format!(
+            "{}data: [DONE]\n\n",
+            sse_event(
+                "tool_request",
+                ",\"request_id\":\"before-done\",\"tool\":\"bash\",\"args\":{\"command\":\"git status --short\"}",
+            )
+        );
+        let source = stream::iter(vec![Ok(events.into_bytes())])
+            .chain(stream::pending::<Result<Vec<u8>, String>>());
+        let mut stream = source;
+        let mut host = RecordingSseStreamHost::new().with_tool_output("bash", "clean");
+
+        let (result, abort) = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            consume_sse_stream(
+                &mut stream,
+                &mut host,
+                std::time::Duration::from_millis(STREAM_IDLE_TIMEOUT_MS),
+            ),
+        )
+        .await
+        .expect("[DONE] must flush already-accepted edge work without waiting for EOF");
+
+        assert!(abort.is_none());
+        assert!(result.accum.stream_complete);
+        assert_eq!(result.tool_results.len(), 1);
+        assert_eq!(result.tool_results[0].request_id, "before-done");
+    }
+
+    #[tokio::test]
+    async fn done_marker_does_not_forward_later_agent_live_evidence() {
+        let chunks: Vec<Result<Vec<u8>, String>> = vec![
+            Ok(b"data: [DONE]\n\n".to_vec()),
+            Ok(b"data: {\"type\":\"agent_live_gap\",\"run_id\":\"late-run\",\"agent_id\":\"late-agent\",\"dropped_event_count\":1}\n\n".to_vec()),
+        ];
+        let mut stream = stream::iter(chunks);
+        let mut host = RecordingSseStreamHost::new();
+
+        let (result, abort) = consume_sse_stream(
+            &mut stream,
+            &mut host,
+            std::time::Duration::from_millis(STREAM_IDLE_TIMEOUT_MS),
+        )
+        .await;
+
+        assert!(abort.is_none());
+        assert!(result.accum.stream_complete);
+        assert!(host.agent_live_gaps.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- terminate SSE transport at [DONE] without forwarding late agent evidence, while flushing accepted edge work
- persist cross-session tool health only after the primary turn is durable
- define canonical Git multi-path diff filters across schema, validation, execution, and semantic deduplication

## Verification
- make check
- make test-offline
- cargo test -p astra-test-harness --lib
- DeepSeek Flash harness: hello, inspect snapshot, agent visibility, and fanout completion (Qwen hard judge: 1.00)