### PR TITLE
fix(runtime): recover large tool results by session handle

### DIFF
--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -18,6 +18,7 @@ use astra_core::work_unit::{
 use astra_runtime::tool_sandbox::{
     SandboxPolicy, sandbox_command, validate_path, wrap_command_with_limits,
 };
+use astra_services::SessionArtifactStore;
 use astra_turn_core::sync_utils::{rwlock_read_clone_or_default, rwlock_write_reset_on_poison};
 use astra_turn_core::tool::deferred_activation::ToolSurfaceNames;
 
@@ -367,26 +368,8 @@ const AGGREGATE_OUTPUT_BUDGET: usize = 200_000;
 /// before doing I/O and suggest lighter alternatives when exceeded.
 const AGGREGATE_SOFT_LIMIT: usize = 120_000;
 
-/// Per-tool persistence threshold (chars). When a single tool result exceeds
-/// this AND aggregate output is above the soft limit, the result is persisted
-/// as an internal artifact and replaced with a preview. The artifact path is
-/// not part of the workspace filesystem contract.
-/// Global default for large-output persistence threshold (50K).
-const PERSIST_THRESHOLD: usize = 50_000;
-
-/// Preview size (bytes) included in the persisted-output reference message.
-const PERSIST_PREVIEW_BYTES: usize = 2000;
-
 /// Maximum file size (10MB) for LSP operations to prevent OOM.
 const MAX_LSP_FILE_SIZE: usize = 10 * 1024 * 1024;
-
-/// Directory for persisted tool results within the astra home.
-fn tool_results_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".astra")
-        .join("tool-results")
-}
 
 /// Convert UTF-16 column position to char index.
 /// LSP protocol uses UTF-16 code units, Rust uses UTF-8 chars.
