### PR TITLE
fix(runtime): extend agent binding MCP timeout

### DIFF
--- a/crates/runtime/src/server/runtime_mcp.rs
+++ b/crates/runtime/src/server/runtime_mcp.rs
@@ -30,7 +30,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::sync::RwLock;
 
-const AGENT_BINDING_MCP_RPC_TIMEOUT_SECS: u64 = 30;
+const AGENT_BINDING_MCP_RPC_TIMEOUT_SECS: u64 = 120;
 const AGENT_BINDING_SEMANTIC_READ_PREPARE_TIMEOUT: Duration = Duration::from_secs(2);
 const AGENT_BINDING_SEMANTIC_READ_CONTRACT_VERSION: &str =
     astra_services::runs::RUNTIME_SEMANTIC_READ_MCP_CONTRACT_VERSION;


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

N/A — follow-up found while validating MOI sandbox queue and execution timeouts.

## What this PR does / why we need it

- Extends the Agent Binding MCP RPC timeout from 30 seconds to 120 seconds.
- Prevents Astra from terminating a valid provider call before a 30-second sandbox queue wait and subsequent command execution can complete.
- Keeps queue-timeout and command-timeout semantics owned by the provider response instead of conflating them with Astra's transport deadline.

## Architecture and complexity delta

- Canonical owner changed or extended: Agent Binding MCP transport in `astra-runtime`.
- Existing implementations/callers searched: the shared timeout constant and both Agent Binding MCP request paths.
- Superseded code, states, tables, shims, and self-only tests removed: N/A.
- Net code/state/table delta: one constant value changed; no new state or abstraction.
- If parallel implementations remain, the external boundary and retirement condition: N/A.

## Production wiring and verification

- Public product entrypoint exercised: MOI Agent Binding MCP sandbox calls under local timeout fault injection.
- Unhappy paths exercised: `agent_binding_timeout_preserves_unknown_outcome_evidence` passed; provider timeout evidence remains unchanged.
- Database schema/query/transaction/migration verified against a real database, or `N/A` with reason: N/A (transport timeout only; no database changes).
- `cargo fmt --all -- --check`
- `cargo test -p astra-runtime agent_binding_timeout_preserves_unknown_outcome_evidence --lib`
- `cargo clippy -p astra-runtime --all-targets -- -D warnings`