@@ -4498,6 +4481,29 @@ impl ToolExecutor {
     }
 
     fn handle_introspect(&self, args: &Value) -> String {
+        if args.get("artifact").is_some() {
+            let Some(session_id) = self.active_session_id().filter(|id| !id.is_empty()) else {
+                return "Error: introspect artifact recovery requires an active session"
+                    .to_string();
+            };
+            let store = astra_services::local_session_artifact_store();
+            let session_dir = match store.session_dir(&session_id) {
+                Ok(session_dir) => session_dir,
+                Err(error) => {
+                    return format!(
+                        "Error: could not resolve the active session for artifact recovery: {error}"
+                    );
+                }
+            };
+            return astra_turn_core::tool_result_storage::resolve_session_tool_result_artifact_request(
+                &session_dir,
+                args,
+            )
+            .unwrap_or_else(|| {
+                Err("introspect artifact recovery request was not recognized".to_string())
+            })
+            .unwrap_or_else(|error| format!("Error: {error}"));
+        }
         let request = astra_turn_core::introspect::IntrospectRequest::from_args(args);
 
         if !request.format.is_json() && request.source_policy.allows_edge_local_artifacts() {
@@ -5108,9 +5114,11 @@ impl ToolExecutor {
             .fetch_add(size, std::sync::atomic::Ordering::Relaxed);
     }
     fn finalize_tool_output(&self, output: String, name: &str) -> String {
-        let output = normalize_empty_output(output, name);
-        let persisted = self.maybe_persist_large_output(output, name);
-        truncate_output(persisted, global_output_limit())
+        // This executor has neither a session owner nor a tool-call id. It
+        // must therefore preserve the evidence exactly; the session-aware
+        // recording pipeline is the sole boundary allowed to turn oversized
+        // output into a recoverable artifact handle.
+        normalize_empty_output(output, name)
     }
 
     pub async fn execute_with_metadata_cancelable(
@@ -5856,78 +5864,6 @@ impl ToolExecutor {
         output
     }
 
-    /// Persist large tool output to disk when aggregate budget is under pressure.
-    ///
-    /// When a single tool result exceeds `PERSIST_THRESHOLD` AND cumulative
-    /// output this turn is above `AGGREGATE_SOFT_LIMIT`, the full output is
-    /// written to an internal artifact and replaced with a ~2KB preview. The
-    /// artifact path is intentionally not exposed to the model because it is
-    /// outside the workspace filesystem contract.
-    fn maybe_persist_large_output(&self, output: String, _tool_name: &str) -> String {
-        // Skip small outputs
-        if output.len() < PERSIST_THRESHOLD {
-            return output;
-        }
-        // Only persist when aggregate pressure is meaningful
-        let agg = self
-            .aggregate_output_bytes
-            .load(std::sync::atomic::Ordering::Relaxed);
-        let agg = agg.saturating_add(output.len());
-        if agg <= AGGREGATE_SOFT_LIMIT {
-            return output;
-        }
-        // Never persist error outputs (they're small and actionable)
-        if cli_tool_output_is_error(&output) {
-            return output;
-        }
-
-        // Write to disk
-        let dir = tool_results_dir();
-        if std::fs::create_dir_all(&dir).is_err() {
-            return output;
-        }
-
-        // Use a content hash for the filename (dedup identical outputs)
-        let hash = {
-            use std::hash::{Hash, Hasher};
-            let mut h = std::collections::hash_map::DefaultHasher::new();
-            output.hash(&mut h);
-            format!("{:016x}", h.finish())
-        };
-        let filepath = dir.join(format!("{hash}.txt"));
-
-        // Write only if not already persisted (idempotent)
-        if !filepath.exists() {
-            if std::fs::write(&filepath, &output).is_err() {
-                return output;
-            }
-        }
-
-        // Build preview: first ~2KB, cut at newline boundary
-        let preview_end = output.len().min(PERSIST_PREVIEW_BYTES);
-        let preview_end = output.floor_char_boundary(preview_end);
-        let preview_end = output[..preview_end]
-            .rfind('\n')
-            .filter(|&pos| pos > preview_end / 2)
-            .map(|pos| pos + 1)
-            .unwrap_or(preview_end);
-        let preview = &output[..preview_end];
-        let total_lines = output.lines().count();
-
-        format!(
-            "<persisted-output>\n\
-             Output too large ({} bytes, ~{} lines) for context window. \
-             Full output was persisted as an internal tool-result artifact outside the workspace.\n\n\
-             Preview (first ~{} bytes):\n\
-             {}\n...\n\
-             </persisted-output>",
-            output.len(),
-            total_lines,
-            PERSIST_PREVIEW_BYTES,
-            preview,
-        )
-    }
-
     /// Execute a multi-step ToolChain, forwarding each step to self.execute().
     ///
     /// Returns a JSON summary with per-step outputs and the final result.
@@ -6576,9 +6512,8 @@ impl astra_tools::ToolExecutor for ToolExecutor {
 #[cfg(test)]
 mod tests {
     use super::{
-        AGGREGATE_SOFT_LIMIT, BgTaskCommand, BgTaskOutputReadMode, BgTaskOutputSearchSnapshot,
-        BgTaskOutputSnapshot, BgTaskOutputStatus, PERSIST_THRESHOLD, ToolExecutor,
-        WorkUnitObservation, WorkUnitStatus, all_tool_schemas,
+        BgTaskCommand, BgTaskOutputReadMode, BgTaskOutputSearchSnapshot, BgTaskOutputSnapshot,
+        BgTaskOutputStatus, ToolExecutor, WorkUnitObservation, WorkUnitStatus, all_tool_schemas,
         background_task_output_result_fields, cli_tool_output_is_error, detect_git_remote_repos,
         embedded_work_unit_observation, extract_github_owner_repo, file_checkpoint_dir_for,
         format_background_task_error, format_background_task_output,
@@ -6924,21 +6859,20 @@ mod tests {
     }
 
     #[test]
-    fn edge_large_output_reference_does_not_expose_unreadable_filesystem_path() {
+    fn edge_preserves_large_output_until_call_id_aware_persistence() {
         let executor = test_executor();
-        executor.aggregate_output_bytes.store(
-            AGGREGATE_SOFT_LIMIT + 1,
-            std::sync::atomic::Ordering::Relaxed,
+        let output = "evidence\n".repeat(100_000);
+
+        let rendered = executor.finalize_tool_output(output.clone(), "bash");
+
+        assert_eq!(
+            rendered, output,
+            "the edge must not replace output before the runtime can bind it to a session and tool call id"
         );
-        let output = "x".repeat(PERSIST_THRESHOLD + 100);
-
-        let rendered = executor.maybe_persist_large_output(output, "bash");
-
-        assert!(rendered.contains("<persisted-output>"));
-        assert!(rendered.contains("internal tool-result artifact"));
-        assert!(!rendered.contains("Full output saved to:"));
-        assert!(!rendered.contains("Use read_file"));
-        assert!(!rendered.contains(".astra/tool-results"));
+        assert!(
+            !rendered.contains("<persisted-output>"),
+            "only the call-id-aware runtime persistence layer may emit an artifact handle"
+        );
     }
 
     #[test]
@@ -9445,6 +9379,48 @@ mod tests {
         assert!(
             !out.contains("first turn"),
             "must not return opaque first-turn placeholder, got: {out}"
+        );
+    }
+
+    #[test]
+    fn introspect_recovers_only_the_active_sessions_large_tool_artifact() {
+        let sessions = tempfile::tempdir().unwrap();
+        let _guard = astra_services::session_journal::JournalDirGuard::new(sessions.path());
+        let session_id = "artifact-recovery-cli";
+        let store = astra_services::local_session_artifact_store();
+        let session_dir = astra_services::SessionArtifactStore::session_dir(&store, session_id)
+            .expect("safe session id resolves to its artifact directory");
+        let content = "checked evidence 😀\n".repeat(4_000);
+        assert!(
+            astra_turn_core::tool_result_storage::maybe_persist_tool_result(
+                &session_dir,
+                "call-artifact-cli",
+                "git",
+                &content,
+            )
+            .is_some(),
+            "setup must create an oversized session artifact"
+        );
+
+        let artifact = astra_turn_core::tool_result_storage::session_tool_result_artifact_uri(
+            "call-artifact-cli",
+        );
+        let active = test_executor().with_active_session_id(session_id);
+        let first = active.handle_introspect(&serde_json::json!({
+            "artifact": artifact,
+            "offset": 0,
+            "max_bytes": 29,
+        }));
+        assert!(first.contains("<tool-result-window>"), "{first}");
+        assert!(first.contains("checked evidence"), "{first}");
+        assert!(first.contains("Continue with introspect("), "{first}");
+        assert!(!first.contains(sessions.path().to_string_lossy().as_ref()));
+
+        let other_session = test_executor().with_active_session_id("artifact-recovery-other");
+        let denied = other_session.handle_introspect(&serde_json::json!({"artifact": artifact}));
+        assert!(
+            denied.contains("was not found in the active session"),
+            "artifact handles must not cross session ownership: {denied}"
         );
     }
 

--- a/crates/astra-cli/src/edge_tools/tests/aggregate_tests.rs
+++ b/crates/astra-cli/src/edge_tools/tests/aggregate_tests.rs
@@ -1,8 +1,7 @@
-use super::super::tool_results_dir;
 use super::test_executor;
 use crate::edge_tools::{
-    AGGREGATE_OUTPUT_BUDGET, AGGREGATE_SOFT_LIMIT, PERSIST_THRESHOLD, ToolExecutor,
-    per_tool_output_limit, tool_output_limit,
+    AGGREGATE_OUTPUT_BUDGET, AGGREGATE_SOFT_LIMIT, ToolExecutor, per_tool_output_limit,
+    tool_output_limit,
 };
 use serde_json::json;
 use std::path::PathBuf;
@@ -11,7 +10,7 @@ use std::path::PathBuf;
 //
 // These tests simulate realistic multi-tool-call turns to verify that:
 // 1. Progressive scaling reduces limits smoothly (not step-function)
-// 2. Internal artifact persistence triggers when aggregate is high + output is large
+// 2. Large output remains intact until the session-aware runtime persistence boundary
 // 3. read_file auto-downgrades to outline under aggregate pressure
 // 4. Ranged reads always work regardless of aggregate pressure
 // 5. git(action=show/diff) respects aggregate-aware limits
@@ -90,139 +89,6 @@ fn progressive_scaling_combines_token_and_aggregate_pressure() {
         both < token_only,
         "combined pressure should be tighter: {both} vs token-only {token_only}"
     );
-}
-
-#[test]
-fn persist_to_disk_triggers_when_aggregate_high_and_output_large() {
-    let executor = test_executor();
-
-    // Simulate high aggregate output (above soft limit)
-    executor.aggregate_output_bytes.store(
-        AGGREGATE_SOFT_LIMIT + 10_000,
-        std::sync::atomic::Ordering::Relaxed,
-    );
-
-    // Small output → not persisted
-    let small = "x".repeat(1000);
-    let result = executor.maybe_persist_large_output(small.clone(), "bash");
-    assert_eq!(result, small, "small output should pass through");
-
-    // Large output → persisted internally while keeping the model-facing text
-    // inside the workspace/provider contract.
-    let marker = format!(
-        "persist-contract-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    );
-    let large = format!("{marker}\n{}", "x\n".repeat(30_000)); // ~60KB
-    let result = executor.maybe_persist_large_output(large.clone(), "bash");
-    assert!(
-        result.contains("<persisted-output>"),
-        "large output should be persisted, got first 200 chars: {}",
-        &result[..result.len().min(200)]
-    );
-    assert!(
-        result.contains("internal tool-result artifact"),
-        "should describe the internal artifact contract"
-    );
-    assert!(
-        !result.contains("tool-results/"),
-        "model-facing result must not expose internal file path"
-    );
-    assert!(
-        result.contains("</persisted-output>"),
-        "should have closing tag"
-    );
-    assert!(
-        !result.contains("read_file"),
-        "must not suggest workspace read_file for internal artifacts"
-    );
-    assert!(
-        result.len() < large.len() / 5,
-        "persisted reference ({}) should be much smaller than original ({})",
-        result.len(),
-        large.len()
-    );
-
-    // Verify file was actually written without parsing a model-visible path.
-    let persisted_file = std::fs::read_dir(tool_results_dir())
-        .unwrap()
-        .flatten()
-        .map(|entry| entry.path())
-        .find(|path| {
-            std::fs::read_to_string(path)
-                .map(|content| content.contains(&marker))
-                .unwrap_or(false)
-        })
-        .expect("persisted file containing unique marker should exist");
-    assert!(
-        persisted_file.exists(),
-        "persisted file should exist: {}",
-        persisted_file.display()
-    );
-
-    // Cleanup
-    let _ = std::fs::remove_file(persisted_file);
-}
-
-#[test]
-fn persist_to_disk_skipped_when_aggregate_low() {
-    let executor = test_executor();
-
-    // Aggregate below soft limit → no persist even for large output
-    executor
-        .aggregate_output_bytes
-        .store(0, std::sync::atomic::Ordering::Relaxed);
-
-    let large = "x\n".repeat(30_000);
-    let result = executor.maybe_persist_large_output(large.clone(), "bash");
-    assert!(
-        !result.contains("<persisted-output>"),
-        "should not persist when aggregate is low"
-    );
-}
-
-#[test]
-fn persist_to_disk_skipped_for_errors() {
-    let executor = test_executor();
-    executor.aggregate_output_bytes.store(
-        AGGREGATE_SOFT_LIMIT + 10_000,
-        std::sync::atomic::Ordering::Relaxed,
-    );
-
-    let error_output = format!("Error: {}", "x".repeat(60_000));
-    let result = executor.maybe_persist_large_output(error_output.clone(), "bash");
-    assert_eq!(
-        result, error_output,
-        "error outputs should never be persisted"
-    );
-}
-
-#[test]
-fn persist_to_disk_idempotent_same_content() {
-    let executor = test_executor();
-    executor.aggregate_output_bytes.store(
-        AGGREGATE_SOFT_LIMIT + 10_000,
-        std::sync::atomic::Ordering::Relaxed,
-    );
-
-    let large = "deterministic content\n".repeat(3000);
-    let result1 = executor.maybe_persist_large_output(large.clone(), "bash");
-    let result2 = executor.maybe_persist_large_output(large, "bash");
-    assert_eq!(
-        result1, result2,
-        "same content should produce identical reference"
-    );
-
-    // Cleanup
-    if let Some(path) = result1
-        .split_whitespace()
-        .find(|s| s.contains("tool-results/"))
-    {
-        let _ = std::fs::remove_file(path);
-    }
 }
 
 #[test]
@@ -374,45 +240,6 @@ async fn multi_turn_full_execute_accumulates_aggregate() {
         after2,
         after + output2.len(),
         "aggregate should accumulate across calls"
-    );
-}
-
-#[tokio::test]
-async fn multi_turn_persist_triggers_via_execute() {
-    // End-to-end: execute() should persist large bash output when aggregate is high
-    let dir = tempfile::tempdir().unwrap();
-    let executor = ToolExecutor::new(dir.path());
-
-    // Pre-load aggregate to above soft limit
-    executor.aggregate_output_bytes.store(
-        AGGREGATE_SOFT_LIMIT + 10_000,
-        std::sync::atomic::Ordering::Relaxed,
-    );
-
-    // Execute bash that produces large output (>50KB)
-    let output = executor
-            .execute(
-                "bash",
-                &json!({"command": format!("python3 -c \"print('x' * 70 + '\\n', end='')\" | head -c 60000; echo; seq 1 500")}),
-            )
-            .await;
-
-    // If the output was large enough, it should have been persisted
-    // (depends on actual bash output size — if python3 isn't available,
-    // the error message will be small and won't trigger persist)
-    if output.len() > PERSIST_THRESHOLD {
-        assert!(
-            output.contains("<persisted-output>"),
-            "large execute output should be persisted when aggregate is high"
-        );
-    }
-    // Either way, aggregate should have been updated
-    let agg = executor
-        .aggregate_output_bytes
-        .load(std::sync::atomic::Ordering::Relaxed);
-    assert!(
-        agg > AGGREGATE_SOFT_LIMIT + 10_000,
-        "aggregate should have increased"
     );
 }
 

--- a/crates/astra-test-harness/cases/session_tool_result_artifact_recovery.yaml
+++ b/crates/astra-test-harness/cases/session_tool_result_artifact_recovery.yaml
@@ -1,0 +1,36 @@
+name: session_tool_result_artifact_recovery
+description: |
+  **What**: Produce a tool result larger than the inline persistence threshold,
+  then recover its first durable window through the advertised `introspect`
+  artifact handle.
+  **Tests**: The full edge → recording → session-owned artifact → model recovery
+  path. The edge may not replace output before it has a call id, and recovery
+  may not require a physical local path.
+  **Pass means**: The agent calls `bash`, follows the returned logical handle
+  with `introspect`, and reports the durable evidence marker.
+  **Fail means**: Large evidence was lost, only an unreadable preview remained,
+  or the artifact recovery surface was not visible to the model.
+prompt: |
+  Perform exactly this evidence-recovery workflow:
+
+  1. Call `bash` with this exact command to produce a large result:
+     `yes RECOVERED_EVIDENCE_OK | head -c 36000`
+  2. The result will give you a session artifact handle. Call `introspect` with
+     that exact handle, `offset: 0`, and `max_bytes: 256`. Do not guess a path
+     and do not use `read_file` or `bash` again.
+  3. In your final response, write exactly `RECOVERED_EVIDENCE_OK`.
+
+  Do not call any other tools.
+capability: tool_use
+difficulty: 2
+timeout_seconds: 120
+criteria:
+  - type: exit_code
+    code: 0
+  - type: tool_sequence
+    tools: [bash, introspect]
+  - type: tools_count_between
+    min: 2
+    max: 2
+  - type: text_contains
+    needle: RECOVERED_EVIDENCE_OK

--- a/crates/astra-tools/src/internal_artifacts.rs
+++ b/crates/astra-tools/src/internal_artifacts.rs
@@ -30,10 +30,11 @@ pub fn internal_tool_result_artifact_access_error(surface: &str, value: &str) ->
     }
     Some(format!(
         "Error: {surface} cannot read runtime-owned tool-result artifacts directly. \
-         Use the owning tool's recovery action instead: \
+         Use the owning recovery action instead: \
          agent_fanout(action='get_results', group_id=...) for fanout groups, \
          agent(action='get_result', agent_id=...) for child agents, or \
-         task_output(task_id=...) for background tasks. \
+         task_output(task_id=...) for background tasks. Session tool-result handles \
+         use introspect(artifact='artifact://session/tool-result/<opaque_token>', offset=0, max_bytes=8192). \
          Do not inspect ~/.astra session artifact files with shell/file tools; \
          if no first-class recovery action exists, report that the result was truncated."
     ))
@@ -52,7 +53,7 @@ mod tests {
             "find ~/.astra/sessions/session-1/tool-results -type f"
         ));
         assert!(references_internal_tool_result_artifact(
-            "artifact://session/tool-result/call_abc"
+            "artifact://session/tool-result/Y2FsbF9hYmM"
         ));
         assert!(references_internal_tool_result_artifact(
             "/home/me/.astra/tool-results/call_abc.txt"

--- a/crates/astra-tools/src/lib.rs
+++ b/crates/astra-tools/src/lib.rs
@@ -600,12 +600,6 @@ pub const AGGREGATE_SOFT_LIMIT: usize = 120_000;
 /// suggest narrowing further before hitting the hard soft-limit.
 pub const AGGREGATE_HINT_THRESHOLD: usize = AGGREGATE_SOFT_LIMIT / 2;
 
-/// Per-tool persistence threshold (chars).
-pub const PERSIST_THRESHOLD: usize = 50_000;
-
-/// Preview size for persisted output references.
-pub const PERSIST_PREVIEW_BYTES: usize = 2000;
-
 /// Truncate tool output to `max_bytes`, cutting at a newline boundary when
 /// possible to avoid mid-line cuts that confuse the LLM.
 pub fn truncate_output(mut output: String, max_bytes: usize) -> String {
@@ -629,71 +623,6 @@ pub fn normalize_empty_output(output: String, tool_name: &str) -> String {
     } else {
         output
     }
-}
-
-/// Directory for persisted tool results within the astra home.
-pub fn tool_results_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".astra")
-        .join("tool-results")
-}
-
-/// Persist large tool output to disk when aggregate budget is under pressure.
-pub fn maybe_persist_large_output(
-    output: String,
-    aggregate_bytes: usize,
-    _tool_name: &str,
-) -> String {
-    if output.len() < PERSIST_THRESHOLD {
-        return output;
-    }
-    if aggregate_bytes <= AGGREGATE_SOFT_LIMIT {
-        return output;
-    }
-    if output.starts_with("Error:") {
-        return output;
-    }
-
-    let dir = tool_results_dir();
-    if std::fs::create_dir_all(&dir).is_err() {
-        return output;
-    }
-
-    let hash = {
-        use std::hash::{Hash, Hasher};
-        let mut h = std::collections::hash_map::DefaultHasher::new();
-        output.hash(&mut h);
-        format!("{:016x}", h.finish())
-    };
-    let filepath = dir.join(format!("{hash}.txt"));
-
-    if !filepath.exists() && std::fs::write(&filepath, &output).is_err() {
-        return output;
-    }
-
-    let preview_end = output.len().min(PERSIST_PREVIEW_BYTES);
-    let preview_end = output.floor_char_boundary(preview_end);
-    let preview_end = output[..preview_end]
-        .rfind('\n')
-        .filter(|&pos| pos > preview_end / 2)
-        .map(|pos| pos + 1)
-        .unwrap_or(preview_end);
-    let preview = &output[..preview_end];
-    let total_lines = output.lines().count();
-
-    format!(
-        "<persisted-output>\n\
-         Output too large ({} bytes, ~{} lines) for context window. \
-         Full output was persisted as an internal tool-result artifact outside the workspace.\n\n\
-         Preview (first ~{} bytes):\n\
-         {}\n...\n\
-         </persisted-output>",
-        output.len(),
-        total_lines,
-        PERSIST_PREVIEW_BYTES,
-        preview,
-    )
 }
 
 // ─── Shared utility functions ───────────────────────────────────────────────
@@ -1195,62 +1124,6 @@ mod tests {
             assert!(func.get("name").and_then(|n| n.as_str()).is_some());
             assert!(func.get("description").and_then(|d| d.as_str()).is_some());
         }
-    }
-
-    // ── Persist large output ───────────────────────────────────────────
-
-    #[test]
-    fn maybe_persist_small_output_passes_through() {
-        let out = "small output".to_string();
-        let result = maybe_persist_large_output(out.clone(), 0, "bash");
-        assert_eq!(result, out);
-    }
-
-    #[test]
-    fn maybe_persist_under_soft_limit_passes_through() {
-        let out = "x".repeat(PERSIST_THRESHOLD + 1);
-        let result = maybe_persist_large_output(out.clone(), 0, "bash");
-        // Under AGGREGATE_SOFT_LIMIT, even large output passes through
-        assert_eq!(result, out);
-    }
-
-    #[test]
-    fn maybe_persist_error_output_passes_through() {
-        let out = format!("Error: {}", "x".repeat(PERSIST_THRESHOLD + 1));
-        let result = maybe_persist_large_output(out.clone(), AGGREGATE_SOFT_LIMIT + 1, "bash");
-        // Error output is never persisted
-        assert_eq!(result, out);
-    }
-
-    // ── UTF-8 char boundary regression for persist preview ───────────────
-
-    #[test]
-    fn persist_preview_multibyte_at_boundary() {
-        // The preview clips at PERSIST_PREVIEW_BYTES (2000). Ensure it doesn't
-        // panic when a multi-byte char straddles that boundary.
-        let prefix = "x".repeat(1997); // 1997 ASCII bytes
-        let mb = "─".repeat(10); // '─' = 3 bytes each
-        let suffix = "y".repeat(PERSIST_THRESHOLD + 1000); // push past threshold
-        let s = format!("{prefix}{mb}{suffix}");
-        assert!(s.len() > PERSIST_THRESHOLD);
-        let result = maybe_persist_large_output(s, AGGREGATE_SOFT_LIMIT + 1, "bash");
-        // Must not panic; if it succeeded, the preview was built safely
-        assert!(result.contains("<persisted-output>"));
-        assert!(!result.contains("Full output saved to:"));
-        assert!(!result.contains("Use read_file"));
-    }
-
-    #[test]
-    fn persist_preview_4byte_emoji_at_boundary() {
-        let prefix = "a".repeat(1998); // 1998 bytes
-        let emoji = "🔥🔥🔥"; // 4 bytes each
-        let suffix = "z".repeat(PERSIST_THRESHOLD + 1000);
-        let s = format!("{prefix}{emoji}{suffix}");
-        assert!(s.len() > PERSIST_THRESHOLD);
-        let result = maybe_persist_large_output(s, AGGREGATE_SOFT_LIMIT + 1, "bash");
-        assert!(result.contains("<persisted-output>"));
-        assert!(!result.contains("Full output saved to:"));
-        assert!(!result.contains("Use read_file"));
     }
 
     // ── porcelain_status_codes ─────────────────────────────────────────

--- a/crates/astra-tools/src/schemas.rs
+++ b/crates/astra-tools/src/schemas.rs
@@ -1504,7 +1504,7 @@ fn all_tool_schemas_core() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "introspect",
-                "description": "Read the live observation snapshot for the running turn/session. Use for self-checks: token/cache pressure, step latency/performance, tool health, recent rounds, runtime errors, stall/noise state, working memory, and plan/task/session lifecycle/resume state including the last lifecycle event when available. CLI/Edge can also inspect local cache and session_memory artifacts. For persisted multi-turn causal analysis, use reflect.",
+                "description": "Read the live observation snapshot for the running turn/session. Use for self-checks: token/cache pressure, step latency/performance, tool health, recent rounds, runtime errors, stall/noise state, working memory, and plan/task/session lifecycle/resume state including the last lifecycle event when available. Use artifact plus offset to read a bounded window from a persisted tool-result handle. CLI/Edge can also inspect local cache and session_memory artifacts. For persisted multi-turn causal analysis, use reflect.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -1514,7 +1514,10 @@ fn all_tool_schemas_core() -> Vec<Value> {
                         "horizon": {"type": "string", "enum": ["now","current_turn","recent","turn","session","cross_session"], "description": "Time range label. Choose trace-like content with facet=trace, not by changing horizon."},
                         "source_policy": {"type": "string", "enum": ["auto","live_only","live_first","durable_first","local_only","cloud_only"], "description": "Preferred data source. Missing or unsatisfied providers are reported instead of fabricated."},
                         "include_context": {"type": "boolean", "description": "Request visible prompt/context facts when a provider is available; these are observed context, not durable truth."},
-                        "format": {"type": "string", "enum": ["text","json"], "description": "Output format. text is default; json returns a structured read-only observation envelope."}
+                        "format": {"type": "string", "enum": ["text","json"], "description": "Output format. text is default; json returns a structured read-only observation envelope."},
+                        "artifact": {"type": "string", "description": "An opaque session-scoped artifact://session/tool-result/<token> handle returned for an oversized tool result. When set, reads that result instead of a runtime snapshot."},
+                        "offset": {"type": "integer", "minimum": 0, "description": "Byte offset for artifact recovery. Start at 0 and continue with the returned next_offset."},
+                        "max_bytes": {"type": "integer", "minimum": 1, "maximum": 65536, "description": "Maximum bytes in one artifact window. Defaults to 8192; use returned next_offset to continue."}
                     },
                     "additionalProperties": false
                 }
@@ -2338,6 +2341,9 @@ mod tests {
             "source_policy",
             "include_context",
             "format",
+            "artifact",
+            "offset",
+            "max_bytes",
         ] {
             assert!(
                 properties.contains_key(key),
@@ -2367,6 +2373,7 @@ mod tests {
             ],
             "introspect source_policy schema must not regress to old edge/server/cloud aliases"
         );
+        assert_eq!(properties["max_bytes"]["maximum"], 65_536);
     }
 
     #[test]

--- a/crates/astra-tools/src/shell_ops.rs
+++ b/crates/astra-tools/src/shell_ops.rs
@@ -4887,7 +4887,7 @@ printf 'probe.txt:1:needle\n'
             "cat /home/me/.astra/sessions/session-1/tool-results/call_abc.txt",
             "find ~/.astra/sessions/session-1/tool-results -type f",
             "grep -R result /home/me/.astra/tool-results/call_abc.txt",
-            "cat artifact://session/tool-result/call_abc",
+            "cat artifact://session/tool-result/Y2FsbF9hYmM",
         ] {
             let error = validate_execute_bash_command(command).expect_err(command);
             assert!(

--- a/crates/astra-turn-core/src/microcompact.rs
+++ b/crates/astra-turn-core/src/microcompact.rs
@@ -292,8 +292,9 @@ impl ToolCallMaps {
     }
 }
 
-/// Marker for tool results persisted to disk by `tool_result_storage`.
-/// These contain a file reference the LLM needs to re-read the output.
+/// Marker for tool results persisted to session-owned `tool_result_storage`.
+/// These retain a logical artifact handle the LLM can re-read through
+/// `introspect`; compaction must not destroy that recovery instruction.
 const PERSISTED_TAG: &str = "<persisted-output>";
 
 fn is_compactable_tool_name(name: &str) -> bool {
@@ -1122,7 +1123,8 @@ mod tests {
     #[test]
     fn skips_persisted_to_disk_results() {
         let persisted = "<persisted-output>\nTool `read_file` produced 50000 chars.\n\
-             File: /tmp/sessions/tool_results/c1.txt\n\
+             Artifact handle: artifact://session/tool-result/YzE\n\
+             Read bounded windows with introspect(artifact=\"artifact://session/tool-result/YzE\", offset=0, max_bytes=8192).\n\
              Preview: first 500 chars...\n</persisted-output>"
             .to_string();
         let mut messages = vec![
@@ -1829,8 +1831,9 @@ mod tests {
     fn persisted_output_mixed_with_compactable_in_same_turn() {
         // One assistant turn produces both a persisted-output result and
         // a normal compactable result. Only the normal one should compact.
-        let persisted =
-            "<persisted-output>Preview of large file... (saved to /tmp/abc)</persisted-output>";
+        let persisted = "<persisted-output>Artifact handle: artifact://session/tool-result/YzE\n\
+            Read with introspect(artifact=\"artifact://session/tool-result/YzE\", offset=0, max_bytes=8192).\n\
+            Preview of large file...</persisted-output>";
         let big = "x".repeat(800);
 
         // Need >6 compactable (non-persisted) to trigger count-based.

--- a/crates/astra-turn-core/src/recent_arg_hints.rs
+++ b/crates/astra-turn-core/src/recent_arg_hints.rs
@@ -251,7 +251,7 @@ mod tests {
             "path": "/home/me/.astra/sessions/v1/users/b64-wrong/sessions/s1/tool-results/call_abc.txt"
         });
         let logical = json!({
-            "path": "artifact://session/tool-result/call_abc"
+            "path": "artifact://session/tool-result/Y2FsbF9hYmM"
         });
         let command = json!({
             "command": "cat /home/me/.astra/sessions/v1/users/b64-wrong/sessions/s1/tool-results/call_abc.txt"

--- a/crates/astra-turn-core/src/tool/result/storage.rs
+++ b/crates/astra-turn-core/src/tool/result/storage.rs
@@ -11,8 +11,12 @@
 //! the model to copy incorrectly; callers that need the full body must resolve
 //! the handle through runtime-owned artifact APIs.
 
-use std::path::{Path, PathBuf};
+use std::{
+    io::{Read, Seek, SeekFrom},
+    path::{Path, PathBuf},
+};
 
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde_json::Value;
 
 /// Maximum length of the human-readable portion of a sanitized filename.
@@ -66,6 +70,31 @@ const TOOL_RESULTS_SUBDIR: &str = "tool-results";
 /// Logical URI prefix for a persisted tool result scoped to the current
 /// session.
 pub const SESSION_TOOL_RESULT_ARTIFACT_URI_PREFIX: &str = "artifact://session/tool-result/";
+
+/// Default payload size for one model-requested artifact window.
+pub const DEFAULT_TOOL_RESULT_WINDOW_BYTES: usize = 8 * 1024;
+
+/// Largest payload size accepted for one model-requested artifact window.
+///
+/// This is a transport-window bound, not a cap on the result itself: callers
+/// can continue from `next_offset` until the complete durable result is read.
+pub const MAX_TOOL_RESULT_WINDOW_BYTES: usize = 64 * 1024;
+
+/// A UTF-8-safe byte window over one persisted tool result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersistedToolResultWindow {
+    pub content: String,
+    pub offset: usize,
+    pub next_offset: usize,
+    pub total_bytes: usize,
+}
+
+impl PersistedToolResultWindow {
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.next_offset >= self.total_bytes
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PersistedFormat {
@@ -189,6 +218,190 @@ pub fn read_persisted_result(session_dir: &Path, tool_call_id: &str) -> Option<S
     std::fs::read_to_string(file_path).ok()
 }
 
+/// Parse a session-local logical tool-result handle without exposing a
+/// filesystem path.
+///
+/// Handles use URL-safe Base64 rather than embedding provider-supplied call
+/// ids directly. Provider identifiers are opaque strings, not a protocol we
+/// control; encoding them preserves every valid id while keeping a handle to
+/// one non-traversable URI segment.
+#[must_use]
+pub fn parse_session_tool_result_artifact_uri(value: &str) -> Option<String> {
+    let encoded = value.strip_prefix(SESSION_TOOL_RESULT_ARTIFACT_URI_PREFIX)?;
+    if encoded.is_empty()
+        || !encoded
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        return None;
+    }
+    let decoded = URL_SAFE_NO_PAD.decode(encoded).ok()?;
+    let tool_call_id = String::from_utf8(decoded).ok()?;
+    (!tool_call_id.is_empty()).then_some(tool_call_id)
+}
+
+/// Read one UTF-8-safe byte window from a persisted result.
+///
+/// The caller owns the session directory, so a logical handle can never cross
+/// session ownership boundaries. `next_offset` is always a valid UTF-8
+/// boundary and is the only continuation cursor a model needs to retain.
+pub fn read_persisted_result_window(
+    session_dir: &Path,
+    tool_call_id: &str,
+    offset: usize,
+    max_bytes: usize,
+) -> Result<Option<PersistedToolResultWindow>, String> {
+    if max_bytes == 0 || max_bytes > MAX_TOOL_RESULT_WINDOW_BYTES {
+        return Err(format!(
+            "max_bytes must be between 1 and {MAX_TOOL_RESULT_WINDOW_BYTES}"
+        ));
+    }
+
+    let safe_id = safe_filename_stem(tool_call_id);
+    let file_path = session_dir
+        .join(TOOL_RESULTS_SUBDIR)
+        .join(format!("{safe_id}.txt"));
+    let total_bytes = match std::fs::metadata(&file_path) {
+        Ok(metadata) => usize::try_from(metadata.len())
+            .map_err(|_| "persisted result is too large for this runtime".to_string())?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("failed to inspect persisted result: {error}")),
+    };
+    if offset > total_bytes {
+        return Err(format!(
+            "offset {offset} is past the end of this {total_bytes}-byte tool result"
+        ));
+    }
+    if offset == total_bytes {
+        return Ok(Some(PersistedToolResultWindow {
+            content: String::new(),
+            offset,
+            next_offset: offset,
+            total_bytes,
+        }));
+    }
+
+    let mut file = std::fs::File::open(&file_path)
+        .map_err(|error| format!("failed to open persisted result: {error}"))?;
+    file.seek(SeekFrom::Start(offset as u64))
+        .map_err(|error| format!("failed to seek persisted result: {error}"))?;
+
+    // Read a few extra bytes so a UTF-8 scalar straddling `max_bytes` can
+    // still make forward progress without returning malformed text.
+    let available = total_bytes.saturating_sub(offset);
+    let read_len = available.min(max_bytes.saturating_add(3));
+    let mut bytes = vec![0_u8; read_len];
+    file.read_exact(&mut bytes)
+        .map_err(|error| format!("failed to read persisted result: {error}"))?;
+
+    if offset > 0 && bytes[0] & 0b1100_0000 == 0b1000_0000 {
+        return Err(format!(
+            "offset {offset} is not a UTF-8 boundary; continue with the next_offset returned by the prior window"
+        ));
+    }
+
+    let budget = available.min(max_bytes);
+    let mut consumed = match std::str::from_utf8(&bytes[..budget]) {
+        Ok(_) => budget,
+        Err(error) if error.error_len().is_some() => {
+            return Err(format!("persisted result is not valid UTF-8: {error}"));
+        }
+        Err(error) => error.valid_up_to(),
+    };
+    if consumed == 0 {
+        // `bytes` includes up to three extra bytes, enough to complete one
+        // valid UTF-8 scalar. Returning that scalar is preferable to an empty
+        // non-terminal window, which would make recovery unable to progress.
+        let scalar_len = utf8_scalar_len(bytes[0])
+            .ok_or_else(|| "persisted result is not valid UTF-8".to_string())?;
+        let scalar = bytes
+            .get(..scalar_len)
+            .ok_or_else(|| "persisted result ended inside a UTF-8 scalar".to_string())?;
+        std::str::from_utf8(scalar)
+            .map_err(|error| format!("persisted result is not valid UTF-8: {error}"))?;
+        consumed = scalar_len;
+    }
+    let content = std::str::from_utf8(&bytes[..consumed])
+        .map_err(|error| format!("persisted result is not valid UTF-8: {error}"))?
+        .to_string();
+
+    Ok(Some(PersistedToolResultWindow {
+        content,
+        offset,
+        next_offset: offset.saturating_add(consumed),
+        total_bytes,
+    }))
+}
+
+/// Resolve the model-facing artifact fields accepted by `introspect`.
+///
+/// Returning `None` means this is an ordinary introspection request. A present
+/// `artifact` field is always handled here, including malformed requests, so
+/// callers never silently fall back to an unrelated runtime snapshot.
+pub fn resolve_session_tool_result_artifact_request(
+    session_dir: &Path,
+    args: &Value,
+) -> Option<Result<String, String>> {
+    let artifact = args.get("artifact")?;
+    let artifact = match artifact.as_str() {
+        Some(value) => value,
+        None => {
+            return Some(Err(
+                "artifact must be a session tool-result handle string".to_string()
+            ));
+        }
+    };
+    let tool_call_id = match parse_session_tool_result_artifact_uri(artifact) {
+        Some(tool_call_id) => tool_call_id,
+        None => {
+            return Some(Err(
+                "artifact must be a valid artifact://session/tool-result/<opaque_token> handle"
+                    .to_string(),
+            ));
+        }
+    };
+    let offset = match args.get("offset") {
+        Some(value) => match value.as_u64().and_then(|value| usize::try_from(value).ok()) {
+            Some(offset) => offset,
+            None => return Some(Err("offset must be a non-negative integer".to_string())),
+        },
+        None => 0,
+    };
+    let max_bytes = match args.get("max_bytes") {
+        Some(value) => match value.as_u64().and_then(|value| usize::try_from(value).ok()) {
+            Some(max_bytes) => max_bytes,
+            None => return Some(Err("max_bytes must be a positive integer".to_string())),
+        },
+        None => DEFAULT_TOOL_RESULT_WINDOW_BYTES,
+    };
+
+    Some(read_persisted_result_window(session_dir, &tool_call_id, offset, max_bytes).and_then(
+        |window| {
+            let Some(window) = window else {
+                return Err("tool-result artifact was not found in the active session".to_string());
+            };
+            let handle = session_tool_result_artifact_uri(&tool_call_id);
+            let continuation = if window.is_complete() {
+                "Complete.".to_string()
+            } else {
+                format!(
+                    "Continue with introspect(artifact=\"{handle}\", offset={}, max_bytes={max_bytes}).",
+                    window.next_offset
+                )
+            };
+            Ok(format!(
+                "<tool-result-window>\n\
+                 Artifact handle: {handle}\n\
+                 Bytes: [{}..{}) of {}\n\n\
+                 {}\n\n\
+                 {continuation}\n\
+                 </tool-result-window>",
+                window.offset, window.next_offset, window.total_bytes, window.content,
+            ))
+        },
+    ))
+}
+
 /// Return the storage directory for tool results under a session.
 pub fn tool_results_dir(session_dir: &Path) -> PathBuf {
     session_dir.join(TOOL_RESULTS_SUBDIR)
@@ -197,7 +410,10 @@ pub fn tool_results_dir(session_dir: &Path) -> PathBuf {
 /// Return the model-facing logical artifact URI for a persisted tool result.
 #[must_use]
 pub fn session_tool_result_artifact_uri(tool_call_id: &str) -> String {
-    format!("{SESSION_TOOL_RESULT_ARTIFACT_URI_PREFIX}{tool_call_id}")
+    format!(
+        "{SESSION_TOOL_RESULT_ARTIFACT_URI_PREFIX}{}",
+        URL_SAFE_NO_PAD.encode(tool_call_id)
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -217,6 +433,18 @@ fn persistable_content(content: &str) -> PersistedContent {
     PersistedContent {
         text: content.to_string(),
         format: PersistedFormat::PlainText,
+    }
+}
+
+/// Return the encoded length of a valid UTF-8 scalar from its first byte.
+/// Continuation bytes and invalid leading bytes deliberately return `None`.
+fn utf8_scalar_len(first: u8) -> Option<usize> {
+    match first {
+        0x00..=0x7f => Some(1),
+        0xc2..=0xdf => Some(2),
+        0xe0..=0xef => Some(3),
+        0xf0..=0xf4 => Some(4),
+        _ => None,
     }
 }
 
@@ -253,8 +481,8 @@ fn build_replacement(
          Tool result id: {tool_call_id}\n\
          Artifact handle: {artifact_uri}\n\
          Storage: session tool-result artifact.\n\
-         Resolve this handle through runtime artifact recovery; do not search, \
-         copy, or read physical local session paths with workspace filesystem tools.\n\
+         Read bounded windows with introspect(artifact=\"{artifact_uri}\", offset=0, max_bytes={DEFAULT_TOOL_RESULT_WINDOW_BYTES}); \
+         continue with the returned next_offset. Do not search, copy, or read physical local session paths.\n\
          {format_note}\
          \n\
          Preview (first ~{prev_len} chars):\n\
@@ -297,8 +525,12 @@ mod tests {
         assert!(replacement.contains(PERSISTED_TAG_CLOSE));
         assert!(replacement.contains("bash"));
         assert!(replacement.contains("Tool result id: call-42"));
-        assert!(replacement.contains("Artifact handle: artifact://session/tool-result/call-42"));
+        assert!(replacement.contains(&format!(
+            "Artifact handle: {}",
+            session_tool_result_artifact_uri("call-42")
+        )));
         assert!(replacement.contains("session tool-result artifact"));
+        assert!(replacement.contains("introspect(artifact="));
         assert!(!replacement.contains("read_file"));
         assert!(!replacement.contains("File:"));
         assert!(!replacement.contains("tool-results"));
@@ -396,9 +628,106 @@ mod tests {
     fn session_artifact_uri_is_stable_and_path_free() {
         let uri = session_tool_result_artifact_uri("call_abc123");
 
-        assert_eq!(uri, "artifact://session/tool-result/call_abc123");
+        assert_eq!(uri, "artifact://session/tool-result/Y2FsbF9hYmMxMjM");
         assert!(!uri.contains(".astra"));
         assert!(!uri.contains("tool-results/"));
+    }
+
+    #[test]
+    fn artifact_handles_are_opaque_and_round_trip_every_provider_call_id() {
+        let provider_id = "call/with spaces: provider-owned 😀";
+        let uri = session_tool_result_artifact_uri(provider_id);
+        assert_eq!(
+            parse_session_tool_result_artifact_uri(&uri),
+            Some(provider_id.to_string())
+        );
+        assert!(!uri.contains(provider_id));
+        for invalid in [
+            "artifact://session/tool-result/",
+            "artifact://session/tool-result/../other-session",
+            "artifact://session/tool-result/call/child",
+            "artifact://session/tool-result/call+child",
+            "artifact://session/tool-result/call_abc-123",
+            "file:///tmp/result.txt",
+        ] {
+            assert_eq!(
+                parse_session_tool_result_artifact_uri(invalid),
+                None,
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn artifact_windows_round_trip_unicode_without_exposing_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = "前缀😀\n".repeat(10_000);
+        assert!(
+            maybe_persist_tool_result(dir.path(), "call-unicode", "bash", &content).is_some(),
+            "setup must create a session artifact"
+        );
+
+        let mut offset = 0;
+        let mut recovered = String::new();
+        while offset < content.len() {
+            let window = read_persisted_result_window(dir.path(), "call-unicode", offset, 7)
+                .unwrap()
+                .expect("persisted result exists");
+            assert!(window.next_offset > offset, "window must make progress");
+            assert!(content.is_char_boundary(window.offset));
+            assert!(content.is_char_boundary(window.next_offset));
+            recovered.push_str(&window.content);
+            offset = window.next_offset;
+        }
+        assert_eq!(recovered, content);
+
+        let rendered = resolve_session_tool_result_artifact_request(
+            dir.path(),
+            &serde_json::json!({
+                "artifact": session_tool_result_artifact_uri("call-unicode"),
+                "max_bytes": 7,
+            }),
+        )
+        .expect("artifact request is recognized")
+        .expect("artifact request succeeds");
+        assert!(rendered.contains(&format!(
+            "Artifact handle: {}",
+            session_tool_result_artifact_uri("call-unicode")
+        )));
+        assert!(rendered.contains("Continue with introspect("));
+        assert!(!rendered.contains(dir.path().to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn artifact_windows_reject_non_boundary_and_cross_session_lookup() {
+        let owner = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let content = "évidence\n".repeat(6_000);
+        assert!(
+            maybe_persist_tool_result(owner.path(), "call-boundary", "grep", &content).is_some()
+        );
+
+        let boundary_error = read_persisted_result_window(owner.path(), "call-boundary", 1, 32)
+            .expect_err("middle of a UTF-8 scalar must not be accepted");
+        assert!(boundary_error.contains("not a UTF-8 boundary"));
+        assert!(
+            read_persisted_result_window(other.path(), "call-boundary", 0, 32)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn artifact_windows_fail_closed_for_corrupt_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let results = tool_results_dir(dir.path());
+        std::fs::create_dir_all(&results).unwrap();
+        let path = results.join(format!("{}.txt", safe_filename_stem("call-corrupt")));
+        std::fs::write(path, b"valid prefix\xff").unwrap();
+
+        let error = read_persisted_result_window(dir.path(), "call-corrupt", 0, 64)
+            .expect_err("a corrupt artifact must not yield a partial evidence window");
+        assert!(error.contains("not valid UTF-8"), "{error}");
     }
 
     #[test]

--- a/crates/astra-turn-core/tests/phase_k_compaction_unhappy.rs
+++ b/crates/astra-turn-core/tests/phase_k_compaction_unhappy.rs
@@ -195,7 +195,8 @@ fn phase_k_state_aware_pins_active_files() {
 #[test]
 fn phase_k_persisted_markers_never_compact_even_under_pressure() {
     let persisted = "<persisted-output>\nTool `read_file` produced 50000 chars.\n\
-         File: /tmp/sessions/tool_results/c1.txt\n\
+         Artifact handle: artifact://session/tool-result/YzE\n\
+         Read with introspect(artifact=\"artifact://session/tool-result/YzE\", offset=0, max_bytes=8192).\n\
          Preview: ...\n</persisted-output>"
         .to_string();
     let live = "x".repeat(3000);

--- a/crates/runtime/src/server/runtime_tool_executor.rs
+++ b/crates/runtime/src/server/runtime_tool_executor.rs
@@ -5306,6 +5306,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn server_introspect_recovers_only_owner_scoped_tool_result_artifacts() {
+        let sessions = TempDir::new().unwrap();
+        let _guard = astra_services::session_journal::JournalDirGuard::new(sessions.path());
+        let (exec, _workspace) = test_executor();
+        let owner = astra_services::OwnerScope::user(&exec.user_id).unwrap();
+        let store = astra_services::local_session_artifact_store();
+        let session_dir = astra_services::SessionArtifactStore::session_dir_for_owner(
+            &store,
+            &owner,
+            &exec.session_id,
+        )
+        .expect("runtime owner and session resolve to a private artifact directory");
+        let content = "server-owned evidence 😀\n".repeat(3_000);
+        assert!(
+            astra_turn_core::tool_result_storage::maybe_persist_tool_result(
+                &session_dir,
+                "call-server-artifact",
+                "git",
+                &content,
+            )
+            .is_some(),
+            "setup must persist a recoverable result in the runtime owner's session"
+        );
+
+        let result = exec
+            .execute_with_metadata(
+                "introspect",
+                &json!({
+                    "artifact": astra_turn_core::tool_result_storage::session_tool_result_artifact_uri(
+                        "call-server-artifact"
+                    ),
+                    "max_bytes": 31,
+                }),
+            )
+            .await;
+        assert!(!result.is_error, "{result:?}");
+        assert!(result.output.contains("<tool-result-window>"), "{result:?}");
+        assert!(
+            result.output.contains("server-owned evidence"),
+            "{result:?}"
+        );
+        assert!(
+            result.output.contains("Continue with introspect("),
+            "{result:?}"
+        );
+        assert!(
+            !result
+                .output
+                .contains(sessions.path().to_string_lossy().as_ref()),
+            "model output must never disclose the physical owner/session path: {result:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn server_only_introspect_json_preserves_provider_coverage_graph() {
         let dir = TempDir::new().unwrap();
         let exec = RuntimeToolExecutor::new(

--- a/crates/runtime/src/server/runtime_tool_executor/tool_handlers.rs
+++ b/crates/runtime/src/server/runtime_tool_executor/tool_handlers.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::Ordering;
 
+use astra_services::{OwnerScope, SessionArtifactStore};
 use astra_turn_core::tool::schema::tool_schema_name;
 use async_trait::async_trait;
 use serde_json::Value;
@@ -491,6 +492,35 @@ impl ToolHandler<RuntimeToolExecutor> for IntrospectToolHandler {
         args: &Value,
         _cancel_token: Option<&CancellationToken>,
     ) -> astra_tools::ToolResult {
+        if args.get("artifact").is_some() {
+            let owner = match OwnerScope::user(&context.user_id) {
+                Ok(owner) => owner,
+                Err(error) => {
+                    return astra_tools::ToolResult::error(format!(
+                        "Error: could not resolve artifact owner: {error}"
+                    ));
+                }
+            };
+            let store = astra_services::local_session_artifact_store();
+            let session_dir = match store.session_dir_for_owner(&owner, &context.session_id) {
+                Ok(session_dir) => session_dir,
+                Err(error) => {
+                    return astra_tools::ToolResult::error(format!(
+                        "Error: could not resolve the active session for artifact recovery: {error}"
+                    ));
+                }
+            };
+            return tool_result_from_output(
+                astra_turn_core::tool_result_storage::resolve_session_tool_result_artifact_request(
+                    &session_dir,
+                    args,
+                )
+                .unwrap_or_else(|| {
+                    Err("introspect artifact recovery request was not recognized".to_string())
+                })
+                .unwrap_or_else(|error| format!("Error: {error}")),
+            );
+        }
         let mut snapshot = current_introspect_snapshot(
             &context.session_id,
             &context.introspect_snapshot,

--- a/crates/runtime/src/server/tool_local_execution.rs
+++ b/crates/runtime/src/server/tool_local_execution.rs
@@ -150,15 +150,11 @@ pub(crate) fn normalize_local_tool_result_output(
     aggregate_output_bytes: &AtomicUsize,
 ) {
     result.output = astra_tools::normalize_empty_output(std::mem::take(&mut result.output), name);
-    let aggregate_before = aggregate_output_bytes.fetch_add(result.output.len(), Ordering::Relaxed);
-    let aggregate_after = aggregate_before.saturating_add(result.output.len());
-    result.output = astra_tools::maybe_persist_large_output(
-        std::mem::take(&mut result.output),
-        aggregate_after,
-        name,
-    );
-    let limit = astra_tools::per_tool_output_limit(name);
-    result.output = astra_tools::truncate_output(std::mem::take(&mut result.output), limit);
+    // The headless recording pipeline owns model-facing truncation and,
+    // crucially, has the session + tool-call id required to make an oversized
+    // result recoverable. Truncating or globally persisting here would discard
+    // evidence before that owner can create a session-scoped artifact handle.
+    aggregate_output_bytes.fetch_add(result.output.len(), Ordering::Relaxed);
 }
 
 pub(crate) fn spawn_memory_recall_feedback_after_success(
@@ -341,6 +337,18 @@ mod tests {
 
         assert_eq!(result.output, "(bash completed with no output)");
         assert_eq!(aggregate.load(Ordering::Relaxed), result.output.len());
+    }
+
+    #[test]
+    fn normalize_large_output_keeps_full_evidence_for_session_recording() {
+        let aggregate = AtomicUsize::new(0);
+        let output = "review evidence\n".repeat(6_000);
+        let mut result = astra_tools::ToolResult::text(output.clone());
+
+        normalize_local_tool_result_output("git", &mut result, &aggregate);
+
+        assert_eq!(result.output, output);
+        assert_eq!(aggregate.load(Ordering::Relaxed), output.len());
     }
 
     #[test]

--- a/crates/runtime/src/turn/headless_tool_pipeline/record.rs
+++ b/crates/runtime/src/turn/headless_tool_pipeline/record.rs
@@ -438,6 +438,37 @@ mod tests {
     }
 
     #[test]
+    fn model_result_persistence_binds_large_evidence_to_its_owner_and_call_id() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _guard = JournalDirGuard::new(temp.path());
+        let session_id = format!("persisted-tool-result-{}", uuid::Uuid::new_v4());
+        let content = "review evidence 😀\n".repeat(4_000);
+        let inline = "inline preview should be replaced".to_string();
+
+        let model_result = maybe_persist_model_tool_result(
+            Some("reviewer-a"),
+            Some(&session_id),
+            "call-evidence-1",
+            "git",
+            &content,
+            inline,
+        );
+
+        assert!(model_result.contains(
+            &astra_turn_core::tool_result_storage::session_tool_result_artifact_uri(
+                "call-evidence-1"
+            )
+        ));
+        assert!(model_result.contains("introspect(artifact="));
+        let dir = model_tool_result_session_dir(Some("reviewer-a"), &session_id).unwrap();
+        assert_eq!(
+            astra_turn_core::tool_result_storage::read_persisted_result(&dir, "call-evidence-1"),
+            Some(content),
+            "the model handle and durable evidence must share the same owner/session/call identity"
+        );
+    }
+
+    #[test]
     fn result_that_never_started_is_rejected_not_executed() {
         let fields = json!({
             "execution_started": false,


### PR DESCRIPTION
## Summary
- bind oversized tool results to owner/session/call identity before replacing model-visible output
- recover bounded UTF-8-safe windows through `introspect` with opaque logical handles
- remove unreachable global persistence/preview code and its nondeterministic tests
- add owner-isolation, malformed/corrupt artifact, Unicode-window, and live harness coverage

## Validation
- `make check`
- `CARGO_BUILD_JOBS=1 make test-offline`
- `make test-harness MODELS=deepseek-v4-flash FORCE_MODEL=deepseek-v4-flash JUDGER=deepseek-v4-flash FILTER=session_tool_result_artifact_recovery` (PASS)

The initial unrestricted offline run was killed by host resource pressure while linking; the serial-build rerun completed the complete suite successfully.