### PR TITLE
fix(session): enforce causal recovery, retention, and bridge fencing

### DIFF
--- a/crates/astra-cli/src/cli/one_shot_session_routing.rs
+++ b/crates/astra-cli/src/cli/one_shot_session_routing.rs
@@ -54,6 +54,7 @@ impl OneShotSessionRouting {
                     source: astra_turn_types::ResumeSourceV1::Checkpoint,
                     cursor,
                     conversation_messages: messages,
+                    materialized_conversation_root_hash: None,
                     degraded_reasons: vec![
                         astra_turn_types::ResumeDegradedReasonV1::LegacyCursorUnknown,
                         astra_turn_types::ResumeDegradedReasonV1::ProjectionCursorMissing,
@@ -431,6 +432,7 @@ mod tests {
                 source: astra_turn_types::ResumeSourceV1::Checkpoint,
                 cursor,
                 conversation_messages: messages,
+                materialized_conversation_root_hash: None,
                 degraded_reasons: Vec::new(),
                 repair_actions: Vec::new(),
                 projections: astra_turn_types::ResumeProjectionSetV1 {

--- a/crates/astra-cli/src/cli/session/session_continuation.rs
+++ b/crates/astra-cli/src/cli/session/session_continuation.rs
@@ -115,6 +115,7 @@ pub(crate) fn continuation_from_resume_bundle(
         cursor,
         source: resume_source,
         conversation_messages: messages,
+        materialized_conversation_root_hash: _,
         degraded_reasons,
         repair_actions,
         projections,
@@ -150,8 +151,21 @@ pub(crate) fn continuation_from_resume_bundle(
         )
         .ok()?
     } else {
+        // The server's schema-v2 cursor identifies the immutable manifest,
+        // while the local ActiveConversation journal identifies its flattened
+        // projection. Keep the authoritative cursor in `resume`, but derive a
+        // schema-v1 content cursor for the local projection store.
+        let mut projection_cursor = cursor.clone();
+        if projection_cursor.projection_schema
+            == astra_turn_types::SEGMENTED_CONVERSATION_PROJECTION_SCHEMA_VERSION
+        {
+            projection_cursor.projection_schema =
+                astra_turn_types::CONVERSATION_PROJECTION_SCHEMA_VERSION;
+            projection_cursor.canonical_root_hash =
+                astra_turn_types::canonical_conversation_root(&messages);
+        }
         astra_turn_core::active_conversation::ActiveConversation::from_cursor_projection(
-            cursor.clone(),
+            projection_cursor,
             messages.clone(),
             source,
         )
@@ -774,6 +788,56 @@ mod tests {
             ),
             messages,
             "instrumentation must not project or reinterpret typed continuation data"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn segmented_resume_keeps_authority_cursor_and_derives_local_content_cursor() {
+        let _identity = crate::cli::cli_config::cli_utils::install_cli_profile_identity_for_test(
+            "segmented-resume-profile",
+            Some("account-1"),
+        )
+        .unwrap();
+        let messages = vec![json!({"role": "user", "content": "resume"})];
+        let materialized_root = astra_turn_types::canonical_conversation_root(&messages);
+        let cursor = astra_turn_types::SessionCursorV1 {
+            schema_version: astra_turn_types::SESSION_CURSOR_SCHEMA_VERSION,
+            owner_id: "account-1".into(),
+            session_id: "segmented-session".into(),
+            branch_id: astra_turn_types::DEFAULT_CONVERSATION_BRANCH_ID.into(),
+            completed_turn: 1,
+            journal_event_seq: 1,
+            conversation_seq: 1,
+            canonical_root_hash: "a".repeat(64),
+            projection_schema: astra_turn_types::SEGMENTED_CONVERSATION_PROJECTION_SCHEMA_VERSION,
+            compaction_generation: 0,
+            config_version_id: None,
+        };
+        let continuation =
+            super::continuation_from_resume_bundle(astra_turn_types::ResumeBundleV1 {
+                schema_version: astra_turn_types::RESUME_BUNDLE_SCHEMA_VERSION,
+                cursor: cursor.clone(),
+                source: astra_turn_types::ResumeSourceV1::CanonicalJournal,
+                conversation_messages: messages,
+                materialized_conversation_root_hash: Some(materialized_root.clone()),
+                degraded_reasons: Vec::new(),
+                repair_actions: Vec::new(),
+                projections: Default::default(),
+            })
+            .expect("segmented canonical resume must create a local continuation");
+
+        assert_eq!(continuation.resume.cursor, cursor);
+        assert_eq!(
+            continuation.active_conversation.cursor().projection_schema,
+            astra_turn_types::CONVERSATION_PROJECTION_SCHEMA_VERSION
+        );
+        assert_eq!(
+            continuation
+                .active_conversation
+                .cursor()
+                .canonical_root_hash,
+            materialized_root
         );
     }
 

--- a/crates/astra-cli/src/cli/session/session_restore_client.rs
+++ b/crates/astra-cli/src/cli/session/session_restore_client.rs
@@ -51,6 +51,8 @@ fn validate_restored_session(
         if bundle.cursor.schema_version != 0
             && bundle.cursor.projection_schema
                 != astra_turn_types::CONVERSATION_PROJECTION_SCHEMA_VERSION
+            && bundle.cursor.projection_schema
+                != astra_turn_types::SEGMENTED_CONVERSATION_PROJECTION_SCHEMA_VERSION
         {
             return Err(format!(
                 "resume projection schema {} is unsupported",
@@ -258,6 +260,7 @@ mod tests {
             cursor,
             source: astra_turn_types::ResumeSourceV1::CanonicalJournal,
             conversation_messages: messages,
+            materialized_conversation_root_hash: None,
             degraded_reasons: Vec::new(),
             repair_actions: Vec::new(),
             projections: Default::default(),

--- a/crates/astra-cli/src/cli/slash/slash_session.rs
+++ b/crates/astra-cli/src/cli/slash/slash_session.rs
@@ -5561,6 +5561,7 @@ async fn apply_restored_session(
                 source: astra_turn_types::ResumeSourceV1::Checkpoint,
                 cursor,
                 conversation_messages: messages,
+                materialized_conversation_root_hash: None,
                 degraded_reasons: vec![
                     astra_turn_types::ResumeDegradedReasonV1::LegacyCursorUnknown,
                     astra_turn_types::ResumeDegradedReasonV1::ProjectionCursorMissing,
@@ -7133,6 +7134,7 @@ mod resume_tests {
             cursor: cursor.clone(),
             source: astra_turn_types::ResumeSourceV1::Checkpoint,
             conversation_messages: messages.clone(),
+            materialized_conversation_root_hash: None,
             degraded_reasons: vec![astra_turn_types::ResumeDegradedReasonV1::CheckpointFallback],
             repair_actions: Vec::new(),
             projections: Default::default(),

--- a/crates/astra-turn-types/src/lib.rs
+++ b/crates/astra-turn-types/src/lib.rs
@@ -90,12 +90,12 @@ pub use semantic_read_cache::{
 pub use session_coordination::{
     ActorContextV1, ActorKindV1, AuthorityEpochsV1, CANONICAL_TURN_DELTA_SCHEMA_VERSION,
     CONTEXT_MANIFEST_NODE_SCHEMA_VERSION, CONVERSATION_AUTHORITY_ENVELOPE_SCHEMA_VERSION,
-    CONVERSATION_SEGMENT_SCHEMA_VERSION, CanonicalTurnDeltaV1, ContextManifestNodeV1,
-    ConversationAuthorityEnvelopeV1, ConversationSegmentRefV1, ConversationSegmentV1,
-    ConversationWriterLeaseV1, CoordinatorConflictOptionV1, CoordinatorMutationV1,
-    EXECUTION_GRANT_SCHEMA_VERSION, ExecutionGrantClaimsV1, SESSION_COORDINATION_SCHEMA_VERSION,
-    SessionContextHeadV1, SessionCoordinationValidationError, SessionKeyV1, SessionSurfaceV1,
-    SignedExecutionGrantV1, TurnReservationV1,
+    CONVERSATION_SEGMENT_SCHEMA_VERSION, CanonicalDeltaModeV1, CanonicalTurnDeltaV1,
+    ContextManifestNodeV1, ConversationAuthorityEnvelopeV1, ConversationSegmentRefV1,
+    ConversationSegmentV1, ConversationWriterLeaseV1, CoordinatorConflictOptionV1,
+    CoordinatorMutationV1, EXECUTION_GRANT_SCHEMA_VERSION, ExecutionGrantClaimsV1,
+    SESSION_COORDINATION_SCHEMA_VERSION, SessionContextHeadV1, SessionCoordinationValidationError,
+    SessionKeyV1, SessionSurfaceV1, SignedExecutionGrantV1, TurnReservationV1,
 };
 pub use session_cursor::{
     CONVERSATION_COMMIT_SCHEMA_VERSION, CONVERSATION_PROJECTION_SCHEMA_VERSION,

--- a/crates/astra-turn-types/src/resume.rs
+++ b/crates/astra-turn-types/src/resume.rs
@@ -4,7 +4,8 @@ use thiserror::Error;
 
 use crate::{
     CONVERSATION_PROJECTION_SCHEMA_VERSION, DEFAULT_CONVERSATION_BRANCH_ID,
-    SESSION_CURSOR_SCHEMA_VERSION, SessionCursorV1, canonical_conversation_root,
+    SEGMENTED_CONVERSATION_PROJECTION_SCHEMA_VERSION, SESSION_CURSOR_SCHEMA_VERSION,
+    SessionCursorV1, canonical_conversation_root,
 };
 
 pub const CAUSAL_PROJECTION_ENVELOPE_SCHEMA_VERSION: u32 = 1;
@@ -307,6 +308,10 @@ pub struct ResumeCandidateV1 {
     pub source: ResumeSourceV1,
     pub cursor: SessionCursorV1,
     pub conversation_messages: Vec<Value>,
+    /// Content identity for projections whose cursor root identifies a
+    /// manifest rather than the flattened message vector.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub materialized_conversation_root_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub degraded_reasons: Vec<ResumeDegradedReasonV1>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -317,7 +322,12 @@ pub struct ResumeCandidateV1 {
 
 impl ResumeCandidateV1 {
     pub fn validates_root(&self) -> bool {
-        canonical_conversation_root(&self.conversation_messages) == self.cursor.canonical_root_hash
+        validates_materialized_root(
+            self.source,
+            &self.cursor,
+            &self.conversation_messages,
+            self.materialized_conversation_root_hash.as_deref(),
+        )
     }
 
     pub fn descriptor(&self) -> ResumeDescriptorV1 {
@@ -357,6 +367,8 @@ pub struct ResumeBundleV1 {
     pub cursor: SessionCursorV1,
     pub source: ResumeSourceV1,
     pub conversation_messages: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub materialized_conversation_root_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub degraded_reasons: Vec<ResumeDegradedReasonV1>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -371,7 +383,12 @@ impl ResumeBundleV1 {
     }
 
     pub fn validates_root(&self) -> bool {
-        canonical_conversation_root(&self.conversation_messages) == self.cursor.canonical_root_hash
+        validates_materialized_root(
+            self.source,
+            &self.cursor,
+            &self.conversation_messages,
+            self.materialized_conversation_root_hash.as_deref(),
+        )
     }
 
     pub fn descriptor(&self) -> ResumeDescriptorV1 {
@@ -429,7 +446,9 @@ fn validate_cursor_schema(cursor: &SessionCursorV1) -> Result<(), ResumeSelectio
             cursor.schema_version,
         ));
     }
-    if cursor.projection_schema != CONVERSATION_PROJECTION_SCHEMA_VERSION {
+    if cursor.projection_schema != CONVERSATION_PROJECTION_SCHEMA_VERSION
+        && cursor.projection_schema != SEGMENTED_CONVERSATION_PROJECTION_SCHEMA_VERSION
+    {
         return Err(ResumeSelectionError::UnsupportedProjectionSchema(
             cursor.projection_schema,
         ));
@@ -572,10 +591,27 @@ pub fn select_resume_bundle(
         cursor,
         source: selected.source,
         conversation_messages: selected.conversation_messages,
+        materialized_conversation_root_hash: selected.materialized_conversation_root_hash,
         degraded_reasons: selected.degraded_reasons,
         repair_actions: selected.repair_actions,
         projections: selected.projections,
     })
+}
+
+fn validates_materialized_root(
+    source: ResumeSourceV1,
+    cursor: &SessionCursorV1,
+    messages: &[Value],
+    materialized_root: Option<&str>,
+) -> bool {
+    let root = canonical_conversation_root(messages);
+    match cursor.projection_schema {
+        0 | CONVERSATION_PROJECTION_SCHEMA_VERSION => root == cursor.canonical_root_hash,
+        SEGMENTED_CONVERSATION_PROJECTION_SCHEMA_VERSION => {
+            source == ResumeSourceV1::CanonicalJournal && materialized_root == Some(root.as_str())
+        }
+        _ => false,
+    }
 }
 
 pub fn legacy_resume_cursor(
@@ -627,6 +663,7 @@ mod tests {
             source,
             cursor: cursor(seq, &canonical_conversation_root(&messages)),
             conversation_messages: messages,
+            materialized_conversation_root_hash: None,
             degraded_reasons: Vec::new(),
             repair_actions: Vec::new(),
             projections: ResumeProjectionSetV1::default(),
@@ -641,6 +678,34 @@ mod tests {
         let selected = select_resume_bundle(Some(&head), [unrelated, canonical]).unwrap();
         assert_eq!(selected.source, ResumeSourceV1::CanonicalJournal);
         assert_eq!(selected.cursor, head);
+    }
+
+    #[test]
+    fn segmented_canonical_resume_verifies_materialized_content_separately_from_manifest_identity()
+    {
+        let messages = vec![json!({"role": "user", "content": "canonical"})];
+        let content_root = canonical_conversation_root(&messages);
+        let mut manifest_cursor = cursor(2, &"a".repeat(64));
+        manifest_cursor.projection_schema = SEGMENTED_CONVERSATION_PROJECTION_SCHEMA_VERSION;
+        let candidate = ResumeCandidateV1 {
+            source: ResumeSourceV1::CanonicalJournal,
+            cursor: manifest_cursor.clone(),
+            conversation_messages: messages.clone(),
+            materialized_conversation_root_hash: Some(content_root),
+            degraded_reasons: Vec::new(),
+            repair_actions: Vec::new(),
+            projections: ResumeProjectionSetV1::default(),
+        };
+
+        let selected = select_resume_bundle(Some(&manifest_cursor), [candidate.clone()]).unwrap();
+        assert!(selected.validates_root());
+
+        let mut missing_proof = candidate;
+        missing_proof.materialized_conversation_root_hash = None;
+        assert_eq!(
+            select_resume_bundle(Some(&manifest_cursor), [missing_proof]),
+            Err(ResumeSelectionError::NoCandidate)
+        );
     }
 
     #[test]
@@ -682,6 +747,7 @@ mod tests {
             source: ResumeSourceV1::Checkpoint,
             cursor: legacy_resume_cursor("owner", "session", 7, &messages),
             conversation_messages: messages,
+            materialized_conversation_root_hash: None,
             degraded_reasons: vec![
                 ResumeDegradedReasonV1::LegacyCursorUnknown,
                 ResumeDegradedReasonV1::CheckpointFallback,

--- a/crates/astra-turn-types/src/session_coordination.rs
+++ b/crates/astra-turn-types/src/session_coordination.rs
@@ -17,6 +17,7 @@ pub const CONVERSATION_AUTHORITY_ENVELOPE_SCHEMA_VERSION: u32 = 1;
 
 const SEGMENT_HASH_DOMAIN: &[u8] = b"astra.owner-scoped-conversation-segment.v1\0";
 const MANIFEST_HASH_DOMAIN: &[u8] = b"astra.incremental-context-manifest.v1\0";
+const REPLACEMENT_MANIFEST_MARKER: &[u8] = b"replacement\0";
 
 /// Full isolation key for one canonical conversation branch.
 ///
@@ -279,6 +280,11 @@ pub struct ContextManifestNodeV1 {
     pub compaction_generation: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config_version_id: Option<String>,
+    /// This node contains the complete canonical projection at this point.
+    /// Its parent remains committed for lineage/audit, but materialization
+    /// must not read content through that parent.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub replaces_history: bool,
     pub appended_segments: Vec<ConversationSegmentRefV1>,
     pub manifest_root: String,
 }
@@ -293,6 +299,55 @@ impl ContextManifestNodeV1 {
         conversation_seq: u64,
         compaction_generation: u64,
         config_version_id: Option<String>,
+        appended_segments: Vec<ConversationSegmentRefV1>,
+    ) -> Result<Self, SessionCoordinationValidationError> {
+        Self::new_with_mode(
+            key,
+            parent_manifest_root,
+            completed_turn,
+            journal_event_seq,
+            conversation_seq,
+            compaction_generation,
+            config_version_id,
+            false,
+            appended_segments,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_replacement(
+        key: SessionKeyV1,
+        parent_manifest_root: Option<String>,
+        completed_turn: u32,
+        journal_event_seq: u64,
+        conversation_seq: u64,
+        compaction_generation: u64,
+        config_version_id: Option<String>,
+        appended_segments: Vec<ConversationSegmentRefV1>,
+    ) -> Result<Self, SessionCoordinationValidationError> {
+        Self::new_with_mode(
+            key,
+            parent_manifest_root,
+            completed_turn,
+            journal_event_seq,
+            conversation_seq,
+            compaction_generation,
+            config_version_id,
+            true,
+            appended_segments,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_mode(
+        key: SessionKeyV1,
+        parent_manifest_root: Option<String>,
+        completed_turn: u32,
+        journal_event_seq: u64,
+        conversation_seq: u64,
+        compaction_generation: u64,
+        config_version_id: Option<String>,
+        replaces_history: bool,
         appended_segments: Vec<ConversationSegmentRefV1>,
     ) -> Result<Self, SessionCoordinationValidationError> {
         key.validate()?;
@@ -320,6 +375,7 @@ impl ContextManifestNodeV1 {
             conversation_seq,
             compaction_generation,
             config_version_id.as_deref(),
+            replaces_history,
             &appended_segments,
         );
         Ok(Self {
@@ -331,6 +387,7 @@ impl ContextManifestNodeV1 {
             conversation_seq,
             compaction_generation,
             config_version_id,
+            replaces_history,
             appended_segments,
             manifest_root,
         })
@@ -353,7 +410,7 @@ impl ContextManifestNodeV1 {
     }
 
     pub fn validate(&self) -> Result<(), SessionCoordinationValidationError> {
-        let expected = Self::new(
+        let expected = Self::new_with_mode(
             self.key.clone(),
             self.parent_manifest_root.clone(),
             self.completed_turn,
@@ -361,6 +418,7 @@ impl ContextManifestNodeV1 {
             self.conversation_seq,
             self.compaction_generation,
             self.config_version_id.clone(),
+            self.replaces_history,
             self.appended_segments.clone(),
         )?;
         if expected.manifest_root != self.manifest_root {
@@ -508,6 +566,14 @@ impl ConversationAuthorityEnvelopeV1 {
 
 /// Changed logical groups and deterministic cursor coordinates for one turn.
 /// The coordinator derives the new root; callers cannot choose it.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CanonicalDeltaModeV1 {
+    #[default]
+    Append,
+    Replace,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CanonicalTurnDeltaV1 {
     pub schema_version: u32,
@@ -517,7 +583,17 @@ pub struct CanonicalTurnDeltaV1 {
     pub compaction_generation: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config_version_id: Option<String>,
+    #[serde(default, skip_serializing_if = "is_append_delta")]
+    pub mode: CanonicalDeltaModeV1,
     pub logical_segments: Vec<Vec<Value>>,
+}
+
+fn is_append_delta(mode: &CanonicalDeltaModeV1) -> bool {
+    *mode == CanonicalDeltaModeV1::Append
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 impl CanonicalTurnDeltaV1 {
@@ -643,10 +719,14 @@ fn manifest_hash(
     conversation_seq: u64,
     compaction_generation: u64,
     config_version_id: Option<&str>,
+    replaces_history: bool,
     segments: &[ConversationSegmentRefV1],
 ) -> String {
     let mut digest = Sha256::new();
     digest.update(MANIFEST_HASH_DOMAIN);
+    if replaces_history {
+        digest.update(REPLACEMENT_MANIFEST_MARKER);
+    }
     hash_field(&mut digest, key.isolation_domain.as_bytes());
     hash_field(&mut digest, key.owner_user_id.as_bytes());
     hash_field(&mut digest, key.session_id.as_bytes());

--- a/crates/astra-turn-types/src/session_handoff.rs
+++ b/crates/astra-turn-types/src/session_handoff.rs
@@ -148,8 +148,12 @@ impl ManifestDeltaV1 {
                         .as_ref()
                         .map(|prefix| prefix.parent_manifest_root.as_str())
                 });
-                for node in &self.missing_nodes {
-                    if node.parent_manifest_root.as_deref() != expected_parent {
+                for (index, node) in self.missing_nodes.iter().enumerate() {
+                    let replacement_from_empty =
+                        index == 0 && expected_parent.is_none() && node.replaces_history;
+                    if !replacement_from_empty
+                        && node.parent_manifest_root.as_deref() != expected_parent
+                    {
                         return Err(SessionHandoffValidationError::InvalidManifestDelta);
                     }
                     expected_parent = Some(node.manifest_root.as_str());
@@ -313,6 +317,9 @@ pub struct SessionHandoffRecordV1 {
     pub reason: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status_detail: Option<String>,
+    /// Exact operation state interrupted by `Blocked`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked_from: Option<SessionHandoffStateV1>,
     pub deadline_unix_ms: i64,
     pub created_at_unix_ms: i64,
     pub updated_at_unix_ms: i64,
@@ -346,6 +353,8 @@ impl SessionHandoffRecordV1 {
         if self.transition_seq == 0
             || self.deadline_unix_ms <= self.created_at_unix_ms
             || self.updated_at_unix_ms < self.created_at_unix_ms
+            || (self.state != SessionHandoffStateV1::Blocked && self.blocked_from.is_some())
+            || self.blocked_from == Some(SessionHandoffStateV1::Blocked)
         {
             return Err(SessionHandoffValidationError::InvalidCoordinate);
         }
@@ -368,7 +377,10 @@ impl SessionHandoffRecordV1 {
         if self.state != expected {
             return Err(SessionHandoffValidationError::StateConflict);
         }
-        if !valid_transition(self.mode, expected, next) {
+        let resumes_blocked_operation = expected == SessionHandoffStateV1::Blocked
+            && (self.blocked_from == Some(next)
+                || (self.blocked_from.is_none() && next == SessionHandoffStateV1::Validating));
+        if !resumes_blocked_operation && !valid_transition(self.mode, expected, next) {
             return Err(SessionHandoffValidationError::InvalidTransition {
                 from: expected,
                 to: next,
@@ -376,6 +388,11 @@ impl SessionHandoffRecordV1 {
         }
         if now_unix_ms < self.updated_at_unix_ms {
             return Err(SessionHandoffValidationError::InvalidCoordinate);
+        }
+        if next == SessionHandoffStateV1::Blocked {
+            self.blocked_from = Some(expected);
+        } else if expected == SessionHandoffStateV1::Blocked {
+            self.blocked_from = None;
         }
         self.state = next;
         self.updated_at_unix_ms = now_unix_ms;
@@ -393,6 +410,9 @@ pub fn valid_transition(
     to: SessionHandoffStateV1,
 ) -> bool {
     use SessionHandoffStateV1 as State;
+    if from == to {
+        return false;
+    }
     if matches!(to, State::Blocked | State::Aborted)
         && !matches!(from, State::Active | State::Aborted)
     {
@@ -405,7 +425,6 @@ pub fn valid_transition(
             | (_, State::Fenced, State::Hydrating)
             | (_, State::Hydrating, State::Active)
             | (_, State::NeedsReconciliation, State::Fencing)
-            | (_, State::Blocked, State::Validating)
             | (
                 SessionHandoffModeV1::Graceful,
                 State::Validating,
@@ -534,6 +553,7 @@ mod tests {
             },
             reason: "move".into(),
             status_detail: None,
+            blocked_from: None,
             deadline_unix_ms: 10_000,
             created_at_unix_ms: 1_000,
             updated_at_unix_ms: 1_000,
@@ -601,6 +621,49 @@ mod tests {
         }
         assert!(handoff.state.is_terminal());
         assert_eq!(handoff.transition_seq, 8);
+    }
+
+    #[test]
+    fn blocked_retry_resumes_the_exact_interrupted_operation() {
+        let mut fencing = record(SessionHandoffModeV1::Forced);
+        fencing
+            .transition(
+                SessionHandoffStateV1::Requested,
+                SessionHandoffStateV1::Validating,
+                1_001,
+            )
+            .unwrap();
+        fencing
+            .transition(
+                SessionHandoffStateV1::Validating,
+                SessionHandoffStateV1::Fencing,
+                1_002,
+            )
+            .unwrap();
+        fencing
+            .transition(
+                SessionHandoffStateV1::Fencing,
+                SessionHandoffStateV1::Blocked,
+                1_003,
+            )
+            .unwrap();
+        assert_eq!(fencing.blocked_from, Some(SessionHandoffStateV1::Fencing));
+        assert!(matches!(
+            fencing.transition(
+                SessionHandoffStateV1::Blocked,
+                SessionHandoffStateV1::Validating,
+                1_004,
+            ),
+            Err(SessionHandoffValidationError::InvalidTransition { .. })
+        ));
+        fencing
+            .transition(
+                SessionHandoffStateV1::Blocked,
+                SessionHandoffStateV1::Fencing,
+                1_004,
+            )
+            .unwrap();
+        assert_eq!(fencing.blocked_from, None);
     }
 
     #[test]

--- a/crates/runtime/src/server/bridge_prep.rs
+++ b/crates/runtime/src/server/bridge_prep.rs
@@ -635,12 +635,7 @@ async fn prepare_chat_turn_bridge_identifiers(
     explicit_identity: Option<&ExplicitBridgeTurnIdentity>,
 ) -> Result<(String, String, u32), (StatusCode, Json<ErrorResponse>)> {
     if let Some(identity) = explicit_identity {
-        let inferred_session_turn = crate::server::session_turn::infer_session_turn(
-            state.shared_pool.as_ref(),
-            user_id,
-            session_id,
-        )
-        .await;
+        let next_session_turn = bridge_next_canonical_turn(state, user_id, session_id).await?;
         let now = current_unix_seconds();
         let cache_key = bridge_cache_key(user_id, session_id);
         let mut cache = state.chat_turn_bridge_cache.lock().await;
@@ -662,11 +657,11 @@ async fn prepare_chat_turn_bridge_identifiers(
                 == Some(identity.user_query_event_id.as_str());
         let is_continuation = bridge_turn_is_continuation(messages, has_tool_results);
         let minimum_session_turn = if is_continuation || same_identity {
-            cached_turn.unwrap_or(inferred_session_turn)
+            cached_turn.unwrap_or(next_session_turn)
         } else {
             cached_turn
                 .map(|turn| turn.saturating_add(1))
-                .unwrap_or(inferred_session_turn)
+                .unwrap_or(next_session_turn)
         };
         if identity.session_turn < minimum_session_turn {
             return Err(astra_core::error_response_coded_with_metadata(
@@ -704,12 +699,7 @@ async fn prepare_chat_turn_bridge_identifiers(
             identity.session_turn,
         ));
     }
-    let inferred_session_turn = crate::server::session_turn::infer_session_turn(
-        state.shared_pool.as_ref(),
-        user_id,
-        session_id,
-    )
-    .await;
+    let next_session_turn = bridge_next_canonical_turn(state, user_id, session_id).await?;
     let now = current_unix_seconds();
     let cache_key = bridge_cache_key(user_id, session_id);
     let mut cache = state.chat_turn_bridge_cache.lock().await;
@@ -734,9 +724,9 @@ async fn prepare_chat_turn_bridge_identifiers(
             })?,
             None => None,
         };
-        cached_turn.unwrap_or(inferred_session_turn)
+        cached_turn.unwrap_or(next_session_turn)
     } else {
-        inferred_session_turn
+        next_session_turn
     };
     let mut updated_entry = prev_entry.unwrap_or_default();
     updated_entry.insert(
@@ -750,6 +740,43 @@ async fn prepare_chat_turn_bridge_identifiers(
     updated_entry.insert("session_turn".to_string(), serde_json::json!(session_turn));
     cache.insert(cache_key, updated_entry, now);
     Ok((turn_chain_id, user_query_event_id, session_turn))
+}
+
+async fn bridge_next_canonical_turn(
+    state: &AppState,
+    user_id: &str,
+    session_id: &str,
+) -> Result<u32, (StatusCode, Json<ErrorResponse>)> {
+    let Some(coordinator) = state.session_context_coordinator.as_ref() else {
+        return Ok(crate::server::session_turn::infer_session_turn(
+            state.shared_pool.as_ref(),
+            user_id,
+            session_id,
+        )
+        .await);
+    };
+    let key = astra_turn_types::SessionKeyV1::owner_session(
+        "server",
+        user_id,
+        session_id,
+        astra_turn_types::DEFAULT_CONVERSATION_BRANCH_ID,
+    );
+    let head = coordinator.load_head(&key).await.map_err(|error| {
+        error_response_coded(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("failed to load canonical bridge head: {error}"),
+            "session_head_unavailable",
+        )
+    })?;
+    head.map_or(Ok(1), |head| {
+        head.cursor.completed_turn.checked_add(1).ok_or_else(|| {
+            error_response_coded(
+                StatusCode::CONFLICT,
+                "canonical bridge turn sequence is exhausted",
+                "session_turn_exhausted",
+            )
+        })
+    })
 }
 
 fn cached_bridge_session_turn(

--- a/crates/runtime/src/server/chat_handlers.rs
+++ b/crates/runtime/src/server/chat_handlers.rs
@@ -64,8 +64,8 @@ pub(super) async fn validate_conversation_authority(
             "execution_grant_verifier_unavailable",
         )
     })?;
-    let current_epochs = coordinator
-        .load_authority_epochs(&authority.key)
+    let active_lease = coordinator
+        .load_active_writer(&authority.key)
         .await
         .map_err(|error| {
             error_response_coded(
@@ -77,16 +77,15 @@ pub(super) async fn validate_conversation_authority(
         .ok_or_else(|| {
             error_response_coded(
                 StatusCode::CONFLICT,
-                "conversation authority references an uninitialized branch",
-                "conversation_authority_missing",
+                "conversation authority no longer owns the active writer lease",
+                "conversation_authority_fenced",
             )
         })?;
     let now_unix_ms = chrono::Utc::now().timestamp_millis();
     let claims = signer
         .verify(
             &authority.execution_grant,
-            &authority.key,
-            current_epochs,
+            &active_lease,
             &authority.run_id,
             authority.run_generation,
             authority.provider_binding_id.as_deref(),
@@ -100,7 +99,10 @@ pub(super) async fn validate_conversation_authority(
                 "conversation_authority_fenced",
             )
         })?;
-    if claims.writer_epoch != authority.writer_epoch || claims.actor_id != authority.actor_id {
+    if claims.writer_epoch != authority.writer_epoch
+        || claims.actor_id != authority.actor_id
+        || authority.execution_grant.claims.lease_id != active_lease.lease_id
+    {
         return Err(error_response_coded(
             StatusCode::CONFLICT,
             "conversation authority generations do not match the signed grant",

--- a/crates/runtime/src/server/chat_handlers.rs
+++ b/crates/runtime/src/server/chat_handlers.rs
@@ -587,7 +587,16 @@ pub(super) async fn dispatch_chat_turn_bridge(
     {
         Ok(response) => response,
         Err((status, error)) => {
-            sse_error_response(status, format!("Chat turn bridge unavailable: {error}"))
+            let context = if status.is_server_error() {
+                "Chat turn bridge unavailable"
+            } else {
+                "Chat turn bridge rejected request"
+            };
+            sse_error_response_with_retryable(
+                status,
+                format!("{context}: {error}"),
+                status == StatusCode::CONFLICT || status_to_sse_retryable(status),
+            )
         }
     }
 }

--- a/crates/runtime/src/server/http_helpers.rs
+++ b/crates/runtime/src/server/http_helpers.rs
@@ -18,12 +18,20 @@ pub(super) fn sse_json_response(events: Vec<serde_json::Value>) -> Response {
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn sse_error_response(status: StatusCode, message: impl Into<String>) -> Response {
+    sse_error_response_with_retryable(status, message, status_to_sse_retryable(status))
+}
+
+pub(super) fn sse_error_response_with_retryable(
+    status: StatusCode,
+    message: impl Into<String>,
+    retryable: bool,
+) -> Response {
     let message = message.into();
     tracing::warn!(
         target: "astra_runtime::sse",
         http_status = status.as_u16(),
         error_code = status_to_sse_error_code(status),
-        retryable = status_to_sse_retryable(status),
+        retryable,
         message = %message,
         "sse error response emitted to client",
     );
@@ -31,7 +39,7 @@ pub(super) fn sse_error_response(status: StatusCode, message: impl Into<String>)
         "type": "error",
         "message": message,
         "code": status_to_sse_error_code(status),
-        "retryable": status_to_sse_retryable(status),
+        "retryable": retryable,
     })])
 }
 
@@ -216,6 +224,7 @@ pub(super) fn status_to_sse_error_code(status: StatusCode) -> &'static str {
     match status {
         StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => "AUTH_ERROR",
         StatusCode::NOT_FOUND => "NOT_FOUND",
+        StatusCode::CONFLICT => "CONFLICT",
         StatusCode::UNPROCESSABLE_ENTITY => "VALIDATION_ERROR",
         _ => "INTERNAL_ERROR",
     }
@@ -249,6 +258,29 @@ mod tests {
     #[test]
     fn sse_code_not_found() {
         assert_eq!(status_to_sse_error_code(StatusCode::NOT_FOUND), "NOT_FOUND");
+    }
+
+    #[test]
+    fn sse_conflict_has_a_typed_machine_code() {
+        assert_eq!(status_to_sse_error_code(StatusCode::CONFLICT), "CONFLICT");
+    }
+
+    #[tokio::test]
+    async fn sse_retry_override_is_scoped_to_the_call_site() {
+        let response = sse_error_response_with_retryable(StatusCode::CONFLICT, "busy", true);
+        let body = body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .expect("body");
+        let text = String::from_utf8(body.to_vec()).expect("utf8");
+        let event: serde_json::Value = serde_json::from_str(
+            text.strip_prefix("data: ")
+                .and_then(|value| value.strip_suffix("\n\n"))
+                .expect("single SSE data event"),
+        )
+        .expect("json");
+        assert_eq!(event["code"], "CONFLICT");
+        assert_eq!(event["retryable"], true);
+        assert!(!status_to_sse_retryable(StatusCode::CONFLICT));
     }
 
     #[test]

--- a/crates/runtime/src/server/mod.rs
+++ b/crates/runtime/src/server/mod.rs
@@ -277,6 +277,7 @@ pub async fn serve(addr: SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
         ));
         bg_handles.push(astra_services::session_reaper::spawn_session_reaper(
             pool.clone(),
+            state.session_fork_coordinator.clone(),
             bg_cancel.clone(),
         ));
         // Spawn background cleanup-debt retry task

--- a/crates/runtime/src/server/router_builder/sessions.rs
+++ b/crates/runtime/src/server/router_builder/sessions.rs
@@ -82,6 +82,10 @@ pub(super) fn add_routes(router: Router<AppState>, state: AppState) -> Router<Ap
             post(session::session_handlers::publish_session_handler),
         )
         .route(
+            "/sessions/{session_id}/execution-grants",
+            post(session::session_handlers::issue_session_execution_grant_handler),
+        )
+        .route(
             "/sessions/{session_id}/handoffs",
             post(session::session_handlers::request_session_handoff_handler),
         )

--- a/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -3053,27 +3053,33 @@ impl AgenticRunLifecycleService {
                 };
                 (lease, true)
             };
-        let reservation = match coordinator
+        let reservation_outcome = coordinator
             .reserve_turn(
                 &lease,
                 head.as_ref().map(|head| &head.cursor),
                 Duration::from_secs(15 * 60),
                 &format!("server-run:{run_id}:turn"),
             )
-            .await
-            .map_err(|error| {
-                error_response_coded(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    format!("failed to reserve canonical turn: {error}"),
-                    "session_turn_reservation_unavailable",
-                )
-            })? {
-            astra_services::ReserveTurnOutcome::Reserved(reservation)
-            | astra_services::ReserveTurnOutcome::AlreadyReserved(reservation) => reservation,
-            astra_services::ReserveTurnOutcome::Conflict { .. } => {
+            .await;
+        let reservation = match reservation_outcome {
+            Err(error) => {
                 if release_writer_on_finish {
                     let _ = coordinator.release_writer(&lease).await;
                 }
+                let _ = distributed_permit.release().await;
+                return Err(error_response_coded(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!("failed to reserve canonical turn: {error}"),
+                    "session_turn_reservation_unavailable",
+                ));
+            }
+            Ok(astra_services::ReserveTurnOutcome::Reserved(reservation))
+            | Ok(astra_services::ReserveTurnOutcome::AlreadyReserved(reservation)) => reservation,
+            Ok(astra_services::ReserveTurnOutcome::Conflict { .. }) => {
+                if release_writer_on_finish {
+                    let _ = coordinator.release_writer(&lease).await;
+                }
+                let _ = distributed_permit.release().await;
                 return Err(error_response_coded(
                     StatusCode::CONFLICT,
                     "canonical session cursor changed before turn reservation",
@@ -3168,36 +3174,26 @@ impl AgenticRunLifecycleService {
         admission: Option<&CanonicalTurnAdmission>,
         messages: &[Value],
         compaction_rewrote_prefix: bool,
+        cancellation_requested: bool,
         run_id: &str,
-    ) -> Result<(), astra_core::ClassifiedError> {
+    ) -> Result<bool, astra_core::ClassifiedError> {
         let Some(admission) = admission else {
-            return Ok(());
+            return Ok(false);
         };
         admission.renewal_cancel.cancel();
         let result = async {
-            if compaction_rewrote_prefix && admission.prior_message_count > 0 {
-                return Err(
-                    "compaction rewrote the admitted canonical prefix before CAS commit"
-                        .to_string(),
-                );
-            }
-            let suffix = messages
-                .get(admission.prior_message_count..)
-                .ok_or_else(|| {
-                    "canonical conversation became shorter than the admitted prefix".to_string()
-                })?;
-            let canonical_suffix =
-                astra_turn_core::prompt_facing::sanitize_canonical_continuation_messages_with_turn_semantics(
-                    suffix.to_vec(),
-                )
-                .map_err(|error| {
-                    format!("canonical turn contains invalid user-turn semantics: {error}")
-                })?;
-            let logical_segments = pack_canonical_turn_segments(canonical_suffix);
-            if logical_segments.is_empty() {
-                return Err("canonical turn produced no committable messages".to_string());
-            }
+            let Some((mode, logical_segments)) = canonical_commit_delta(
+                admission.prior_message_count,
+                admission.had_canonical_head,
+                messages,
+                compaction_rewrote_prefix,
+                cancellation_requested,
+            )?
+            else {
+                return Ok(false);
+            };
             let base = admission.reservation.expected_cursor.as_ref();
+            let replaces_history = mode == astra_turn_types::CanonicalDeltaModeV1::Replace;
             let delta = astra_turn_types::CanonicalTurnDeltaV1 {
                 schema_version: astra_turn_types::CANONICAL_TURN_DELTA_SCHEMA_VERSION,
                 completed_turn: admission.reservation.reserved_turn,
@@ -3205,8 +3201,13 @@ impl AgenticRunLifecycleService {
                     .map_or(1, |cursor| cursor.journal_event_seq.saturating_add(1)),
                 conversation_seq: base
                     .map_or(1, |cursor| cursor.conversation_seq.saturating_add(1)),
-                compaction_generation: base.map_or(0, |cursor| cursor.compaction_generation),
+                compaction_generation: if replaces_history {
+                    base.map_or(1, |cursor| cursor.compaction_generation.saturating_add(1))
+                } else {
+                    base.map_or(0, |cursor| cursor.compaction_generation)
+                },
                 config_version_id: base.and_then(|cursor| cursor.config_version_id.clone()),
+                mode,
                 logical_segments,
             };
             match admission
@@ -3220,7 +3221,7 @@ impl AgenticRunLifecycleService {
                 .map_err(|error| error.to_string())?
             {
                 astra_turn_types::CoordinatorMutationV1::Applied { .. }
-                | astra_turn_types::CoordinatorMutationV1::AlreadyApplied { .. } => Ok(()),
+                | astra_turn_types::CoordinatorMutationV1::AlreadyApplied { .. } => Ok(true),
                 astra_turn_types::CoordinatorMutationV1::Conflict { .. } => {
                     Err("canonical session head changed before turn commit".to_string())
                 }
@@ -4164,6 +4165,7 @@ impl AgenticRunLifecycleService {
                 source: resume_source,
                 cursor,
                 conversation_messages: restored_messages,
+                materialized_conversation_root_hash: None,
                 degraded_reasons: resume_degraded_reasons,
                 repair_actions: resume_repair_actions,
                 projections: astra_turn_types::ResumeProjectionSetV1::default(),
@@ -8094,6 +8096,43 @@ fn runtime_workspace_authority_from_request(
     }
 }
 
+fn canonical_commit_delta(
+    prior_message_count: usize,
+    had_canonical_head: bool,
+    messages: &[Value],
+    compaction_rewrote_prefix: bool,
+    cancellation_requested: bool,
+) -> Result<Option<(astra_turn_types::CanonicalDeltaModeV1, Vec<Vec<Value>>)>, String> {
+    let mode = if compaction_rewrote_prefix && had_canonical_head {
+        astra_turn_types::CanonicalDeltaModeV1::Replace
+    } else {
+        astra_turn_types::CanonicalDeltaModeV1::Append
+    };
+    let changed_messages = if mode == astra_turn_types::CanonicalDeltaModeV1::Replace {
+        messages
+    } else {
+        messages.get(prior_message_count..).ok_or_else(|| {
+            "canonical conversation became shorter than the admitted prefix".to_string()
+        })?
+    };
+    let canonical_changed =
+        astra_turn_core::prompt_facing::sanitize_canonical_continuation_messages_with_turn_semantics(
+            changed_messages.to_vec(),
+        )
+        .map_err(|error| {
+            format!("canonical turn contains invalid user-turn semantics: {error}")
+        })?;
+    let logical_segments = pack_canonical_turn_segments(canonical_changed);
+    if logical_segments.is_empty() {
+        return if cancellation_requested {
+            Ok(None)
+        } else {
+            Err("canonical turn produced no committable messages".into())
+        };
+    }
+    Ok(Some((mode, logical_segments)))
+}
+
 fn pack_canonical_turn_segments(mut messages: Vec<Value>) -> Vec<Vec<Value>> {
     const TARGET_PACK_BYTES: u64 = 512 * 1024;
 
@@ -9058,11 +9097,13 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                         canonical_turn.as_ref(),
                         &loop_state.messages,
                         loop_state.context_compression_triggered,
+                        bg_cancel_flag.load(Ordering::Acquire)
+                            || bg_llm_cancel_token.is_cancelled(),
                         &bg_run_id,
                     )
                     .await
                     {
-                        Ok(()) => canonical_context_persisted = true,
+                        Ok(persisted) => canonical_context_persisted = persisted,
                         Err(commit_error) => outcome = Err(commit_error),
                     }
                 }
@@ -10688,11 +10729,13 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                         canonical_turn.as_ref(),
                         &state.messages,
                         state.context_compression_triggered,
+                        bg_cancel_flag.load(Ordering::Acquire)
+                            || bg_llm_cancel_token.is_cancelled(),
                         &bg_run_id,
                     )
                     .await
                     {
-                        Ok(()) => canonical_context_persisted = true,
+                        Ok(persisted) => canonical_context_persisted = persisted,
                         Err(commit_error) => loop_result = Err(commit_error),
                     }
                 }

--- a/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -2711,6 +2711,9 @@ struct CanonicalTurnAdmission {
     prior_messages: Vec<Value>,
     prior_message_count: usize,
     had_canonical_head: bool,
+    /// Leases supplied as an explicit controller capability outlive one run;
+    /// only leases acquired internally by this run are released here.
+    release_writer_on_finish: bool,
     release_started: Arc<AtomicBool>,
     renewal_cancel: CancellationToken,
     _weighted_permit: astra_services::WeightedAdmissionPermit,
@@ -2723,6 +2726,9 @@ impl Drop for CanonicalTurnAdmission {
             return;
         }
         self.renewal_cancel.cancel();
+        if !self.release_writer_on_finish {
+            return;
+        }
         let coordinator = Arc::clone(&self.coordinator);
         let lease = self.lease.clone();
         if let Ok(runtime) = tokio::runtime::Handle::try_current() {
@@ -2969,51 +2975,84 @@ impl AgenticRunLifecycleService {
                 })?,
             None => Vec::new(),
         };
-        let authority_epochs = coordinator
-            .load_authority_epochs(&key)
-            .await
-            .map_err(|error| {
-                error_response_coded(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    format!("failed to load canonical authority epochs: {error}"),
-                    "session_authority_unavailable",
-                )
-            })?
-            .unwrap_or_default();
-        let actor = astra_turn_types::ActorContextV1::owner_user(
-            user_id,
-            format!("server-run:{run_id}"),
-            astra_turn_types::ActorKindV1::Server,
-            astra_turn_types::SessionSurfaceV1::Server,
-            None,
-            authority_epochs,
-        );
-        let lease = match coordinator
-            .acquire_writer(
-                &key,
-                head.as_ref().map(|head| &head.cursor),
-                &actor,
-                Duration::from_secs(15 * 60),
-                &format!("server-run:{run_id}:writer"),
-            )
-            .await
-            .map_err(|error| {
-                error_response_coded(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    format!("failed to acquire canonical writer: {error}"),
-                    "session_writer_unavailable",
-                )
-            })? {
-            astra_services::AcquireWriterOutcome::Acquired(lease)
-            | astra_services::AcquireWriterOutcome::AlreadyAcquired(lease) => lease,
-            astra_services::AcquireWriterOutcome::Conflict { .. } => {
-                return Err(error_response_coded(
-                    StatusCode::CONFLICT,
-                    "another controller owns this canonical session branch",
-                    "session_writer_conflict",
-                ));
-            }
-        };
+        let (lease, release_writer_on_finish) =
+            if let Some(authority) = request.conversation_authority.as_ref() {
+                let active = coordinator
+                    .load_active_writer(&key)
+                    .await
+                    .map_err(|error| {
+                        error_response_coded(
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            format!("failed to load canonical writer: {error}"),
+                            "session_writer_unavailable",
+                        )
+                    })?
+                    .filter(|lease| {
+                        lease.key == key
+                            && lease.lease_id == authority.execution_grant.claims.lease_id
+                            && lease.writer_epoch == authority.writer_epoch
+                            && lease.actor.actor_id == authority.actor_id
+                            && authority.run_id == run_id
+                            && authority.expected_cursor
+                                == head.as_ref().map(|head| head.cursor.clone())
+                    })
+                    .ok_or_else(|| {
+                        error_response_coded(
+                            StatusCode::CONFLICT,
+                            "conversation authority no longer owns the active writer lease",
+                            "conversation_authority_fenced",
+                        )
+                    })?;
+                (active, false)
+            } else {
+                let authority_epochs = coordinator
+                    .load_authority_epochs(&key)
+                    .await
+                    .map_err(|error| {
+                        error_response_coded(
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            format!("failed to load canonical authority epochs: {error}"),
+                            "session_authority_unavailable",
+                        )
+                    })?
+                    .unwrap_or_default();
+                let actor = astra_turn_types::ActorContextV1::owner_user(
+                    user_id,
+                    format!("server-run:{run_id}"),
+                    astra_turn_types::ActorKindV1::Server,
+                    astra_turn_types::SessionSurfaceV1::Server,
+                    None,
+                    authority_epochs,
+                );
+                let acquired = coordinator
+                    .acquire_writer(
+                        &key,
+                        head.as_ref().map(|head| &head.cursor),
+                        &actor,
+                        Duration::from_secs(15 * 60),
+                        &format!("server-run:{run_id}:writer"),
+                    )
+                    .await
+                    .map_err(|error| {
+                        error_response_coded(
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            format!("failed to acquire canonical writer: {error}"),
+                            "session_writer_unavailable",
+                        )
+                    })?;
+                let lease = match acquired {
+                    astra_services::AcquireWriterOutcome::Acquired(lease)
+                    | astra_services::AcquireWriterOutcome::AlreadyAcquired(lease) => lease,
+                    astra_services::AcquireWriterOutcome::Conflict { .. } => {
+                        return Err(error_response_coded(
+                            StatusCode::CONFLICT,
+                            "another controller owns this canonical session branch",
+                            "session_writer_conflict",
+                        ));
+                    }
+                };
+                (lease, true)
+            };
         let reservation = match coordinator
             .reserve_turn(
                 &lease,
@@ -3032,7 +3071,9 @@ impl AgenticRunLifecycleService {
             astra_services::ReserveTurnOutcome::Reserved(reservation)
             | astra_services::ReserveTurnOutcome::AlreadyReserved(reservation) => reservation,
             astra_services::ReserveTurnOutcome::Conflict { .. } => {
-                let _ = coordinator.release_writer(&lease).await;
+                if release_writer_on_finish {
+                    let _ = coordinator.release_writer(&lease).await;
+                }
                 return Err(error_response_coded(
                     StatusCode::CONFLICT,
                     "canonical session cursor changed before turn reservation",
@@ -3115,6 +3156,7 @@ impl AgenticRunLifecycleService {
             prior_messages,
             prior_message_count,
             had_canonical_head: head.is_some(),
+            release_writer_on_finish,
             release_started: Arc::new(AtomicBool::new(false)),
             renewal_cancel,
             _weighted_permit: weighted_permit,
@@ -3186,7 +3228,9 @@ impl AgenticRunLifecycleService {
             }
         }
         .await;
-        let _ = admission.coordinator.release_writer(&admission.lease).await;
+        if admission.release_writer_on_finish {
+            let _ = admission.coordinator.release_writer(&admission.lease).await;
+        }
         let _ = admission.distributed_permit.release().await;
         admission.release_started.store(true, Ordering::Release);
         result.map_err(|message| {
@@ -8247,7 +8291,11 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             }
         }
 
-        let run_id = Uuid::new_v4().to_string();
+        let run_id = request
+            .conversation_authority
+            .as_ref()
+            .map(|authority| authority.run_id.clone())
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
         let session_id = request
             .session_id
             .clone()
@@ -9387,9 +9435,27 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         }
 
         let provider_idempotent_start = provider_identity.is_some();
-        let run_id = provider_identity
+        let authority_run_id = request
+            .conversation_authority
             .as_ref()
-            .map(|identity| identity.run_id.clone())
+            .map(|authority| authority.run_id.as_str());
+        if let (Some(identity), Some(authority_run_id)) =
+            (provider_identity.as_ref(), authority_run_id)
+            && identity.run_id != authority_run_id
+        {
+            return Err(error_response_coded(
+                StatusCode::CONFLICT,
+                "provider and conversation authority identify different runs",
+                "conversation_authority_run_conflict",
+            ));
+        }
+        let run_id = authority_run_id
+            .map(str::to_owned)
+            .or_else(|| {
+                provider_identity
+                    .as_ref()
+                    .map(|identity| identity.run_id.clone())
+            })
             .unwrap_or_else(|| Uuid::new_v4().to_string());
         let session_id = request
             .session_id

--- a/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -34,6 +34,7 @@ use astra_server_types::ws_progress_callback::ProgressEvent;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+use crate::turn::canonical_commit::{canonical_commit_delta, pack_canonical_turn_segments};
 use crate::turn::run_control::{RunControlProvider, RunControlStatus, UserIntentProvider};
 use astra_core::{
     ErrorResponse, SharedPool, connect_matrixone, error_response, error_response_coded,
@@ -8094,108 +8095,6 @@ fn runtime_workspace_authority_from_request(
         }
         None => default,
     }
-}
-
-fn canonical_commit_delta(
-    prior_message_count: usize,
-    had_canonical_head: bool,
-    messages: &[Value],
-    compaction_rewrote_prefix: bool,
-    cancellation_requested: bool,
-) -> Result<Option<(astra_turn_types::CanonicalDeltaModeV1, Vec<Vec<Value>>)>, String> {
-    let mode = if compaction_rewrote_prefix && had_canonical_head {
-        astra_turn_types::CanonicalDeltaModeV1::Replace
-    } else {
-        astra_turn_types::CanonicalDeltaModeV1::Append
-    };
-    let changed_messages = if mode == astra_turn_types::CanonicalDeltaModeV1::Replace {
-        messages
-    } else {
-        messages.get(prior_message_count..).ok_or_else(|| {
-            "canonical conversation became shorter than the admitted prefix".to_string()
-        })?
-    };
-    let canonical_changed =
-        astra_turn_core::prompt_facing::sanitize_canonical_continuation_messages_with_turn_semantics(
-            changed_messages.to_vec(),
-        )
-        .map_err(|error| {
-            format!("canonical turn contains invalid user-turn semantics: {error}")
-        })?;
-    let logical_segments = pack_canonical_turn_segments(canonical_changed);
-    if logical_segments.is_empty() {
-        return if cancellation_requested {
-            Ok(None)
-        } else {
-            Err("canonical turn produced no committable messages".into())
-        };
-    }
-    Ok(Some((mode, logical_segments)))
-}
-
-fn pack_canonical_turn_segments(mut messages: Vec<Value>) -> Vec<Vec<Value>> {
-    const TARGET_PACK_BYTES: u64 = 512 * 1024;
-
-    let mut packs = Vec::new();
-    let mut current = Vec::new();
-    let mut current_bytes = 2_u64;
-    let mut index = 0;
-    while index < messages.len() {
-        let group_start = index;
-        let keeps_tool_results = opens_structured_tool_group(&messages[index]);
-        index += 1;
-        if keeps_tool_results {
-            while index < messages.len() && is_structured_tool_result(&messages[index]) {
-                index += 1;
-            }
-        }
-        let group = &mut messages[group_start..index];
-        let group_bytes = astra_turn_types::canonical_conversation_serialized_len(group);
-        let projected = current_bytes
-            .saturating_add(group_bytes.saturating_sub(2))
-            .saturating_add(u64::from(!current.is_empty()));
-        if !current.is_empty() && projected > TARGET_PACK_BYTES {
-            packs.push(std::mem::take(&mut current));
-            current_bytes = 2;
-        }
-        current_bytes = current_bytes
-            .saturating_add(group_bytes.saturating_sub(2))
-            .saturating_add(u64::from(!current.is_empty()));
-        current.extend(group.iter_mut().map(Value::take));
-    }
-    if !current.is_empty() {
-        packs.push(current);
-    }
-    packs
-}
-
-fn opens_structured_tool_group(message: &Value) -> bool {
-    message.get("role").and_then(Value::as_str) == Some("assistant")
-        && (message
-            .get("tool_calls")
-            .and_then(Value::as_array)
-            .is_some_and(|calls| !calls.is_empty())
-            || message
-                .get("content")
-                .and_then(Value::as_array)
-                .is_some_and(|content| {
-                    content
-                        .iter()
-                        .any(|item| item.get("type").and_then(Value::as_str) == Some("tool_use"))
-                }))
-}
-
-fn is_structured_tool_result(message: &Value) -> bool {
-    message.get("role").and_then(Value::as_str) == Some("tool")
-        || message
-            .get("content")
-            .and_then(Value::as_array)
-            .is_some_and(|content| {
-                !content.is_empty()
-                    && content
-                        .iter()
-                        .all(|item| item.get("type").and_then(Value::as_str) == Some("tool_result"))
-            })
 }
 
 fn execution_bindings_from_workspace_record(

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -74,6 +74,34 @@ fn canonical_segment_packing_bounds_ordinary_groups_without_reordering() {
 }
 
 #[test]
+fn cancelled_turn_without_a_delta_does_not_become_a_commit_failure() {
+    let prior = vec![json!({"role": "user", "content": "already committed"})];
+    assert_eq!(
+        canonical_commit_delta(1, true, &prior, false, true).unwrap(),
+        None
+    );
+    assert!(
+        canonical_commit_delta(1, true, &prior, false, false)
+            .unwrap_err()
+            .contains("no committable messages")
+    );
+}
+
+#[test]
+fn compaction_commits_the_complete_replacement_projection() {
+    let compacted = vec![
+        json!({"role": "user", "content": "summary"}),
+        json!({"role": "assistant", "content": "current"}),
+    ];
+    let (mode, packs) = canonical_commit_delta(20, true, &compacted, true, false)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(mode, astra_turn_types::CanonicalDeltaModeV1::Replace);
+    assert_eq!(packs.concat(), compacted);
+}
+
+#[test]
 fn fresh_request_admission_accounts_for_large_non_message_payloads() {
     let mut request = test_request("small");
     let baseline = fresh_request_admission_bytes(&request).unwrap();

--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -5848,7 +5848,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 &final_tools,
                 Some(effective_max_output),
             );
-            crate::turn::llm::exchange_capture::spawn_prompt_request_plan_persist_or_log(
+            crate::turn::llm::exchange_capture::persist_prompt_request_plan_or_log(
                 "server_loop_host",
                 self.shared_pool.clone(),
                 astra_services::PromptRequestPersistInput {
@@ -5863,7 +5863,8 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                     provider: llm_cfg.provider.clone(),
                 },
                 prompt_request_plan,
-            );
+            )
+            .await;
             let durable_ledger = self.required_inference_ledger()?;
             let run_id = state.current_run_id.clone().ok_or_else(|| {
                 astra_core::ClassifiedError::new(

--- a/crates/runtime/src/server/session/session_handlers.rs
+++ b/crates/runtime/src/server/session/session_handlers.rs
@@ -1977,16 +1977,56 @@ pub(crate) async fn resume_session_handler(
         return Err(internal_error("shared MatrixOne pool is not configured"));
     };
     let svc = astra_services::session_restore::HybridRestoreService::new(shared_pool.get().clone());
-    let mut restored = svc
+    let legacy = svc
         .restore_session(&user_id, &session.session_id)
         .await
-        .map_err(internal_error)?
-        .ok_or_else(|| {
-            error_response(
-                StatusCode::NOT_FOUND,
-                format!("session {} has no resumable state", session.session_id),
-            )
-        })?;
+        .map_err(internal_error)?;
+    let key = server_session_key(&user_id, &session.session_id);
+    let canonical_head = match state.session_context_coordinator.as_ref() {
+        Some(coordinator) => coordinator
+            .load_head(&key)
+            .await
+            .map_err(session_context_http_error)?,
+        None => None,
+    };
+    let mut restored = legacy.unwrap_or_else(|| astra_services::session_restore::RestoredSession {
+        session_id: session.session_id.clone(),
+        last_status: "active".into(),
+        restored_from_cloud: true,
+        ..Default::default()
+    });
+    if let Some(head) = canonical_head {
+        let coordinator = state
+            .session_context_coordinator
+            .as_ref()
+            .expect("coordinator produced the canonical head");
+        let materialized = coordinator
+            .materialize(&head)
+            .await
+            .map_err(session_context_http_error)?;
+        let materialized_root =
+            astra_turn_types::canonical_conversation_root(&materialized.messages);
+        let bundle = astra_turn_types::select_resume_bundle(
+            Some(&head.cursor),
+            [astra_turn_types::ResumeCandidateV1 {
+                source: astra_turn_types::ResumeSourceV1::CanonicalJournal,
+                cursor: head.cursor.clone(),
+                conversation_messages: materialized.messages,
+                materialized_conversation_root_hash: Some(materialized_root),
+                degraded_reasons: Vec::new(),
+                repair_actions: Vec::new(),
+                projections: Default::default(),
+            }],
+        )
+        .map_err(internal_error)?;
+        astra_services::session_restore::install_canonical_resume_bundle(&mut restored, bundle)
+            .map_err(internal_error)?;
+    } else if restored.resume_bundle.is_none() && restored.conversation_messages.is_empty() {
+        return Err(error_response(
+            StatusCode::NOT_FOUND,
+            format!("session {} has no resumable state", session.session_id),
+        ));
+    }
     // Resume is the hydration API consumed by CLI clients. Cross-placement
     // observation and control remain explicit operations on `/attachments`
     // and `/handoffs`; inferring a Server attachment here would assign the

--- a/crates/runtime/src/server/session/session_handlers.rs
+++ b/crates/runtime/src/server/session/session_handlers.rs
@@ -1934,9 +1934,31 @@ pub(crate) struct SessionSegmentUploadResponse {
 #[serde(deny_unknown_fields)]
 pub(crate) struct SessionPublishRequest {
     pub idempotency_key: String,
+    #[serde(default)]
+    pub writer_lease: Option<astra_turn_types::ConversationWriterLeaseV1>,
     pub items: Vec<astra_services::PublishJournalItemV1>,
     #[serde(default = "default_writer_ttl_seconds")]
     pub writer_ttl_seconds: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SessionExecutionGrantRequest {
+    pub idempotency_key: String,
+    pub run_id: String,
+    #[serde(default)]
+    pub run_generation: u64,
+    #[serde(default)]
+    pub provider_binding_id: Option<String>,
+    #[serde(default)]
+    pub provider_generation: u64,
+    #[serde(default)]
+    pub round: u32,
+    #[serde(default)]
+    pub attempt: u32,
+    pub trace_id: String,
+    #[serde(default = "default_writer_ttl_seconds")]
+    pub ttl_seconds: u64,
 }
 
 pub(crate) async fn resume_session_handler(
@@ -2607,6 +2629,7 @@ pub(crate) async fn publish_session_handler(
                 idempotency_key: request.idempotency_key,
                 key,
                 actor,
+                writer_lease: request.writer_lease,
                 items: request.items,
             },
             std::time::Duration::from_secs(request.writer_ttl_seconds),
@@ -2614,6 +2637,102 @@ pub(crate) async fn publish_session_handler(
         .await
         .map(Json)
         .map_err(session_publish_http_error)
+}
+
+pub(crate) async fn issue_session_execution_grant_handler(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    headers: HeaderMap,
+    Json(request): Json<SessionExecutionGrantRequest>,
+) -> Result<
+    Json<astra_turn_types::ConversationAuthorityEnvelopeV1>,
+    (StatusCode, Json<ErrorResponse>),
+> {
+    let user = state.auth_service.current_user(&headers).await?;
+    let session = state
+        .session_service
+        .get_session(session_id, user.user_id.clone())
+        .await?;
+    let pool = state
+        .shared_pool
+        .as_ref()
+        .ok_or_else(|| internal_error("shared MatrixOne pool is not configured"))?;
+    let device = verify_device_proof_from_headers(
+        pool,
+        &user.user_id,
+        &session.session_id,
+        &headers,
+        DeviceProofPurpose::Publish,
+    )
+    .await?;
+    let key = server_session_key(&user.user_id, &session.session_id);
+    let coordinator = state
+        .session_context_coordinator
+        .as_ref()
+        .ok_or_else(|| internal_error("session context coordinator is not configured"))?;
+    let lease = coordinator
+        .load_active_writer(&key)
+        .await
+        .map_err(session_context_http_error)?
+        .filter(|lease| lease.actor.device_id.as_deref() == Some(device.device_id.as_str()))
+        .ok_or_else(|| {
+            error_response_coded(
+                StatusCode::CONFLICT,
+                "authenticated device does not own the active writer lease",
+                "session_writer_conflict",
+            )
+        })?;
+    let head = coordinator
+        .load_head(&key)
+        .await
+        .map_err(session_context_http_error)?;
+    let signer = state
+        .execution_grant_signer
+        .as_ref()
+        .ok_or_else(|| internal_error("execution grant signer is not configured"))?;
+    let now_unix_ms = chrono::Utc::now().timestamp_millis();
+    let grant = signer
+        .issue(
+            &lease,
+            request.run_id.clone(),
+            request.run_generation,
+            request.provider_binding_id.clone(),
+            request.provider_generation,
+            now_unix_ms,
+            std::time::Duration::from_secs(request.ttl_seconds),
+        )
+        .map_err(|error| {
+            error_response_coded(
+                StatusCode::BAD_REQUEST,
+                format!("invalid execution grant request: {error}"),
+                "execution_grant_invalid",
+            )
+        })?;
+    let envelope = astra_turn_types::ConversationAuthorityEnvelopeV1 {
+        schema_version: astra_turn_types::CONVERSATION_AUTHORITY_ENVELOPE_SCHEMA_VERSION,
+        key,
+        expected_cursor: head.as_ref().map(|head| head.cursor.clone()),
+        prompt_manifest_root: head.as_ref().map(|head| head.latest_manifest_root.clone()),
+        writer_epoch: lease.writer_epoch,
+        run_id: request.run_id,
+        run_generation: request.run_generation,
+        provider_binding_id: request.provider_binding_id,
+        provider_generation: request.provider_generation,
+        round: request.round,
+        attempt: request.attempt,
+        idempotency_key: request.idempotency_key,
+        actor_id: lease.actor.actor_id,
+        trace_id: request.trace_id,
+        execution_grant: grant,
+    };
+    envelope.validate_shape().map_err(|error| {
+        error_response_coded(
+            StatusCode::BAD_REQUEST,
+            format!("invalid execution authority coordinates: {error}"),
+            "execution_grant_invalid",
+        )
+    })?;
+    Ok(Json(envelope))
 }
 
 fn server_session_key(user_id: &str, session_id: &str) -> astra_turn_types::SessionKeyV1 {

--- a/crates/runtime/src/server/state_builder/bridge.rs
+++ b/crates/runtime/src/server/state_builder/bridge.rs
@@ -9,6 +9,10 @@ pub(super) fn attach_chat_turn_bridge(
     matrix_rt: &Arc<crate::matrix_cloud_runtime::MatrixCloudRuntime>,
 ) -> AppState {
     let edge_callback_ledger = state.edge_callback_ledger.clone();
+    let session_context_coordinator = state
+        .session_context_coordinator
+        .clone()
+        .expect("core state must install the canonical session coordinator before the bridge");
     state
         .with_chat_turn_bridge(Arc::new(
             turn::bridge::inprocess::InProcessChatTurnBridge::new(
@@ -16,6 +20,7 @@ pub(super) fn attach_chat_turn_bridge(
                 Arc::clone(bridge_encryptor),
             )
             .with_pool(shared_pool.clone())
+            .with_session_context_coordinator(session_context_coordinator)
             .with_edge_callback_ledger(edge_callback_ledger)
             .with_persist_tracker(
                 Arc::clone(matrix_rt) as Arc<dyn crate::matrix_cloud_runtime::BridgePersistTracker>

--- a/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/crates/runtime/src/turn/bridge/inprocess.rs
@@ -39,7 +39,7 @@ use std::{
         Arc, Mutex, Weak,
         atomic::{AtomicBool, Ordering},
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use astra_core::SharedPool;
@@ -281,6 +281,460 @@ impl Drop for BridgePersistFenceGuard {
 }
 
 type BridgePersistTails = Arc<Mutex<HashMap<String, Weak<BridgePersistFence>>>>;
+
+const BRIDGE_CANONICAL_LEASE_TTL: Duration = Duration::from_secs(15 * 60);
+const BRIDGE_CANONICAL_RENEW_INTERVAL: Duration = Duration::from_secs(4 * 60);
+const BRIDGE_CANONICAL_RELEASE_RETRY_DELAYS: [Duration; 2] =
+    [Duration::from_millis(25), Duration::from_millis(100)];
+
+async fn release_bridge_canonical_writer(
+    coordinator: &Arc<dyn astra_services::SessionContextCoordinator>,
+    lease: &astra_turn_types::ConversationWriterLeaseV1,
+) -> Result<(), astra_services::SessionContextCoordinatorError> {
+    for delay in BRIDGE_CANONICAL_RELEASE_RETRY_DELAYS {
+        match coordinator.release_writer(lease).await {
+            Ok(()) => return Ok(()),
+            Err(_) => tokio::time::sleep(delay).await,
+        }
+    }
+    coordinator.release_writer(lease).await
+}
+
+struct BridgeCanonicalAdmission {
+    coordinator: Arc<dyn astra_services::SessionContextCoordinator>,
+    lease: astra_turn_types::ConversationWriterLeaseV1,
+    reservation: astra_turn_types::TurnReservationV1,
+    current_turn_canonical_messages: Vec<Value>,
+    release_writer_on_finish: bool,
+    release_on_drop: bool,
+    renewal_cancel: CancellationToken,
+    turn_chain_id: String,
+}
+
+impl Drop for BridgeCanonicalAdmission {
+    fn drop(&mut self) {
+        self.renewal_cancel.cancel();
+        if !self.release_on_drop || !self.release_writer_on_finish {
+            return;
+        }
+        let coordinator = Arc::clone(&self.coordinator);
+        let lease = self.lease.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let _ = release_bridge_canonical_writer(&coordinator, &lease).await;
+            });
+        }
+    }
+}
+
+impl BridgeCanonicalAdmission {
+    fn retain_for_continuation(&mut self) {
+        self.release_on_drop = false;
+    }
+
+    async fn commit_terminal(&mut self, assistant_text: &str) -> Result<(), String> {
+        self.renewal_cancel.cancel();
+        let mut final_messages = std::mem::take(&mut self.current_turn_canonical_messages);
+        if !assistant_text.trim().is_empty() {
+            final_messages.push(json!({
+                "role": "assistant",
+                "content": assistant_text,
+            }));
+        }
+        let canonical =
+            astra_turn_core::prompt_facing::sanitize_canonical_continuation_messages_with_turn_semantics(
+                final_messages,
+            )
+            .map_err(|error| format!("bridge result has invalid turn semantics: {error}"))?;
+        let Some((mode, logical_segments)) = crate::turn::canonical_commit::canonical_commit_delta(
+            0, false, &canonical, false, false,
+        )?
+        else {
+            return Err("bridge terminal result produced no canonical delta".into());
+        };
+        let base = self.reservation.expected_cursor.as_ref();
+        let delta = astra_turn_types::CanonicalTurnDeltaV1 {
+            schema_version: astra_turn_types::CANONICAL_TURN_DELTA_SCHEMA_VERSION,
+            completed_turn: self.reservation.reserved_turn,
+            journal_event_seq: base.map_or(1, |cursor| cursor.journal_event_seq.saturating_add(1)),
+            conversation_seq: base.map_or(1, |cursor| cursor.conversation_seq.saturating_add(1)),
+            compaction_generation: base.map_or(0, |cursor| cursor.compaction_generation),
+            config_version_id: base.and_then(|cursor| cursor.config_version_id.clone()),
+            mode,
+            logical_segments,
+        };
+        match self
+            .coordinator
+            .commit_turn(
+                &self.reservation,
+                delta,
+                &format!("server-bridge:{}:commit", self.turn_chain_id),
+            )
+            .await
+            .map_err(|error| error.to_string())?
+        {
+            astra_turn_types::CoordinatorMutationV1::Applied { .. }
+            | astra_turn_types::CoordinatorMutationV1::AlreadyApplied { .. } => {}
+            astra_turn_types::CoordinatorMutationV1::Conflict { .. } => {
+                return Err("canonical conversation head changed before bridge commit".into());
+            }
+            astra_turn_types::CoordinatorMutationV1::NeedsRepair { reason, .. } => {
+                return Err(reason);
+            }
+        }
+        if self.release_writer_on_finish {
+            match release_bridge_canonical_writer(&self.coordinator, &self.lease).await {
+                Ok(()) => self.release_on_drop = false,
+                Err(error) => {
+                    // Keep `release_on_drop` set so the response-stream drop
+                    // performs one final detached retry without delaying the
+                    // already durable turn.
+                    self.release_on_drop = true;
+                    tracing::warn!(
+                        target: "astra_runtime::bridge_inprocess",
+                        session_id = %self.reservation.key.session_id,
+                        error = %error,
+                        "canonical bridge turn committed but writer release failed"
+                    );
+                }
+            }
+        } else {
+            self.release_on_drop = false;
+        }
+        Ok(())
+    }
+}
+
+struct BridgeCanonicalAdmissionResult {
+    admission: Option<BridgeCanonicalAdmission>,
+    provider_messages: Vec<Value>,
+}
+
+fn start_bridge_canonical_renewal(
+    coordinator: Arc<dyn astra_services::SessionContextCoordinator>,
+    mut lease: astra_turn_types::ConversationWriterLeaseV1,
+    mut reservation: astra_turn_types::TurnReservationV1,
+    authority_loss_cancel: CancellationToken,
+) -> CancellationToken {
+    let renewal_cancel = CancellationToken::new();
+    let heartbeat_cancel = renewal_cancel.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = heartbeat_cancel.cancelled() => break,
+                _ = tokio::time::sleep(BRIDGE_CANONICAL_RENEW_INTERVAL) => {}
+            }
+            lease = match coordinator
+                .renew_writer(&lease, BRIDGE_CANONICAL_LEASE_TTL)
+                .await
+            {
+                Ok(lease) => lease,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "astra_runtime::bridge_inprocess",
+                        error = %error,
+                        "canonical bridge writer renewal failed; cancelling in-flight work"
+                    );
+                    authority_loss_cancel.cancel();
+                    break;
+                }
+            };
+            reservation = match coordinator
+                .renew_turn_reservation(&reservation, BRIDGE_CANONICAL_LEASE_TTL)
+                .await
+            {
+                Ok(reservation) => reservation,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "astra_runtime::bridge_inprocess",
+                        error = %error,
+                        "canonical bridge turn renewal failed; cancelling in-flight work"
+                    );
+                    authority_loss_cancel.cancel();
+                    break;
+                }
+            };
+        }
+    });
+    renewal_cancel
+}
+
+fn canonical_bridge_current_turn_suffix_is_valid(
+    messages: &[Value],
+    allow_leading_system: bool,
+) -> bool {
+    let mut index = 0;
+    if allow_leading_system {
+        while messages
+            .get(index)
+            .and_then(|message| message.get("role"))
+            .and_then(Value::as_str)
+            == Some("system")
+        {
+            index += 1;
+        }
+    }
+    if messages
+        .get(index)
+        .and_then(|message| message.get("role"))
+        .and_then(Value::as_str)
+        != Some("user")
+    {
+        return false;
+    }
+    index += 1;
+
+    while index < messages.len() {
+        let Some(calls) = messages[index]
+            .get("tool_calls")
+            .and_then(Value::as_array)
+            .filter(|calls| !calls.is_empty())
+        else {
+            return false;
+        };
+        if messages[index].get("role").and_then(Value::as_str) != Some("assistant") {
+            return false;
+        }
+        index += 1;
+
+        let mut result_ids = HashSet::new();
+        while index < messages.len()
+            && messages[index].get("role").and_then(Value::as_str) == Some("tool")
+        {
+            let Some(tool_call_id) = messages[index]
+                .get("tool_call_id")
+                .and_then(Value::as_str)
+                .filter(|id| !id.is_empty())
+            else {
+                return false;
+            };
+            if !result_ids.insert(tool_call_id) {
+                return false;
+            }
+            index += 1;
+        }
+        if calls.iter().any(|call| {
+            call.get("id")
+                .and_then(Value::as_str)
+                .is_none_or(|id| !result_ids.contains(id))
+        }) {
+            return false;
+        }
+    }
+    true
+}
+
+fn admit_canonical_bridge_prompt(
+    mut prior_messages: Vec<Value>,
+    request_messages: Vec<Value>,
+) -> Result<(Vec<Value>, Vec<Value>), String> {
+    let mut request_canonical =
+        astra_turn_core::prompt_facing::sanitize_canonical_continuation_messages_with_turn_semantics(
+            request_messages.clone(),
+        )
+        .map_err(|error| format!("bridge prompt has invalid turn semantics: {error}"))?;
+
+    let had_canonical_head = !prior_messages.is_empty();
+    let (current_turn, provider_messages) = if request_canonical.starts_with(&prior_messages) {
+        let current_turn = request_canonical.split_off(prior_messages.len());
+        (current_turn, request_messages)
+    } else {
+        let mut provider_messages =
+            Vec::with_capacity(prior_messages.len() + request_messages.len());
+        provider_messages.append(&mut prior_messages);
+        provider_messages.extend(request_messages);
+        (request_canonical, provider_messages)
+    };
+
+    if !canonical_bridge_current_turn_suffix_is_valid(&current_turn, !had_canonical_head) {
+        return Err(
+            "bridge prompt must contain exactly one structurally valid current-turn suffix".into(),
+        );
+    }
+    Ok((current_turn, provider_messages))
+}
+
+async fn begin_bridge_canonical_admission(
+    coordinator: Option<&Arc<dyn astra_services::SessionContextCoordinator>>,
+    user_id: &str,
+    session_id: &str,
+    turn_chain_id: &str,
+    requested_turn: Option<u32>,
+    authority: Option<&astra_turn_types::ConversationAuthorityEnvelopeV1>,
+    request_messages: Vec<Value>,
+    authority_loss_cancel: CancellationToken,
+) -> Result<BridgeCanonicalAdmissionResult, (StatusCode, String)> {
+    let Some(coordinator) = coordinator.cloned() else {
+        return Ok(BridgeCanonicalAdmissionResult {
+            admission: None,
+            provider_messages: request_messages,
+        });
+    };
+    let key = astra_turn_types::SessionKeyV1::owner_session(
+        "server",
+        user_id,
+        session_id,
+        astra_turn_types::DEFAULT_CONVERSATION_BRANCH_ID,
+    );
+    let head = coordinator.load_head(&key).await.map_err(|error| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("failed to load canonical bridge head: {error}"),
+        )
+    })?;
+    let prior_messages = match &head {
+        Some(head) => coordinator
+            .materialize(head)
+            .await
+            .map(|materialized| materialized.messages)
+            .map_err(|error| {
+                (
+                    StatusCode::CONFLICT,
+                    format!("canonical bridge history requires repair: {error}"),
+                )
+            })?,
+        None => Vec::new(),
+    };
+    let (current_turn_canonical_messages, provider_messages) =
+        admit_canonical_bridge_prompt(prior_messages, request_messages)
+            .map_err(|error| (StatusCode::CONFLICT, error))?;
+
+    let (lease, release_writer_on_finish, release_writer_on_admission_failure) =
+        if let Some(authority) = authority {
+            let active = coordinator
+                .load_active_writer(&key)
+                .await
+                .map_err(|error| {
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        format!("failed to load canonical bridge writer: {error}"),
+                    )
+                })?
+                .filter(|lease| {
+                    lease.key == key
+                        && lease.lease_id == authority.execution_grant.claims.lease_id
+                        && lease.writer_epoch == authority.writer_epoch
+                        && lease.actor.actor_id == authority.actor_id
+                        && authority.expected_cursor
+                            == head.as_ref().map(|head| head.cursor.clone())
+                })
+                .ok_or_else(|| {
+                    (
+                        StatusCode::CONFLICT,
+                        "bridge conversation authority no longer owns the active writer lease"
+                            .into(),
+                    )
+                })?;
+            (active, false, false)
+        } else {
+            let authority_epochs = coordinator
+                .load_authority_epochs(&key)
+                .await
+                .map_err(|error| {
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        format!("failed to load canonical bridge authority epochs: {error}"),
+                    )
+                })?
+                .unwrap_or_default();
+            let actor = astra_turn_types::ActorContextV1::owner_user(
+                user_id,
+                format!("server-bridge:{turn_chain_id}"),
+                astra_turn_types::ActorKindV1::Server,
+                astra_turn_types::SessionSurfaceV1::Cli,
+                None,
+                authority_epochs,
+            );
+            match coordinator
+                .acquire_writer(
+                    &key,
+                    head.as_ref().map(|head| &head.cursor),
+                    &actor,
+                    BRIDGE_CANONICAL_LEASE_TTL,
+                    &format!("server-bridge:{turn_chain_id}:writer"),
+                )
+                .await
+                .map_err(|error| {
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        format!("failed to acquire canonical bridge writer: {error}"),
+                    )
+                })? {
+                astra_services::AcquireWriterOutcome::Acquired(lease) => (lease, true, true),
+                astra_services::AcquireWriterOutcome::AlreadyAcquired(lease) => {
+                    (lease, true, false)
+                }
+                astra_services::AcquireWriterOutcome::Conflict { .. } => {
+                    return Err((
+                        StatusCode::CONFLICT,
+                        "another controller owns this canonical session branch".into(),
+                    ));
+                }
+            }
+        };
+    let reservation = match coordinator
+        .reserve_turn(
+            &lease,
+            head.as_ref().map(|head| &head.cursor),
+            BRIDGE_CANONICAL_LEASE_TTL,
+            &format!("server-bridge:{turn_chain_id}:turn"),
+        )
+        .await
+    {
+        Ok(astra_services::ReserveTurnOutcome::Reserved(reservation))
+        | Ok(astra_services::ReserveTurnOutcome::AlreadyReserved(reservation)) => reservation,
+        Ok(astra_services::ReserveTurnOutcome::Conflict { .. }) => {
+            if release_writer_on_admission_failure {
+                let _ = release_bridge_canonical_writer(&coordinator, &lease).await;
+            }
+            return Err((
+                StatusCode::CONFLICT,
+                "canonical session cursor changed before bridge reservation".into(),
+            ));
+        }
+        Err(error) => {
+            if release_writer_on_admission_failure {
+                let _ = release_bridge_canonical_writer(&coordinator, &lease).await;
+            }
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("failed to reserve canonical bridge turn: {error}"),
+            ));
+        }
+    };
+    if requested_turn.is_some_and(|turn| turn != reservation.reserved_turn) {
+        if release_writer_on_admission_failure {
+            let _ = release_bridge_canonical_writer(&coordinator, &lease).await;
+        }
+        return Err((
+            StatusCode::CONFLICT,
+            format!(
+                "bridge session_turn does not match reserved canonical turn {}",
+                reservation.reserved_turn
+            ),
+        ));
+    }
+    let renewal_cancel = start_bridge_canonical_renewal(
+        Arc::clone(&coordinator),
+        lease.clone(),
+        reservation.clone(),
+        authority_loss_cancel,
+    );
+    let admission = BridgeCanonicalAdmission {
+        coordinator,
+        lease,
+        reservation,
+        current_turn_canonical_messages,
+        release_writer_on_finish,
+        release_on_drop: release_writer_on_admission_failure,
+        renewal_cancel,
+        turn_chain_id: turn_chain_id.to_string(),
+    };
+    Ok(BridgeCanonicalAdmissionResult {
+        admission: Some(admission),
+        provider_messages,
+    })
+}
 
 fn track_ordered_bridge_persist<F>(
     tails: &BridgePersistTails,
@@ -1641,6 +2095,8 @@ pub struct InProcessChatTurnBridge {
     /// Shared DB pool — avoids creating a new connection per turn.
     /// When `None`, falls back to ephemeral single-connection pool.
     pub shared_pool: Option<SharedPool>,
+    /// Canonical conversation authority for every networked bridge turn.
+    session_context_coordinator: Option<Arc<dyn astra_services::SessionContextCoordinator>>,
     /// Same `Arc` as [`crate::AppState::edge_callback_ledger`] — bridge takes tool callbacks here.
     pub edge_callback_ledger: Arc<tokio::sync::Mutex<HashMap<String, Value>>>,
     /// Cached Memoria client — created once, reused across turns.
@@ -1665,6 +2121,7 @@ impl InProcessChatTurnBridge {
             matrixone,
             encryptor,
             shared_pool: None,
+            session_context_coordinator: None,
             edge_callback_ledger: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             memoria_client: crate::turn::cloud::memoria_compact::HttpMemoriaPort::from_env(),
             session_start_memory_cache: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
@@ -1675,7 +2132,18 @@ impl InProcessChatTurnBridge {
     }
 
     pub fn with_pool(mut self, pool: SharedPool) -> Self {
+        self.session_context_coordinator = Some(Arc::new(
+            astra_services::DatabaseSessionContextCoordinator::new(pool.clone()),
+        ));
         self.shared_pool = Some(pool);
+        self
+    }
+
+    pub fn with_session_context_coordinator(
+        mut self,
+        coordinator: Arc<dyn astra_services::SessionContextCoordinator>,
+    ) -> Self {
+        self.session_context_coordinator = Some(coordinator);
         self
     }
 
@@ -1751,6 +2219,12 @@ impl InProcessChatTurnBridge {
 
         // Parse request body
         let payload = parse_bridge_payload(&body)?;
+        // Every response stream owns a cancellation token, including direct
+        // callers that did not supply one. It also terminates provider work
+        // immediately if the canonical writer/reservation renewal is fenced.
+        let response_cancel = client_cancel
+            .clone()
+            .unwrap_or_else(|| Arc::new(CancellationToken::new()));
         let agent_id = payload
             .get("agent_id")
             .and_then(Value::as_str)
@@ -1774,6 +2248,32 @@ impl InProcessChatTurnBridge {
             })?;
         let (messages, recovered_required_runtime_texts) =
             normalize_bridge_prompt_messages(optional_payload_array(&payload, "messages")?);
+        let conversation_authority = payload
+            .get("conversation_authority")
+            .filter(|value| !value.is_null())
+            .cloned()
+            .map(serde_json::from_value::<astra_turn_types::ConversationAuthorityEnvelopeV1>)
+            .transpose()
+            .map_err(|error| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("invalid bridge conversation authority: {error}"),
+                )
+            })?;
+        let BridgeCanonicalAdmissionResult {
+            admission: mut canonical_admission,
+            provider_messages: messages,
+        } = begin_bridge_canonical_admission(
+            self.session_context_coordinator.as_ref(),
+            &user_id,
+            &session_id,
+            &turn_chain_id,
+            header_session_turn,
+            conversation_authority.as_ref(),
+            messages,
+            response_cancel.as_ref().clone(),
+        )
+        .await?;
         let tool_results = optional_payload_array(&payload, "tool_results")?;
         let edge_tools = optional_payload_array(&payload, "edge_tools")?;
         let edge_profile = optional_payload_object(&payload, "edge_profile")?;
@@ -1894,12 +2394,6 @@ impl InProcessChatTurnBridge {
 
         let bridge_e2e_capture = bridge_e2e_for_stream.clone();
         let bridge_e2e_stream_blocks_capture = bridge_e2e_stream_blocks_for_stream.clone();
-        // Every response stream owns a cancellation token, including direct
-        // callers that did not supply one. The drop guard below therefore has
-        // one uniform way to terminate provider work and durable state.
-        let response_cancel = client_cancel
-            .clone()
-            .unwrap_or_else(|| Arc::new(CancellationToken::new()));
         let client_cancel_capture = response_cancel.clone();
         let memoria_client_owned = bind_bridge_memoria_owner(self.memoria_client.clone(), &user_id)
             .map_err(|error| {
@@ -4826,6 +5320,24 @@ impl InProcessChatTurnBridge {
             let has_tool_calls = !all_round_tool_calls.is_empty();
             let llm_content = full_text.trim().to_string();
             let should_persist_llm = !llm_content.is_empty() || has_tool_calls;
+            if has_tool_calls {
+                if let Some(admission) = canonical_admission.as_mut() {
+                    // The CLI owns the provisional messages between bridge
+                    // rounds. Keep the same database reservation so another
+                    // pod/device cannot interleave a different visible turn.
+                    admission.retain_for_continuation();
+                }
+            } else if let Some(admission) = canonical_admission.as_mut()
+                && let Err(error) = admission.commit_terminal(&llm_content).await
+            {
+                yield render_sse_map(&build_stream_error_event(
+                    &format!("canonical turn commit failed: {error}"),
+                    "durability_degraded",
+                    true,
+                ));
+                mark_disconnect_capture_finalized(&disconnect_capture_state);
+                return;
+            }
 
             // P2 fix: on continuation calls (CLI sent tool_results), the user query
             // was already persisted on the first bridge call. Skip to avoid duplicate event_id.
@@ -5722,6 +6234,192 @@ mod tests {
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     };
+
+    #[tokio::test]
+    async fn canonical_bridge_reservation_spans_rounds_and_fences_competing_turns() {
+        let temp = tempfile::tempdir().unwrap();
+        let coordinator: Arc<dyn astra_services::SessionContextCoordinator> = Arc::new(
+            astra_services::FileSessionContextCoordinator::new(temp.path()),
+        );
+        let user_message = json!({"role": "user", "content": "inspect the repository"});
+        let mut first = begin_bridge_canonical_admission(
+            Some(&coordinator),
+            "owner-1",
+            "session-1",
+            "turn-chain-1",
+            Some(1),
+            None,
+            vec![user_message.clone()],
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap()
+        .admission
+        .unwrap();
+
+        let competing = begin_bridge_canonical_admission(
+            Some(&coordinator),
+            "owner-1",
+            "session-1",
+            "turn-chain-2",
+            Some(1),
+            None,
+            vec![user_message.clone()],
+            CancellationToken::new(),
+        )
+        .await;
+        let Err(competing) = competing else {
+            panic!("a different visible turn must not interleave between tool rounds");
+        };
+        assert_eq!(competing.0, StatusCode::CONFLICT);
+
+        first.retain_for_continuation();
+        drop(first);
+
+        let stale_retry = begin_bridge_canonical_admission(
+            Some(&coordinator),
+            "owner-1",
+            "session-1",
+            "turn-chain-1",
+            Some(2),
+            None,
+            vec![user_message.clone()],
+            CancellationToken::new(),
+        )
+        .await;
+        let Err(stale_retry) = stale_retry else {
+            panic!("a retry with a mismatched turn must be rejected");
+        };
+        assert_eq!(stale_retry.0, StatusCode::CONFLICT);
+        let key = astra_turn_types::SessionKeyV1::owner_session(
+            "server",
+            "owner-1",
+            "session-1",
+            astra_turn_types::DEFAULT_CONVERSATION_BRANCH_ID,
+        );
+        assert!(
+            coordinator
+                .load_active_writer(&key)
+                .await
+                .unwrap()
+                .is_some(),
+            "a rejected retry must not release the original request's writer lease"
+        );
+
+        let tool_call = json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{\"path\":\"README.md\"}"}
+            }]
+        });
+        let tool_result = json!({
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": "repository contents"
+        });
+        let provisional = vec![user_message, tool_call, tool_result];
+        let mut continuation = begin_bridge_canonical_admission(
+            Some(&coordinator),
+            "owner-1",
+            "session-1",
+            "turn-chain-1",
+            Some(1),
+            None,
+            provisional,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap()
+        .admission
+        .unwrap();
+        continuation
+            .commit_terminal("inspection complete")
+            .await
+            .unwrap();
+
+        let head = coordinator.load_head(&key).await.unwrap().unwrap();
+        assert_eq!(head.cursor.completed_turn, 1);
+        let materialized = coordinator.materialize(&head).await.unwrap();
+        assert_eq!(
+            materialized
+                .messages
+                .last()
+                .and_then(|message| message.get("content"))
+                .and_then(Value::as_str),
+            Some("inspection complete")
+        );
+        assert!(
+            materialized
+                .messages
+                .iter()
+                .any(|message| message.get("tool_call_id") == Some(&json!("call-1"))),
+            "the canonical turn must retain the complete typed tool group"
+        );
+        assert!(
+            coordinator
+                .load_active_writer(&key)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let next_user = json!({"role": "user", "content": "summarize the result"});
+        let BridgeCanonicalAdmissionResult {
+            admission,
+            provider_messages,
+        } = begin_bridge_canonical_admission(
+            Some(&coordinator),
+            "owner-1",
+            "session-1",
+            "turn-chain-2",
+            Some(2),
+            None,
+            vec![next_user.clone()],
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            provider_messages[..materialized.messages.len()],
+            materialized.messages,
+            "the server-owned canonical head must be prepended to a current-turn-only request"
+        );
+        assert_eq!(provider_messages.last(), Some(&next_user));
+        let mut next = admission.unwrap();
+        next.commit_terminal("summary complete").await.unwrap();
+
+        let head = coordinator.load_head(&key).await.unwrap().unwrap();
+        assert_eq!(head.cursor.completed_turn, 2);
+        let materialized = coordinator.materialize(&head).await.unwrap();
+        assert_eq!(
+            materialized
+                .messages
+                .last()
+                .and_then(|message| message.get("content"))
+                .and_then(Value::as_str),
+            Some("summary complete")
+        );
+    }
+
+    #[test]
+    fn canonical_bridge_prompt_rejects_divergent_completed_history() {
+        let prior = vec![
+            json!({"role": "user", "content": "first"}),
+            json!({"role": "assistant", "content": "first reply"}),
+        ];
+        let divergent = vec![
+            json!({"role": "user", "content": "different history"}),
+            json!({"role": "assistant", "content": "old reply"}),
+            json!({"role": "user", "content": "current"}),
+        ];
+
+        let error = admit_canonical_bridge_prompt(prior, divergent)
+            .expect_err("a completed client-side history must not be reinterpreted as one turn");
+        assert!(error.contains("structurally valid current-turn suffix"));
+    }
 
     #[test]
     fn disconnect_capture_clone_preserves_nested_wire_state() {

--- a/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/crates/runtime/src/turn/bridge/inprocess.rs
@@ -2999,7 +2999,7 @@ impl InProcessChatTurnBridge {
                                 return;
                             }
                         };
-                    crate::turn::llm::exchange_capture::spawn_prompt_request_plan_persist_or_log(
+                    crate::turn::llm::exchange_capture::persist_prompt_request_plan_or_log(
                         "bridge_inprocess e2e capture",
                         shared_pool.clone(),
                         astra_services::PromptRequestPersistInput {
@@ -3014,7 +3014,8 @@ impl InProcessChatTurnBridge {
                             provider: provider.clone(),
                         },
                         prompt_request_plan,
-                    );
+                    )
+                    .await;
                     yield render_sse(&crate::turn::llm::context::context_meta_event_with_compactions(
                         &breakdown,
                         Some(&bridge_manifest_trace_json),
@@ -3115,7 +3116,7 @@ impl InProcessChatTurnBridge {
                                 return;
                             }
                         };
-                    crate::turn::llm::exchange_capture::spawn_prompt_request_plan_persist_or_log(
+                    crate::turn::llm::exchange_capture::persist_prompt_request_plan_or_log(
                         "bridge_inprocess live capture",
                         shared_pool.clone(),
                         astra_services::PromptRequestPersistInput {
@@ -3130,7 +3131,8 @@ impl InProcessChatTurnBridge {
                             provider: provider.clone(),
                         },
                         prompt_request_plan,
-                    );
+                    )
+                    .await;
 
                     // wip-7: emit per-channel fingerprints ONLY — no raw
                     // text crosses the HTTP boundary. Raw channel content
@@ -3639,7 +3641,7 @@ impl InProcessChatTurnBridge {
                                 Some(&bridge_manifest_trace_json),
                                 &context_compactions,
                             ));
-                            crate::turn::llm::exchange_capture::spawn_prompt_request_plan_persist_or_log(
+                            crate::turn::llm::exchange_capture::persist_prompt_request_plan_or_log(
                                 "bridge_inprocess retry capture",
                                 shared_pool.clone(),
                                 astra_services::PromptRequestPersistInput {
@@ -3654,7 +3656,8 @@ impl InProcessChatTurnBridge {
                                     provider: provider.clone(),
                                 },
                                 prompt_request_plan,
-                            );
+                            )
+                            .await;
 
                             // Retry LLM call
                             match call_llm_stream_with_attempt_observer(

--- a/crates/runtime/src/turn/canonical_commit.rs
+++ b/crates/runtime/src/turn/canonical_commit.rs
@@ -1,0 +1,103 @@
+use serde_json::Value;
+
+pub(crate) fn canonical_commit_delta(
+    prior_message_count: usize,
+    had_canonical_head: bool,
+    messages: &[Value],
+    compaction_rewrote_prefix: bool,
+    cancellation_requested: bool,
+) -> Result<Option<(astra_turn_types::CanonicalDeltaModeV1, Vec<Vec<Value>>)>, String> {
+    let mode = if compaction_rewrote_prefix && had_canonical_head {
+        astra_turn_types::CanonicalDeltaModeV1::Replace
+    } else {
+        astra_turn_types::CanonicalDeltaModeV1::Append
+    };
+    let changed_messages = if mode == astra_turn_types::CanonicalDeltaModeV1::Replace {
+        messages
+    } else {
+        messages.get(prior_message_count..).ok_or_else(|| {
+            "canonical conversation became shorter than the admitted prefix".to_string()
+        })?
+    };
+    let canonical_changed =
+        astra_turn_core::prompt_facing::sanitize_canonical_continuation_messages_with_turn_semantics(
+            changed_messages.to_vec(),
+        )
+        .map_err(|error| {
+            format!("canonical turn contains invalid user-turn semantics: {error}")
+        })?;
+    let logical_segments = pack_canonical_turn_segments(canonical_changed);
+    if logical_segments.is_empty() {
+        return if cancellation_requested {
+            Ok(None)
+        } else {
+            Err("canonical turn produced no committable messages".into())
+        };
+    }
+    Ok(Some((mode, logical_segments)))
+}
+
+pub(crate) fn pack_canonical_turn_segments(mut messages: Vec<Value>) -> Vec<Vec<Value>> {
+    const TARGET_PACK_BYTES: u64 = 512 * 1024;
+
+    let mut packs = Vec::new();
+    let mut current = Vec::new();
+    let mut current_bytes = 2_u64;
+    let mut index = 0;
+    while index < messages.len() {
+        let group_start = index;
+        let keeps_tool_results = opens_structured_tool_group(&messages[index]);
+        index += 1;
+        if keeps_tool_results {
+            while index < messages.len() && is_structured_tool_result(&messages[index]) {
+                index += 1;
+            }
+        }
+        let group = &mut messages[group_start..index];
+        let group_bytes = astra_turn_types::canonical_conversation_serialized_len(group);
+        let projected = current_bytes
+            .saturating_add(group_bytes.saturating_sub(2))
+            .saturating_add(u64::from(!current.is_empty()));
+        if !current.is_empty() && projected > TARGET_PACK_BYTES {
+            packs.push(std::mem::take(&mut current));
+            current_bytes = 2;
+        }
+        current_bytes = current_bytes
+            .saturating_add(group_bytes.saturating_sub(2))
+            .saturating_add(u64::from(!current.is_empty()));
+        current.extend(group.iter_mut().map(Value::take));
+    }
+    if !current.is_empty() {
+        packs.push(current);
+    }
+    packs
+}
+
+fn opens_structured_tool_group(message: &Value) -> bool {
+    message.get("role").and_then(Value::as_str) == Some("assistant")
+        && (message
+            .get("tool_calls")
+            .and_then(Value::as_array)
+            .is_some_and(|calls| !calls.is_empty())
+            || message
+                .get("content")
+                .and_then(Value::as_array)
+                .is_some_and(|content| {
+                    content
+                        .iter()
+                        .any(|item| item.get("type").and_then(Value::as_str) == Some("tool_use"))
+                }))
+}
+
+fn is_structured_tool_result(message: &Value) -> bool {
+    message.get("role").and_then(Value::as_str) == Some("tool")
+        || message
+            .get("content")
+            .and_then(Value::as_array)
+            .is_some_and(|content| {
+                !content.is_empty()
+                    && content
+                        .iter()
+                        .all(|item| item.get("type").and_then(Value::as_str) == Some("tool_result"))
+            })
+}

--- a/crates/runtime/src/turn/llm/exchange_capture.rs
+++ b/crates/runtime/src/turn/llm/exchange_capture.rs
@@ -339,7 +339,7 @@ pub(crate) async fn persist_configured_capture_or_log(
     }
 }
 
-pub(crate) fn spawn_prompt_request_plan_persist_or_log(
+pub(crate) async fn persist_prompt_request_plan_or_log(
     context: &'static str,
     shared_pool: Option<SharedPool>,
     input: astra_services::PromptRequestPersistInput,
@@ -351,23 +351,19 @@ pub(crate) fn spawn_prompt_request_plan_persist_or_log(
     let Some(shared_pool) = shared_pool else {
         return;
     };
-    tokio::spawn(async move {
-        if let Err(error) =
-            astra_services::persist_prompt_request(&shared_pool, &input, &plan).await
-        {
-            let pool_stats = shared_pool.stats();
-            tracing::error!(
-                target: "astra_runtime::prompt_delta",
-                %context,
-                request_id = %plan.request_id,
-                db_pool_max = pool_stats.max_connections,
-                db_pool_size = pool_stats.size,
-                db_pool_idle = pool_stats.num_idle,
-                error = %error,
-                "failed to persist prompt request delta"
-            );
-        }
-    });
+    if let Err(error) = astra_services::persist_prompt_request(&shared_pool, &input, &plan).await {
+        let pool_stats = shared_pool.stats();
+        tracing::error!(
+            target: "astra_runtime::prompt_delta",
+            %context,
+            request_id = %plan.request_id,
+            db_pool_max = pool_stats.max_connections,
+            db_pool_size = pool_stats.size,
+            db_pool_idle = pool_stats.num_idle,
+            error = %error,
+            "failed to persist prompt request delta"
+        );
+    }
 }
 
 fn capture_file_path(

--- a/crates/runtime/src/turn/mod.rs
+++ b/crates/runtime/src/turn/mod.rs
@@ -3,6 +3,7 @@ pub mod agentic_loop;
 pub mod bedrock;
 pub mod bridge;
 pub mod budget_messaging;
+pub(crate) mod canonical_commit;
 pub mod chat_turn_budget_pressure;
 pub mod cloud;
 pub mod compaction_replay;

--- a/crates/runtime/tests/system_matrix_http_e2e/journey_extended.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/journey_extended.rs
@@ -23,6 +23,20 @@ fn parse_sse_events(raw: &str) -> Vec<Value> {
         .collect()
 }
 
+fn has_turn_complete(raw: &str) -> bool {
+    parse_sse_events(raw)
+        .iter()
+        .any(|event| event.get("type").and_then(Value::as_str) == Some("turn_complete"))
+}
+
+fn has_retryable_conflict(raw: &str) -> bool {
+    parse_sse_events(raw).iter().any(|event| {
+        event.get("type").and_then(Value::as_str) == Some("error")
+            && event.get("code").and_then(Value::as_str) == Some("CONFLICT")
+            && event.get("retryable").and_then(Value::as_bool) == Some(true)
+    })
+}
+
 pub async fn run_session_cancel_then_delete() {
     let b = bootstrap().await;
     let ctx = &b.ctx;
@@ -901,7 +915,8 @@ pub async fn run_same_session_concurrent_turns_isolated() {
         "messages": [{ "role": "user", "content": "same-session overlap request A" }],
         "model_selection": seeded_model_selection(ctx),
         "test_llm_rounds": [{
-            "full_text": "Overlap response A"
+            "full_text": "Overlap response A",
+            "delay_ms": 250
         }]
     });
     let payload_b = json!({
@@ -911,7 +926,8 @@ pub async fn run_same_session_concurrent_turns_isolated() {
         "messages": [{ "role": "user", "content": "same-session overlap request B" }],
         "model_selection": seeded_model_selection(ctx),
         "test_llm_rounds": [{
-            "full_text": "Overlap response B"
+            "full_text": "Overlap response B",
+            "delay_ms": 250
         }]
     });
 
@@ -933,19 +949,13 @@ pub async fn run_same_session_concurrent_turns_isolated() {
 
         let mut stream = response.into_body().into_data_stream();
         let mut acc = Vec::new();
-        let mut saw_turn_complete = false;
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.expect("overlap sse chunk");
             acc.extend_from_slice(&chunk);
             if String::from_utf8_lossy(&acc).contains("\"type\":\"turn_complete\"") {
-                saw_turn_complete = true;
                 break;
             }
         }
-        assert!(
-            saw_turn_complete,
-            "overlap turn never reached turn_complete"
-        );
         String::from_utf8_lossy(&acc).into_owned()
     };
 
@@ -953,16 +963,57 @@ pub async fn run_same_session_concurrent_turns_isolated() {
         collect_turn(
             ctx.app.clone(),
             b.auth_header.clone(),
-            payload_a,
+            payload_a.clone(),
             test_secret.clone(),
         ),
         collect_turn(
             ctx.app.clone(),
             b.auth_header.clone(),
-            payload_b,
-            test_secret
+            payload_b.clone(),
+            test_secret.clone()
         ),
     );
+
+    let completed_a = has_turn_complete(&raw_a);
+    let completed_b = has_turn_complete(&raw_b);
+    assert_eq!(
+        usize::from(completed_a) + usize::from(completed_b),
+        1,
+        "one concurrent writer must commit and one must be fenced: A={raw_a}; B={raw_b}"
+    );
+    assert_eq!(
+        usize::from(has_retryable_conflict(&raw_a)) + usize::from(has_retryable_conflict(&raw_b)),
+        1,
+        "the losing writer must receive one typed retryable conflict: A={raw_a}; B={raw_b}"
+    );
+
+    let (raw_a, raw_b) = if completed_a {
+        let retried_b = collect_turn(
+            ctx.app.clone(),
+            b.auth_header.clone(),
+            payload_b,
+            test_secret.clone(),
+        )
+        .await;
+        assert!(
+            has_turn_complete(&retried_b),
+            "the fenced turn must succeed after the winner commits: {retried_b}"
+        );
+        (raw_a, retried_b)
+    } else {
+        let retried_a = collect_turn(
+            ctx.app.clone(),
+            b.auth_header.clone(),
+            payload_a,
+            test_secret.clone(),
+        )
+        .await;
+        assert!(
+            has_turn_complete(&retried_a),
+            "the fenced turn must succeed after the winner commits: {retried_a}"
+        );
+        (retried_a, raw_b)
+    };
 
     assert!(
         raw_a.contains("Overlap response A"),
@@ -1089,19 +1140,13 @@ pub async fn run_same_session_waiting_turn_overlap_isolated() {
 
         let mut stream = response.into_body().into_data_stream();
         let mut acc = Vec::new();
-        let mut saw_turn_complete = false;
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.expect("waiting-overlap sse chunk");
             acc.extend_from_slice(&chunk);
             if String::from_utf8_lossy(&acc).contains("\"type\":\"turn_complete\"") {
-                saw_turn_complete = true;
                 break;
             }
         }
-        assert!(
-            saw_turn_complete,
-            "waiting-overlap turn never reached turn_complete"
-        );
         String::from_utf8_lossy(&acc).into_owned()
     };
 
@@ -1211,12 +1256,16 @@ pub async fn run_same_session_waiting_turn_overlap_isolated() {
         "tool-backed overlap turn should not leak the plain-turn response: {primary_raw}"
     );
     assert!(
-        overlap_raw.contains("Waiting overlap plain turn finished."),
-        "overlap turn should keep its own final text: {overlap_raw}"
+        has_retryable_conflict(&overlap_raw),
+        "a second writer must receive a typed retryable conflict while the tool turn owns the reservation: {overlap_raw}"
     );
     assert!(
         !overlap_raw.contains("tc-overlap-wait-1"),
         "plain overlap turn should not leak the tool-backed request id: {overlap_raw}"
+    );
+    assert!(
+        !overlap_raw.contains("Waiting overlap plain turn finished."),
+        "a fenced overlap must not execute its model fixture: {overlap_raw}"
     );
 
     ctx.pool.close().await;

--- a/crates/runtime/tests/system_matrix_http_e2e/journey_full.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/journey_full.rs
@@ -113,7 +113,11 @@ async fn run_tool_backed_chat_turn(
         }
     }
 
-    assert!(posted_result, "tool-backed chat never emitted tool_request");
+    assert!(
+        posted_result,
+        "tool-backed chat never emitted tool_request; SSE: {}",
+        String::from_utf8_lossy(&acc)
+    );
     assert!(
         saw_turn_complete,
         "tool-backed chat never reached turn_complete"
@@ -168,58 +172,6 @@ pub async fn run_product_matrix_full_journey(
     assert_eq!(
         put_s["title"].as_str(),
         Some("product matrix session (updated)")
-    );
-
-    let (st_close, closed) = post_empty(
-        app,
-        &format!("/sessions/{session_id}/close"),
-        Some(auth_header),
-    )
-    .await;
-    assert_eq!(st_close, StatusCode::OK, "close session: {closed}");
-    assert_eq!(
-        closed["status"].as_str(),
-        Some("closed"),
-        "close response: {closed}"
-    );
-
-    let sess_status =
-        sqlx::query("SELECT status FROM agent_sessions WHERE session_id = ? AND user_id = ?")
-            .bind(&session_id)
-            .bind(&user_id)
-            .fetch_one(pool)
-            .await
-            .expect("session status after close");
-    assert_eq!(
-        sess_status.try_get::<String, _>("status").ok().as_deref(),
-        Some("closed"),
-        "agent_sessions.status after POST .../close"
-    );
-
-    let (st_res, resm) = post_empty(
-        app,
-        &format!("/sessions/{session_id}/resume"),
-        Some(auth_header),
-    )
-    .await;
-    assert_eq!(st_res, StatusCode::OK, "resume session: {resm}");
-    assert_eq!(
-        resm["last_status"].as_str(),
-        Some("active"),
-        "resume response: {resm}"
-    );
-
-    let sess_active =
-        sqlx::query("SELECT status FROM agent_sessions WHERE session_id = ? AND user_id = ?")
-            .bind(&session_id)
-            .bind(&user_id)
-            .fetch_one(pool)
-            .await
-            .expect("session status after resume");
-    assert_eq!(
-        sess_active.try_get::<String, _>("status").ok().as_deref(),
-        Some("active"),
-        "agent_sessions.status after POST .../resume"
     );
 
     let (st_act, act) = get_json(
@@ -1168,6 +1120,81 @@ pub async fn run_product_matrix_full_journey(
             .map(|s| s.is_empty())
             .unwrap_or(true),
         "reasoning_content should be empty for mock round with reasoning: \"\""
+    );
+
+    // A session is resumable only after it has a durable conversation
+    // generation. Exercise close/resume at that boundary so this journey
+    // verifies hydration, rather than treating resume as a status-only reopen.
+    let (st_close, closed) = post_empty(
+        app,
+        &format!("/sessions/{session_id}/close"),
+        Some(auth_header),
+    )
+    .await;
+    assert_eq!(st_close, StatusCode::OK, "close session: {closed}");
+    assert_eq!(
+        closed["status"].as_str(),
+        Some("closed"),
+        "close response: {closed}"
+    );
+
+    let sess_status =
+        sqlx::query("SELECT status FROM agent_sessions WHERE session_id = ? AND user_id = ?")
+            .bind(&session_id)
+            .bind(&user_id)
+            .fetch_one(pool)
+            .await
+            .expect("session status after close");
+    assert_eq!(
+        sess_status.try_get::<String, _>("status").ok().as_deref(),
+        Some("closed"),
+        "agent_sessions.status after POST .../close"
+    );
+
+    let (st_res, resm) = post_empty(
+        app,
+        &format!("/sessions/{session_id}/resume"),
+        Some(auth_header),
+    )
+    .await;
+    assert_eq!(st_res, StatusCode::OK, "resume session: {resm}");
+    assert_eq!(
+        resm["last_status"].as_str(),
+        Some("active"),
+        "resume response: {resm}"
+    );
+    assert_eq!(
+        resm["resume_bundle"]["source"].as_str(),
+        Some("canonical_journal"),
+        "resume must hydrate from the canonical journal: {resm}"
+    );
+    let resumed_messages = resm["resume_bundle"]["conversation_messages"]
+        .as_array()
+        .expect("canonical resume must contain conversation messages");
+    assert!(
+        resumed_messages
+            .iter()
+            .any(|message| message.to_string().contains("matrix journey ping")),
+        "canonical resume lost the user message: {resm}"
+    );
+    assert!(
+        resumed_messages
+            .iter()
+            .any(|message| message.to_string().contains(LLM_TEXT)),
+        "canonical resume lost the assistant message: {resm}"
+    );
+
+    let sess_active =
+        sqlx::query("SELECT status FROM agent_sessions WHERE session_id = ? AND user_id = ?")
+            .bind(&session_id)
+            .bind(&user_id)
+            .fetch_one(pool)
+            .await
+            .expect("session status after resume");
+    assert_eq!(
+        sess_active.try_get::<String, _>("status").ok().as_deref(),
+        Some("active"),
+        "agent_sessions.status after POST .../resume"
     );
 
     let turn_cnt_row = sqlx::query(

--- a/crates/runtime/tests/system_matrix_http_e2e/main.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/main.rs
@@ -30,11 +30,11 @@
 //!   `tool_request` callbacks, then accepts the second callback result before the first while the
 //!   initial SSE handoff still ends with `has_tool_calls=true`.
 //! - **`e2e_matrix_same_session_concurrent_turns_isolated`** — two concurrent `POST /chat/turn`
-//!   requests target the same session; assert both complete with distinct persisted `event_id` and
-//!   `causal_chain_id` values instead of cross-wiring each other.
+//!   requests target the same session; assert one canonical writer commits, the other receives a
+//!   typed retryable conflict, and its serial retry persists a distinct causal chain.
 //! - **`e2e_matrix_same_session_waiting_turn_overlap_isolated`** — a same-session tool-backed
-//!   handoff can overlap a second plain turn without leaking the second turn's response into the
-//!   first stream (or vice versa).
+//!   handoff fences a second plain writer with a typed retryable conflict without leaking either
+//!   turn's data into the other stream.
 //! - **`e2e_matrix_auth_session_negative_paths`** — `GET /sessions` without auth (401), duplicate
 //!   register, bad login, and successful login after negative calls (replaces stub `auth_contract` /
 //!   `session_contract` negative coverage).

--- a/crates/services/src/execution_grant.rs
+++ b/crates/services/src/execution_grant.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use astra_turn_types::{
-    AuthorityEpochsV1, ConversationWriterLeaseV1, EXECUTION_GRANT_SCHEMA_VERSION,
-    ExecutionGrantClaimsV1, SessionKeyV1, SignedExecutionGrantV1,
+    ConversationWriterLeaseV1, EXECUTION_GRANT_SCHEMA_VERSION, ExecutionGrantClaimsV1,
+    SignedExecutionGrantV1,
 };
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use hmac::{Hmac, Mac};
@@ -116,8 +116,7 @@ impl ExecutionGrantSigner {
     pub fn verify<'a>(
         &self,
         grant: &'a SignedExecutionGrantV1,
-        expected_key: &SessionKeyV1,
-        expected_epochs: AuthorityEpochsV1,
+        active_lease: &ConversationWriterLeaseV1,
         expected_run_id: &str,
         expected_run_generation: u64,
         expected_provider_binding_id: Option<&str>,
@@ -153,8 +152,12 @@ impl ExecutionGrantSigner {
         if grant.claims.expires_at_unix_ms <= now_unix_ms {
             return Err(ExecutionGrantError::Expired);
         }
-        if &grant.claims.key != expected_key
-            || grant.claims.authority_epochs != expected_epochs
+        if grant.claims.key != active_lease.key
+            || grant.claims.lease_id != active_lease.lease_id
+            || grant.claims.writer_epoch != active_lease.writer_epoch
+            || grant.claims.actor_id != active_lease.actor.actor_id
+            || grant.claims.authority_epochs != active_lease.actor.authority_epochs
+            || active_lease.expires_at_unix_ms <= now_unix_ms
             || grant.claims.run_id != expected_run_id
             || grant.claims.run_generation != expected_run_generation
             || grant.claims.provider_binding_id.as_deref() != expected_provider_binding_id
@@ -234,22 +237,15 @@ mod tests {
             .unwrap();
 
         signer
-            .verify(
-                &grant,
-                &lease.key,
-                lease.actor.authority_epochs,
-                "run-1",
-                11,
-                Some("provider-1"),
-                13,
-                2_001,
-            )
+            .verify(&grant, &lease, "run-1", 11, Some("provider-1"), 13, 2_001)
             .unwrap();
         assert_eq!(
             signer.verify(
                 &grant,
-                &SessionKeyV1::owner_session("test", "owner-b", "session", "main"),
-                lease.actor.authority_epochs,
+                &ConversationWriterLeaseV1 {
+                    key: SessionKeyV1::owner_session("test", "owner-b", "session", "main",),
+                    ..lease.clone()
+                },
                 "run-1",
                 11,
                 Some("provider-1"),
@@ -259,29 +255,11 @@ mod tests {
             Err(ExecutionGrantError::Fenced)
         );
         assert_eq!(
-            signer.verify(
-                &grant,
-                &lease.key,
-                lease.actor.authority_epochs,
-                "run-1",
-                12,
-                Some("provider-1"),
-                13,
-                2_001,
-            ),
+            signer.verify(&grant, &lease, "run-1", 12, Some("provider-1"), 13, 2_001,),
             Err(ExecutionGrantError::Fenced)
         );
         assert_eq!(
-            signer.verify(
-                &grant,
-                &lease.key,
-                lease.actor.authority_epochs,
-                "run-1",
-                11,
-                Some("provider-2"),
-                13,
-                2_001,
-            ),
+            signer.verify(&grant, &lease, "run-1", 11, Some("provider-2"), 13, 2_001,),
             Err(ExecutionGrantError::Fenced)
         );
     }
@@ -295,16 +273,7 @@ mod tests {
             .unwrap();
         grant.claims.writer_epoch += 1;
         assert_eq!(
-            signer.verify(
-                &grant,
-                &lease.key,
-                lease.actor.authority_epochs,
-                "run-1",
-                1,
-                None,
-                1,
-                2_001,
-            ),
+            signer.verify(&grant, &lease, "run-1", 1, None, 1, 2_001,),
             Err(ExecutionGrantError::InvalidSignature)
         );
 
@@ -312,17 +281,34 @@ mod tests {
             .issue(&lease, "run-1", 1, None, 1, 2_000, Duration::from_secs(1))
             .unwrap();
         assert_eq!(
-            signer.verify(
-                &grant,
-                &lease.key,
-                lease.actor.authority_epochs,
+            signer.verify(&grant, &lease, "run-1", 1, None, 1, 3_000,),
+            Err(ExecutionGrantError::Expired)
+        );
+    }
+
+    #[test]
+    fn transfer_fences_a_previously_valid_grant() {
+        let signer = ExecutionGrantSigner::new([9_u8; 32]).unwrap();
+        let old_lease = lease("owner-a", 7);
+        let grant = signer
+            .issue(
+                &old_lease,
                 "run-1",
                 1,
                 None,
                 1,
-                3_000,
-            ),
-            Err(ExecutionGrantError::Expired)
+                2_000,
+                Duration::from_secs(30),
+            )
+            .unwrap();
+        let mut transferred = old_lease.clone();
+        transferred.lease_id = "lease-2".into();
+        transferred.writer_epoch += 1;
+        transferred.actor.actor_id = "actor-2".into();
+
+        assert_eq!(
+            signer.verify(&grant, &transferred, "run-1", 1, None, 1, 2_001),
+            Err(ExecutionGrantError::Fenced)
         );
     }
 }

--- a/crates/services/src/inference_execution.rs
+++ b/crates/services/src/inference_execution.rs
@@ -588,6 +588,125 @@ async fn insert_model_request_context_event(
             )
         })?;
     }
+    prune_model_request_context_scope(connection, attempt).await?;
+    Ok(())
+}
+
+async fn prune_model_request_context_scope(
+    connection: &mut sqlx::MySqlConnection,
+    attempt: &InferenceProviderAttemptPlan,
+) -> ServiceResult<()> {
+    const MAX_CONTEXT_EVENTS_PER_SCOPE: i64 = 2_048;
+    const PRUNE_ATTEMPTS_PER_BATCH: i64 = 256;
+
+    let (probe_sql, oldest_sql, scope_value) =
+        if let Some(session_id) = attempt.invocation_input.scope.session_id() {
+            (
+                "SELECT event_id FROM model_request_context_events
+                 WHERE user_id = ? AND session_id = ?
+                 ORDER BY created_at DESC, event_id DESC
+                 LIMIT 1 OFFSET ?",
+                "SELECT attempt_id FROM model_request_context_events
+                 WHERE user_id = ? AND session_id = ?
+                 GROUP BY attempt_id
+                 HAVING COUNT(*) = 2
+                 ORDER BY MIN(created_at) ASC, attempt_id ASC
+                 LIMIT ?",
+                session_id,
+            )
+        } else if let Some(harness_run_id) = attempt.invocation_input.scope.harness_run_id() {
+            (
+                "SELECT event_id FROM model_request_context_events
+                 WHERE user_id = ? AND harness_run_id = ?
+                 ORDER BY created_at DESC, event_id DESC
+                 LIMIT 1 OFFSET ?",
+                "SELECT attempt_id FROM model_request_context_events
+                 WHERE user_id = ? AND harness_run_id = ?
+                 GROUP BY attempt_id
+                 HAVING COUNT(*) = 2
+                 ORDER BY MIN(created_at) ASC, attempt_id ASC
+                 LIMIT ?",
+                harness_run_id,
+            )
+        } else {
+            return Err(ServiceError::new(
+                ServiceErrorKind::Internal,
+                "model request context has no durable session or harness scope",
+            ));
+        };
+    let over_limit = sqlx::query(probe_sql)
+        .bind(&attempt.user_id)
+        .bind(scope_value)
+        .bind(MAX_CONTEXT_EVENTS_PER_SCOPE)
+        .fetch_optional(&mut *connection)
+        .await
+        .map_err(|error| {
+            ServiceError::with_source(
+                ServiceErrorKind::Persistence,
+                "probe model request context retention",
+                error,
+            )
+        })?
+        .is_some();
+    if !over_limit {
+        return Ok(());
+    }
+
+    let oldest_attempts = sqlx::query(oldest_sql)
+        .bind(&attempt.user_id)
+        .bind(scope_value)
+        .bind(PRUNE_ATTEMPTS_PER_BATCH)
+        .fetch_all(&mut *connection)
+        .await
+        .map_err(|error| {
+            ServiceError::with_source(
+                ServiceErrorKind::Persistence,
+                "load model request context retention batch",
+                error,
+            )
+        })?;
+    let attempt_ids = oldest_attempts
+        .into_iter()
+        .map(|row| {
+            row.try_get::<String, _>("attempt_id").map_err(|error| {
+                ServiceError::with_source(
+                    ServiceErrorKind::Persistence,
+                    "decode model request context retention batch",
+                    error,
+                )
+            })
+        })
+        .collect::<ServiceResult<Vec<_>>>()?;
+    if attempt_ids.is_empty() {
+        // Concurrent accepted attempts are not disposable until their
+        // terminal fact arrives. Provider-slot admission bounds this temporary
+        // excess; a later terminal insert will prune complete pairs.
+        return Ok(());
+    }
+    let mut delete = sqlx::QueryBuilder::<sqlx::MySql>::new(
+        "DELETE FROM model_request_context_events WHERE user_id = ",
+    );
+    delete
+        .push_bind(&attempt.user_id)
+        .push(" AND attempt_id IN (");
+    {
+        let mut separated = delete.separated(", ");
+        for attempt_id in &attempt_ids {
+            separated.push_bind(attempt_id);
+        }
+    }
+    delete.push(")");
+    delete
+        .build()
+        .execute(&mut *connection)
+        .await
+        .map_err(|error| {
+            ServiceError::with_source(
+                ServiceErrorKind::Persistence,
+                "prune model request context retention batch",
+                error,
+            )
+        })?;
     Ok(())
 }
 

--- a/crates/services/src/prompt_delta.rs
+++ b/crates/services/src/prompt_delta.rs
@@ -576,7 +576,7 @@ pub async fn load_latest_prompt_observability_for_run(
         "SELECT request_id, request_hash, message_count, tool_count, summary_json
          FROM prompt_request_records
          WHERE user_id = ? AND run_id = ?
-         ORDER BY created_at DESC, turn DESC, round DESC, attempt DESC
+         ORDER BY turn DESC, round DESC, attempt DESC, created_at DESC, request_id DESC
          LIMIT 1",
         user_id,
         run_id,
@@ -594,7 +594,7 @@ pub async fn load_latest_prompt_observability_for_session(
         "SELECT request_id, request_hash, message_count, tool_count, summary_json
          FROM prompt_request_records
          WHERE user_id = ? AND session_id = ?
-         ORDER BY created_at DESC, turn DESC, round DESC, attempt DESC
+         ORDER BY turn DESC, round DESC, attempt DESC, created_at DESC, request_id DESC
          LIMIT 1",
         user_id,
         session_id,
@@ -801,12 +801,23 @@ async fn load_previous_request(
         "SELECT request_id, provider, CAST(summary_json AS CHAR) AS summary_json
          FROM prompt_request_records
          WHERE user_id = ? AND session_id = ? AND source = ?
-         ORDER BY created_at DESC, turn DESC, round DESC, attempt DESC
+           AND (
+               turn < ?
+               OR (turn = ? AND round < ?)
+               OR (turn = ? AND round = ? AND attempt < ?)
+           )
+         ORDER BY turn DESC, round DESC, attempt DESC, created_at DESC, request_id DESC
          LIMIT 1",
     )
     .bind(&input.user_id)
     .bind(&input.session_id)
     .bind(&input.source)
+    .bind(i64::from(input.turn))
+    .bind(i64::from(input.turn))
+    .bind(i64::from(input.round))
+    .bind(i64::from(input.turn))
+    .bind(i64::from(input.round))
+    .bind(i64::from(input.attempt))
     .fetch_optional(pool)
     .await
     .map_err(|error| error.to_string())
@@ -834,8 +845,8 @@ async fn load_request_chunks(
          WHERE request.user_id = ? AND request.session_id = ? AND request.source = ?
          GROUP BY request.request_id, request.previous_request_id,
                   request.created_at, request.turn, request.round, request.attempt
-         ORDER BY request.created_at DESC, request.turn DESC,
-                  request.round DESC, request.attempt DESC
+         ORDER BY request.turn DESC, request.round DESC,
+                  request.attempt DESC, request.created_at DESC, request.request_id DESC
          LIMIT ?",
     )
     .bind(&input.user_id)

--- a/crates/services/src/session_context_coordinator.rs
+++ b/crates/services/src/session_context_coordinator.rs
@@ -15,13 +15,14 @@ use std::{
 
 use astra_core::SharedPool;
 use astra_turn_types::{
-    ActorContextV1, AuthorityEpochsV1, CANONICAL_TURN_DELTA_SCHEMA_VERSION, CanonicalTurnDeltaV1,
-    ContextManifestNodeV1, ConversationSegmentV1, ConversationWriterLeaseV1,
+    ActorContextV1, AuthorityEpochsV1, CANONICAL_TURN_DELTA_SCHEMA_VERSION, CanonicalDeltaModeV1,
+    CanonicalTurnDeltaV1, ContextManifestNodeV1, ConversationSegmentV1, ConversationWriterLeaseV1,
     CoordinatorConflictOptionV1, CoordinatorMutationV1, HandoffRiskEvidenceV1,
     MANIFEST_DELTA_SCHEMA_VERSION, ManifestDeltaV1, SESSION_COORDINATION_SCHEMA_VERSION,
-    SessionContextHeadV1, SessionCursorV1, SessionForkManifestV1, SessionForkStateV1,
-    SessionHandoffModeV1, SessionKeyV1, SharedManifestPrefixV1, TurnReservationV1,
-    canonical_conversation_root, canonical_conversation_serialized_len,
+    SessionContextHeadV1, SessionCoordinationValidationError, SessionCursorV1,
+    SessionForkManifestV1, SessionForkStateV1, SessionHandoffModeV1, SessionKeyV1,
+    SharedManifestPrefixV1, TurnReservationV1, canonical_conversation_root,
+    canonical_conversation_serialized_len,
 };
 use async_trait::async_trait;
 use fs2::FileExt;
@@ -35,6 +36,8 @@ use uuid::Uuid;
 const FILE_STATE_SCHEMA_VERSION: u32 = 1;
 const MAX_IDEMPOTENCY_KEY_BYTES: usize = 512;
 const MAX_SEGMENT_BATCH: usize = 256;
+const MAX_STAGED_SEGMENT_BYTES: u64 = 8 * 1024 * 1024;
+const MAX_STAGED_BATCH_BYTES: u64 = 32 * 1024 * 1024;
 const MAX_LEASE_TTL: Duration = Duration::from_secs(15 * 60);
 const MAX_RESERVATION_TTL: Duration = Duration::from_secs(15 * 60);
 const RECEIPT_HASH_DOMAIN: &[u8] = b"astra.session-coordinator-receipt.v1\0";
@@ -678,7 +681,17 @@ impl SessionContextCoordinator for FileSessionContextCoordinator {
                         "manifest delta identity mismatch".into(),
                     ));
                 }
-                current = node.parent_manifest_root.clone();
+                if node.replaces_history
+                    && boundary.is_some()
+                    && node.parent_manifest_root.as_deref() != boundary
+                {
+                    return Err(SessionContextCoordinatorError::DivergentManifest);
+                }
+                current = if node.replaces_history && boundary.is_none() {
+                    None
+                } else {
+                    node.parent_manifest_root.clone()
+                };
                 reverse.push(node);
             }
             if !found_after {
@@ -1138,21 +1151,11 @@ impl SessionContextCoordinator for FileSessionContextCoordinator {
                         )?,
                     );
                 }
-                let node = ContextManifestNodeV1::new(
-                    reservation.key.clone(),
-                    state
-                        .head
-                        .as_ref()
-                        .map(|head| head.latest_manifest_root.clone()),
-                    delta.completed_turn,
-                    delta.journal_event_seq,
-                    delta.conversation_seq,
-                    delta.compaction_generation,
-                    delta.config_version_id.clone(),
-                    segments
-                        .iter()
-                        .map(ConversationSegmentV1::reference)
-                        .collect(),
+                let node = manifest_node_for_delta(
+                    &reservation.key,
+                    state.head.as_ref(),
+                    &delta,
+                    &segments,
                 )
                 .map_err(|error| SessionContextCoordinatorError::Invalid(error.to_string()))?;
 
@@ -1186,7 +1189,7 @@ impl SessionContextCoordinator for FileSessionContextCoordinator {
                 archive_previous_commit(&coordinator, state, session_dir)?;
                 let cursor = node.cursor();
                 let (total_canonical_bytes, total_message_count) =
-                    next_head_totals(state.head.as_ref(), &segments)?;
+                    next_head_totals(state.head.as_ref(), &segments, delta.mode)?;
                 state.head = Some(SessionContextHeadV1 {
                     schema_version: SESSION_COORDINATION_SCHEMA_VERSION,
                     key: reservation.key.clone(),
@@ -1324,27 +1327,39 @@ impl SessionContextCoordinator for DatabaseSessionContextCoordinator {
         let mut rows = sqlx::query(
             "SELECT manifest_json FROM conversation_manifest_nodes
              WHERE isolation_domain = ? AND owner_user_id = ?
-               AND session_id = ? AND branch_id = ?",
+               AND session_id = ? AND branch_id = ?
+               AND compaction_generation = ? AND reachable = 1",
         )
         .bind(&head.key.isolation_domain)
         .bind(&head.key.owner_user_id)
         .bind(&head.key.session_id)
         .bind(&head.key.branch_id)
+        .bind(i64_from_u64(
+            "head compaction generation",
+            head.cursor.compaction_generation,
+        )?)
         .fetch_all(self.pool.get())
         .await
         .map_err(|source| database_error("load_manifests", source))?;
-        if let Some(prefix) = &fork_base {
+        if let Some(prefix) = &fork_base
+            && prefix.parent_cursor.compaction_generation == head.cursor.compaction_generation
+        {
             rows.extend(
                 sqlx::query(
                     "SELECT manifest_json FROM conversation_manifest_nodes
                      WHERE isolation_domain = ? AND owner_user_id = ?
                        AND session_id = ? AND branch_id = ?
+                       AND compaction_generation = ? AND reachable = 1
                        AND conversation_seq <= ?",
                 )
                 .bind(&prefix.parent_key.isolation_domain)
                 .bind(&prefix.parent_key.owner_user_id)
                 .bind(&prefix.parent_key.session_id)
                 .bind(&prefix.parent_key.branch_id)
+                .bind(i64_from_u64(
+                    "fork parent compaction generation",
+                    prefix.parent_cursor.compaction_generation,
+                )?)
                 .bind(i64_from_u64(
                     "fork parent conversation sequence",
                     prefix.parent_cursor.conversation_seq,
@@ -1435,7 +1450,8 @@ impl SessionContextCoordinator for DatabaseSessionContextCoordinator {
                     let row = sqlx::query(
                         "SELECT conversation_seq FROM conversation_manifest_nodes
                          WHERE isolation_domain = ? AND owner_user_id = ?
-                           AND session_id = ? AND branch_id = ? AND manifest_root = ?",
+                           AND session_id = ? AND branch_id = ?
+                           AND manifest_root = ? AND reachable = 1",
                     )
                     .bind(&key.isolation_domain)
                     .bind(&key.owner_user_id)
@@ -1456,12 +1472,18 @@ impl SessionContextCoordinator for DatabaseSessionContextCoordinator {
                 (Some(sequence), sequence, Some(root.to_owned()), None)
             }
             None => match &fork_base {
-                Some(prefix) => (
-                    Some(prefix.parent_cursor.conversation_seq),
-                    prefix.parent_cursor.conversation_seq,
-                    Some(prefix.parent_manifest_root.clone()),
-                    Some(prefix.clone()),
-                ),
+                Some(prefix)
+                    if prefix.parent_cursor.compaction_generation
+                        == head.cursor.compaction_generation =>
+                {
+                    (
+                        Some(prefix.parent_cursor.conversation_seq),
+                        prefix.parent_cursor.conversation_seq,
+                        Some(prefix.parent_manifest_root.clone()),
+                        Some(prefix.clone()),
+                    )
+                }
+                Some(_) => (None, 0, None, None),
                 None => (None, 0, None, None),
             },
         };
@@ -1478,6 +1500,7 @@ impl SessionContextCoordinator for DatabaseSessionContextCoordinator {
             "SELECT manifest_json FROM conversation_manifest_nodes
              WHERE isolation_domain = ? AND owner_user_id = ?
                AND session_id = ? AND branch_id = ?
+               AND compaction_generation = ? AND reachable = 1
                AND conversation_seq > ? AND conversation_seq <= ?
              ORDER BY conversation_seq ASC",
         )
@@ -1485,6 +1508,10 @@ impl SessionContextCoordinator for DatabaseSessionContextCoordinator {
         .bind(&key.owner_user_id)
         .bind(&key.session_id)
         .bind(&key.branch_id)
+        .bind(i64_from_u64(
+            "manifest delta compaction generation",
+            head.cursor.compaction_generation,
+        )?)
         .bind(i64_from_u64("manifest delta lower bound", lower_bound)?)
         .bind(i64_from_u64(
             "manifest delta head sequence",
@@ -1742,7 +1769,8 @@ impl SessionContextCoordinator for DatabaseSessionContextCoordinator {
         let parent_row = sqlx::query(
             "SELECT manifest_json FROM conversation_manifest_nodes
              WHERE isolation_domain = ? AND owner_user_id = ?
-               AND session_id = ? AND branch_id = ? AND manifest_root = ?",
+               AND session_id = ? AND branch_id = ?
+               AND manifest_root = ? AND reachable = 1",
         )
         .bind(&manifest.parent_key.isolation_domain)
         .bind(&manifest.parent_key.owner_user_id)
@@ -2595,24 +2623,10 @@ impl SessionContextCoordinator for DatabaseSessionContextCoordinator {
                     .map_err(|error| SessionContextCoordinatorError::Invalid(error.to_string()))?,
             );
         }
-        let node = ContextManifestNodeV1::new(
-            reservation.key.clone(),
-            base_head
-                .as_ref()
-                .map(|head| head.latest_manifest_root.clone()),
-            delta.completed_turn,
-            delta.journal_event_seq,
-            delta.conversation_seq,
-            delta.compaction_generation,
-            delta.config_version_id.clone(),
-            segments
-                .iter()
-                .map(ConversationSegmentV1::reference)
-                .collect(),
-        )
-        .map_err(|error| SessionContextCoordinatorError::Invalid(error.to_string()))?;
+        let node = manifest_node_for_delta(&reservation.key, base_head.as_ref(), &delta, &segments)
+            .map_err(|error| SessionContextCoordinatorError::Invalid(error.to_string()))?;
         let (prepared_total_canonical_bytes, prepared_total_message_count) =
-            next_head_totals(base_head.as_ref(), &segments)?;
+            next_head_totals(base_head.as_ref(), &segments, delta.mode)?;
         self.persist_database_immutables(
             &reservation.key,
             &segments,
@@ -2758,7 +2772,7 @@ impl SessionContextCoordinator for DatabaseSessionContextCoordinator {
         }
         let cursor = node.cursor();
         let (total_canonical_bytes, total_message_count) =
-            next_head_totals(state.head.as_ref(), &segments)?;
+            next_head_totals(state.head.as_ref(), &segments, delta.mode)?;
         if (total_canonical_bytes, total_message_count)
             != (prepared_total_canonical_bytes, prepared_total_message_count)
         {
@@ -2789,6 +2803,7 @@ impl SessionContextCoordinator for DatabaseSessionContextCoordinator {
              SET reachable = 1
              WHERE isolation_domain = ? AND owner_user_id = ?
                AND session_id = ? AND branch_id = ? AND manifest_root = ?
+               AND compaction_generation = ?
                AND total_canonical_bytes = ? AND total_message_count = ?",
         )
         .bind(&reservation.key.isolation_domain)
@@ -2796,6 +2811,10 @@ impl SessionContextCoordinator for DatabaseSessionContextCoordinator {
         .bind(&reservation.key.session_id)
         .bind(&reservation.key.branch_id)
         .bind(&cursor.canonical_root_hash)
+        .bind(i64_from_u64(
+            "reachable compaction generation",
+            cursor.compaction_generation,
+        )?)
         .bind(i64_from_u64(
             "reachable total canonical bytes",
             total_canonical_bytes,
@@ -3007,7 +3026,11 @@ impl FileSessionContextCoordinator {
                     "manifest owner, branch, or root mismatch".into(),
                 ));
             }
-            manifest_root = node.parent_manifest_root.clone();
+            manifest_root = if node.replaces_history {
+                None
+            } else {
+                node.parent_manifest_root.clone()
+            };
             reverse_nodes.push(node);
         }
         reverse_nodes.reverse();
@@ -3139,6 +3162,49 @@ impl DatabaseSessionContextCoordinator {
         total_message_count: u64,
     ) -> Result<(), SessionContextCoordinatorError> {
         self.persist_database_segments(key, segments).await?;
+        let mut tx = self
+            .pool
+            .get()
+            .begin()
+            .await
+            .map_err(|source| database_error("begin_persist_manifest", source))?;
+        let mut lock_segments = QueryBuilder::<MySql>::new(
+            "SELECT segment_hash FROM conversation_segments
+             WHERE isolation_domain = ",
+        );
+        lock_segments
+            .push_bind(&key.isolation_domain)
+            .push(" AND owner_user_id = ")
+            .push_bind(&key.owner_user_id)
+            .push(" AND segment_hash IN (");
+        {
+            let mut separated = lock_segments.separated(", ");
+            for segment in segments {
+                separated.push_bind(&segment.segment_hash);
+            }
+        }
+        lock_segments.push(") FOR UPDATE");
+        let locked_segments = lock_segments
+            .build()
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|source| database_error("lock_manifest_segments", source))?;
+        let locked_hashes = locked_segments
+            .into_iter()
+            .map(|row| {
+                row.try_get::<String, _>("segment_hash")
+                    .map_err(|source| database_error("decode_locked_manifest_segment", source))
+            })
+            .collect::<Result<HashSet<_>, _>>()?;
+        if locked_hashes.len() != segments.len()
+            || segments
+                .iter()
+                .any(|segment| !locked_hashes.contains(&segment.segment_hash))
+        {
+            return Err(SessionContextCoordinatorError::NeedsRepair(
+                "manifest references a segment that is not durably staged".into(),
+            ));
+        }
         let canonical_segment_bytes =
             node.appended_segments
                 .iter()
@@ -3153,8 +3219,9 @@ impl DatabaseSessionContextCoordinator {
             "INSERT IGNORE INTO conversation_manifest_nodes
              (isolation_domain, owner_user_id, session_id, branch_id, manifest_root,
               parent_manifest_root, completed_turn, conversation_seq,
-              canonical_segment_bytes, total_canonical_bytes, total_message_count, manifest_json)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+              compaction_generation, canonical_segment_bytes, total_canonical_bytes,
+              total_message_count, manifest_json)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&key.isolation_domain)
         .bind(&key.owner_user_id)
@@ -3166,6 +3233,10 @@ impl DatabaseSessionContextCoordinator {
         .bind(i64_from_u64(
             "conversation sequence",
             node.conversation_seq,
+        )?)
+        .bind(i64_from_u64(
+            "manifest compaction generation",
+            node.compaction_generation,
         )?)
         .bind(i64_from_u64(
             "manifest segment bytes",
@@ -3180,7 +3251,7 @@ impl DatabaseSessionContextCoordinator {
             total_message_count,
         )?)
         .bind(database_to_json("manifest", node)?)
-        .execute(self.pool.get())
+        .execute(&mut *tx)
         .await
         .map_err(|source| database_error("persist_manifest", source))?;
         if result.rows_affected() == 0 {
@@ -3194,7 +3265,7 @@ impl DatabaseSessionContextCoordinator {
             .bind(&key.session_id)
             .bind(&key.branch_id)
             .bind(&node.manifest_root)
-            .fetch_one(self.pool.get())
+            .fetch_one(&mut *tx)
             .await
             .map_err(|source| database_error("verify_existing_manifest", source))?
             .try_get::<String, _>("manifest_json")
@@ -3206,7 +3277,66 @@ impl DatabaseSessionContextCoordinator {
                 ));
             }
         }
-        Ok(())
+
+        let mut insert_references = QueryBuilder::<MySql>::new(
+            "INSERT IGNORE INTO conversation_manifest_segments
+             (isolation_domain, owner_user_id, session_id, branch_id,
+              manifest_root, segment_position, segment_hash) ",
+        );
+        insert_references.push_values(
+            node.appended_segments.iter().enumerate(),
+            |mut values, (position, segment)| {
+                values
+                    .push_bind(&key.isolation_domain)
+                    .push_bind(&key.owner_user_id)
+                    .push_bind(&key.session_id)
+                    .push_bind(&key.branch_id)
+                    .push_bind(&node.manifest_root)
+                    .push_bind(i64::try_from(position).unwrap_or(i64::MAX))
+                    .push_bind(&segment.segment_hash);
+            },
+        );
+        insert_references
+            .build()
+            .execute(&mut *tx)
+            .await
+            .map_err(|source| database_error("persist_manifest_segment_references", source))?;
+        let stored_references = sqlx::query(
+            "SELECT segment_position, segment_hash
+             FROM conversation_manifest_segments
+             WHERE isolation_domain = ? AND owner_user_id = ?
+               AND session_id = ? AND branch_id = ? AND manifest_root = ?
+             ORDER BY segment_position ASC",
+        )
+        .bind(&key.isolation_domain)
+        .bind(&key.owner_user_id)
+        .bind(&key.session_id)
+        .bind(&key.branch_id)
+        .bind(&node.manifest_root)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|source| database_error("verify_manifest_segment_references", source))?;
+        if stored_references.len() != node.appended_segments.len() {
+            return Err(SessionContextCoordinatorError::NeedsRepair(
+                "immutable manifest segment reference count is inconsistent".into(),
+            ));
+        }
+        for (position, row) in stored_references.iter().enumerate() {
+            let stored_position = database_u64(row, "segment_position")?;
+            let stored_hash = row
+                .try_get::<String, _>("segment_hash")
+                .map_err(|source| database_error("decode_manifest_segment_reference", source))?;
+            if stored_position != u64::try_from(position).unwrap_or(u64::MAX)
+                || stored_hash != node.appended_segments[position].segment_hash
+            {
+                return Err(SessionContextCoordinatorError::NeedsRepair(
+                    "immutable manifest segment reference does not match the manifest".into(),
+                ));
+            }
+        }
+        tx.commit()
+            .await
+            .map_err(|source| database_error("commit_persist_manifest", source))
     }
 
     async fn persist_database_segments(
@@ -3274,7 +3404,11 @@ fn order_manifest_chain(
         let node = nodes.remove(&current).ok_or_else(|| {
             SessionContextCoordinatorError::NeedsRepair(format!("missing manifest {current}"))
         })?;
-        root = node.parent_manifest_root.clone();
+        root = if node.replaces_history {
+            None
+        } else {
+            node.parent_manifest_root.clone()
+        };
         reverse.push(node);
     }
     reverse.reverse();
@@ -3326,7 +3460,17 @@ fn order_manifest_suffix(
         if after_sequence.is_some_and(|sequence| node.conversation_seq <= sequence) {
             return Err(SessionContextCoordinatorError::DivergentManifest);
         }
-        root = node.parent_manifest_root.clone();
+        if node.replaces_history
+            && after_manifest_root.is_some()
+            && node.parent_manifest_root.as_deref() != after_manifest_root
+        {
+            return Err(SessionContextCoordinatorError::DivergentManifest);
+        }
+        root = if node.replaces_history && after_manifest_root.is_none() {
+            None
+        } else {
+            node.parent_manifest_root.clone()
+        };
         reverse.push(node);
     }
     reverse.reverse();
@@ -4131,9 +4275,45 @@ fn i64_from_u64(field: &'static str, value: u64) -> Result<i64, SessionContextCo
         .map_err(|_| SessionContextCoordinatorError::Invalid(format!("{field} exceeds BIGINT")))
 }
 
+fn manifest_node_for_delta(
+    key: &SessionKeyV1,
+    head: Option<&SessionContextHeadV1>,
+    delta: &CanonicalTurnDeltaV1,
+    segments: &[ConversationSegmentV1],
+) -> Result<ContextManifestNodeV1, SessionCoordinationValidationError> {
+    let parent = head.map(|head| head.latest_manifest_root.clone());
+    let references = segments
+        .iter()
+        .map(ConversationSegmentV1::reference)
+        .collect();
+    match delta.mode {
+        CanonicalDeltaModeV1::Append => ContextManifestNodeV1::new(
+            key.clone(),
+            parent,
+            delta.completed_turn,
+            delta.journal_event_seq,
+            delta.conversation_seq,
+            delta.compaction_generation,
+            delta.config_version_id.clone(),
+            references,
+        ),
+        CanonicalDeltaModeV1::Replace => ContextManifestNodeV1::new_replacement(
+            key.clone(),
+            parent,
+            delta.completed_turn,
+            delta.journal_event_seq,
+            delta.conversation_seq,
+            delta.compaction_generation,
+            delta.config_version_id.clone(),
+            references,
+        ),
+    }
+}
+
 fn next_head_totals(
     head: Option<&SessionContextHeadV1>,
     segments: &[ConversationSegmentV1],
+    mode: CanonicalDeltaModeV1,
 ) -> Result<(u64, u64), SessionContextCoordinatorError> {
     let appended_bytes = segments.iter().try_fold(0_u64, |total, segment| {
         total.checked_add(segment.canonical_bytes).ok_or_else(|| {
@@ -4147,8 +4327,16 @@ fn next_head_totals(
                 SessionContextCoordinatorError::NeedsRepair("head message count overflow".into())
             })
     })?;
-    let base_bytes = head.map_or(0, |head| head.total_canonical_bytes);
-    let base_messages = head.map_or(0, |head| head.total_message_count);
+    let base_bytes = if mode == CanonicalDeltaModeV1::Replace {
+        0
+    } else {
+        head.map_or(0, |head| head.total_canonical_bytes)
+    };
+    let base_messages = if mode == CanonicalDeltaModeV1::Replace {
+        0
+    } else {
+        head.map_or(0, |head| head.total_message_count)
+    };
     Ok((
         base_bytes.checked_add(appended_bytes).ok_or_else(|| {
             SessionContextCoordinatorError::NeedsRepair("head canonical byte overflow".into())
@@ -4237,10 +4425,28 @@ fn validate_segment_upload(
         .map(|segment| segment.segment_hash.clone())
         .collect::<Vec<_>>();
     validate_segment_batch(key, &hashes)?;
+    let mut total_bytes = 0_u64;
     for segment in segments {
         segment
             .validate_for(key)
             .map_err(|error| SessionContextCoordinatorError::Invalid(error.to_string()))?;
+        if segment.canonical_bytes > MAX_STAGED_SEGMENT_BYTES {
+            return Err(SessionContextCoordinatorError::Invalid(format!(
+                "conversation segment exceeds {MAX_STAGED_SEGMENT_BYTES} canonical bytes"
+            )));
+        }
+        total_bytes = total_bytes
+            .checked_add(segment.canonical_bytes)
+            .ok_or_else(|| {
+                SessionContextCoordinatorError::Invalid(
+                    "conversation segment batch byte count overflow".into(),
+                )
+            })?;
+    }
+    if total_bytes > MAX_STAGED_BATCH_BYTES {
+        return Err(SessionContextCoordinatorError::Invalid(format!(
+            "conversation segment batch exceeds {MAX_STAGED_BATCH_BYTES} canonical bytes"
+        )));
     }
     Ok(())
 }
@@ -4453,9 +4659,13 @@ fn validate_delta_advance(
                 head.cursor.compaction_generation,
             )
         });
+    let expected_compaction_generation = match delta.mode {
+        CanonicalDeltaModeV1::Append => base_compaction_generation,
+        CanonicalDeltaModeV1::Replace => base_compaction_generation.saturating_add(1),
+    };
     if delta.journal_event_seq <= base_journal_seq
         || delta.conversation_seq != base_conversation_seq.saturating_add(1)
-        || delta.compaction_generation != base_compaction_generation
+        || delta.compaction_generation != expected_compaction_generation
     {
         return Err(SessionContextCoordinatorError::Invalid(
             "turn delta must advance the reserved base monotonically".into(),
@@ -4473,13 +4683,29 @@ fn validate_manifest_advance(
         if cursor.completed_turn != prior.completed_turn.saturating_add(1)
             || cursor.conversation_seq != prior.conversation_seq.saturating_add(1)
             || cursor.journal_event_seq <= prior.journal_event_seq
-            || cursor.compaction_generation != prior.compaction_generation
+            || if node.replaces_history {
+                cursor.compaction_generation != prior.compaction_generation.saturating_add(1)
+            } else {
+                cursor.compaction_generation != prior.compaction_generation
+            }
         {
             return Err(SessionContextCoordinatorError::NeedsRepair(
                 "manifest cursor sequence is non-monotonic".into(),
             ));
         }
-    } else if cursor.completed_turn != 1 || cursor.conversation_seq != 1 {
+    } else if node.replaces_history {
+        if cursor.completed_turn == 0
+            || cursor.conversation_seq == 0
+            || cursor.compaction_generation == 0
+        {
+            return Err(SessionContextCoordinatorError::NeedsRepair(
+                "replacement manifest cursor is invalid".into(),
+            ));
+        }
+    } else if cursor.completed_turn != 1
+        || cursor.conversation_seq != 1
+        || cursor.compaction_generation != 0
+    {
         return Err(SessionContextCoordinatorError::NeedsRepair(
             "manifest genesis cursor is invalid".into(),
         ));
@@ -4508,6 +4734,9 @@ fn turn_delta_hash(delta: &CanonicalTurnDeltaV1) -> String {
     digest.update(delta.journal_event_seq.to_be_bytes());
     digest.update(delta.conversation_seq.to_be_bytes());
     digest.update(delta.compaction_generation.to_be_bytes());
+    if delta.mode == CanonicalDeltaModeV1::Replace {
+        digest.update(b"replace\0");
+    }
     hash_field(
         &mut digest,
         delta.config_version_id.as_deref().unwrap_or_default(),
@@ -4932,6 +5161,7 @@ mod tests {
             conversation_seq,
             compaction_generation: 0,
             config_version_id: None,
+            mode: astra_turn_types::CanonicalDeltaModeV1::Append,
             logical_segments: vec![vec![
                 json!({"role": "user", "content": format!("question-{turn}")}),
                 json!({"role": "assistant", "content": format!("answer-{turn}")}),
@@ -5342,6 +5572,109 @@ mod tests {
             .unwrap();
         assert_eq!(materialized.messages.len(), 2);
         assert_eq!(materialized.head.cursor, cursor);
+    }
+
+    #[tokio::test]
+    async fn replacement_commit_recalculates_head_and_cuts_materialization_history() {
+        let temp = TempDir::new().unwrap();
+        let clock = Arc::new(ManualClock::new(1_000));
+        let coordinator = coordinator(&temp, clock);
+        let key = key("owner-a");
+        let lease = acquired(
+            coordinator
+                .acquire_writer(
+                    &key,
+                    None,
+                    &actor("owner-a"),
+                    Duration::from_secs(30),
+                    "acquire",
+                )
+                .await
+                .unwrap(),
+        );
+
+        let first_reservation = reserved(
+            coordinator
+                .reserve_turn(&lease, None, Duration::from_secs(20), "reserve-1")
+                .await
+                .unwrap(),
+        );
+        coordinator
+            .commit_turn(&first_reservation, delta(1, 1, 1), "commit-1")
+            .await
+            .unwrap();
+        let first_head = coordinator.load_head(&key).await.unwrap().unwrap();
+
+        let second_reservation = reserved(
+            coordinator
+                .reserve_turn(
+                    &lease,
+                    Some(&first_head.cursor),
+                    Duration::from_secs(20),
+                    "reserve-2",
+                )
+                .await
+                .unwrap(),
+        );
+        coordinator
+            .commit_turn(&second_reservation, delta(2, 2, 2), "commit-2")
+            .await
+            .unwrap();
+        let pre_compaction_head = coordinator.load_head(&key).await.unwrap().unwrap();
+        assert_eq!(pre_compaction_head.total_message_count, 4);
+
+        let replacement_reservation = reserved(
+            coordinator
+                .reserve_turn(
+                    &lease,
+                    Some(&pre_compaction_head.cursor),
+                    Duration::from_secs(20),
+                    "reserve-replacement",
+                )
+                .await
+                .unwrap(),
+        );
+        let compacted_messages = vec![
+            json!({"role": "user", "content": "compacted question"}),
+            json!({"role": "assistant", "content": "compacted answer"}),
+        ];
+        let replacement = CanonicalTurnDeltaV1 {
+            schema_version: CANONICAL_TURN_DELTA_SCHEMA_VERSION,
+            completed_turn: 3,
+            journal_event_seq: 3,
+            conversation_seq: 3,
+            compaction_generation: 1,
+            config_version_id: None,
+            mode: CanonicalDeltaModeV1::Replace,
+            logical_segments: vec![compacted_messages.clone()],
+        };
+        coordinator
+            .commit_turn(&replacement_reservation, replacement, "commit-replacement")
+            .await
+            .unwrap();
+
+        let compacted_head = coordinator.load_head(&key).await.unwrap().unwrap();
+        assert_eq!(compacted_head.cursor.compaction_generation, 1);
+        assert_eq!(compacted_head.total_message_count, 2);
+        let materialized = coordinator.materialize(&compacted_head).await.unwrap();
+        assert_eq!(materialized.messages, compacted_messages);
+        assert_eq!(materialized.logical_segment_count, 1);
+
+        let delta_from_empty = coordinator.load_manifest_delta(&key, None).await.unwrap();
+        assert_eq!(delta_from_empty.missing_nodes.len(), 1);
+        assert!(delta_from_empty.missing_nodes[0].replaces_history);
+        assert!(matches!(
+            coordinator
+                .reserve_turn(
+                    &lease,
+                    Some(&pre_compaction_head.cursor),
+                    Duration::from_secs(20),
+                    "stale-after-replacement",
+                )
+                .await
+                .unwrap(),
+            ReserveTurnOutcome::Conflict { .. }
+        ));
     }
 
     #[tokio::test]

--- a/crates/services/src/session_fork_coordinator.rs
+++ b/crates/services/src/session_fork_coordinator.rs
@@ -459,6 +459,80 @@ impl DatabaseSessionForkCoordinator {
         Ok(result.rows_affected())
     }
 
+    /// Remove normalized segment references after their manifest node is gone.
+    ///
+    /// This runs after manifest collection and is deliberately bounded so one
+    /// tenant's old history cannot monopolize a maintenance sweep.
+    pub async fn collect_orphaned_manifest_segment_references(
+        &self,
+        limit: u32,
+    ) -> Result<u64, SessionForkCoordinatorError> {
+        if limit == 0 || limit > 10_000 {
+            return Err(SessionForkCoordinatorError::Invalid(
+                "cleanup limit must be between 1 and 10000".into(),
+            ));
+        }
+        let result = sqlx::query(
+            "DELETE FROM conversation_manifest_segments
+             WHERE NOT EXISTS (
+                       SELECT 1 FROM conversation_manifest_nodes
+                       WHERE conversation_manifest_nodes.isolation_domain =
+                                 conversation_manifest_segments.isolation_domain
+                         AND conversation_manifest_nodes.owner_user_id =
+                                 conversation_manifest_segments.owner_user_id
+                         AND conversation_manifest_nodes.session_id =
+                                 conversation_manifest_segments.session_id
+                         AND conversation_manifest_nodes.branch_id =
+                                 conversation_manifest_segments.branch_id
+                         AND conversation_manifest_nodes.manifest_root =
+                                 conversation_manifest_segments.manifest_root
+                   )
+             ORDER BY created_at ASC LIMIT ?",
+        )
+        .bind(i64::from(limit))
+        .execute(self.pool.get())
+        .await
+        .map_err(|source| database_error("collect_orphan_manifest_segment_refs", source))?;
+        Ok(result.rows_affected())
+    }
+
+    /// Collect owner-deduplicated segment payloads with no manifest reference.
+    ///
+    /// A staging grace protects uploads that have not reached `commit_turn`
+    /// yet. Committed manifests install their references transactionally, so
+    /// anything older than the grace and still unreferenced is abandoned.
+    pub async fn collect_unreferenced_conversation_segments(
+        &self,
+        limit: u32,
+    ) -> Result<u64, SessionForkCoordinatorError> {
+        const STAGING_GRACE_SECS: i64 = 24 * 60 * 60;
+        if limit == 0 || limit > 10_000 {
+            return Err(SessionForkCoordinatorError::Invalid(
+                "cleanup limit must be between 1 and 10000".into(),
+            ));
+        }
+        let result = sqlx::query(
+            "DELETE FROM conversation_segments
+             WHERE created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
+               AND NOT EXISTS (
+                       SELECT 1 FROM conversation_manifest_segments
+                       WHERE conversation_manifest_segments.isolation_domain =
+                                 conversation_segments.isolation_domain
+                         AND conversation_manifest_segments.owner_user_id =
+                                 conversation_segments.owner_user_id
+                         AND conversation_manifest_segments.segment_hash =
+                                 conversation_segments.segment_hash
+                   )
+             ORDER BY created_at ASC LIMIT ?",
+        )
+        .bind(STAGING_GRACE_SECS)
+        .bind(i64::from(limit))
+        .execute(self.pool.get())
+        .await
+        .map_err(|source| database_error("collect_unreferenced_segments", source))?;
+        Ok(result.rows_affected())
+    }
+
     /// Remove fork metadata bottom-up after its child session is deleted.
     ///
     /// An ancestor pin is deliberately retained while a live descendant fork
@@ -1044,6 +1118,7 @@ mod tests {
             conversation_seq: u64::from(turn),
             compaction_generation: 0,
             config_version_id: None,
+            mode: astra_turn_types::CanonicalDeltaModeV1::Append,
             logical_segments: vec![vec![
                 json!({"role":"user","content":format!("question-{turn}")}),
                 json!({"role":"assistant","content":format!("answer-{turn}")}),

--- a/crates/services/src/session_handoff.rs
+++ b/crates/services/src/session_handoff.rs
@@ -432,6 +432,7 @@ impl DatabaseSessionHandoffService {
             risk: request.risk.clone(),
             reason: request.reason.clone(),
             status_detail: workspace_mismatch.then(|| "workspace_evidence_mismatch".to_owned()),
+            blocked_from: workspace_mismatch.then_some(SessionHandoffStateV1::Validating),
             deadline_unix_ms: checked_expiry(now, deadline)?,
             created_at_unix_ms: now,
             updated_at_unix_ms: now,
@@ -1673,6 +1674,7 @@ mod tests {
                     conversation_seq: 1,
                     compaction_generation: 0,
                     config_version_id: None,
+                    mode: astra_turn_types::CanonicalDeltaModeV1::Append,
                     logical_segments: vec![vec![
                         json!({"role": "user", "content": "question"}),
                         json!({"role": "assistant", "content": "answer"}),

--- a/crates/services/src/session_lifecycle.rs
+++ b/crates/services/src/session_lifecycle.rs
@@ -61,6 +61,62 @@ const SESSION_DELETE_PLAN_STEP_RUNS_SQL: &str = "DELETE FROM plan_step_runs
                WHERE session_id = ? AND user_id = ?
            )";
 
+const SESSION_DELETE_CHILD_FORKS_SELECT_SQL: &str =
+    "SELECT isolation_domain, fork_id, parent_session_id
+       FROM session_forks
+      WHERE child_session_id = ? AND owner_user_id = ?";
+
+const SESSION_DELETE_CHILD_FORK_EVENTS_SQL: &str = "DELETE FROM session_fork_events
+         WHERE isolation_domain = ? AND owner_user_id = ? AND fork_id = ?";
+
+const SESSION_DELETE_CHILD_MANIFEST_PINS_SQL: &str = "DELETE FROM conversation_manifest_pins
+         WHERE isolation_domain = ? AND owner_user_id = ? AND pin_id = ?";
+
+const SESSION_DELETE_CHILD_FORKS_SQL: &str = "DELETE FROM session_forks
+         WHERE isolation_domain = ? AND owner_user_id = ? AND fork_id = ?";
+
+const SESSION_DELETE_ORPHAN_MANIFESTS_SQL: &str = "DELETE FROM conversation_manifest_nodes
+         WHERE isolation_domain = ? AND owner_user_id = ? AND session_id = ?
+           AND NOT EXISTS (
+               SELECT 1 FROM agent_sessions
+               WHERE agent_sessions.session_id = conversation_manifest_nodes.session_id
+                 AND agent_sessions.user_id = conversation_manifest_nodes.owner_user_id
+           )
+           AND NOT EXISTS (
+               SELECT 1 FROM conversation_manifest_pins
+               WHERE conversation_manifest_pins.isolation_domain =
+                         conversation_manifest_nodes.isolation_domain
+                 AND conversation_manifest_pins.owner_user_id =
+                         conversation_manifest_nodes.owner_user_id
+                 AND conversation_manifest_pins.parent_session_id =
+                         conversation_manifest_nodes.session_id
+                 AND (
+                     conversation_manifest_pins.pin_state IN ('prepared', 'active')
+                     OR (
+                         conversation_manifest_pins.pin_state = 'grace'
+                         AND conversation_manifest_pins.grace_expires_at_ms >
+                             CAST(UNIX_TIMESTAMP(NOW(6)) * 1000 AS SIGNED)
+                     )
+                 )
+           )";
+
+const SESSION_DELETE_ORPHAN_MANIFEST_REFERENCES_SQL: &str =
+    "DELETE FROM conversation_manifest_segments
+      WHERE owner_user_id = ? AND session_id = ?
+        AND NOT EXISTS (
+                SELECT 1 FROM conversation_manifest_nodes
+                 WHERE conversation_manifest_nodes.isolation_domain =
+                           conversation_manifest_segments.isolation_domain
+                   AND conversation_manifest_nodes.owner_user_id =
+                           conversation_manifest_segments.owner_user_id
+                   AND conversation_manifest_nodes.session_id =
+                           conversation_manifest_segments.session_id
+                   AND conversation_manifest_nodes.branch_id =
+                           conversation_manifest_segments.branch_id
+                   AND conversation_manifest_nodes.manifest_root =
+                           conversation_manifest_segments.manifest_root
+            )";
+
 const SESSION_DELETE_WORKSPACE_CLEANUP_DEBT_MESSAGE: &str =
     "session hard delete requested cloud workspace cleanup";
 
@@ -412,6 +468,13 @@ const SESSION_DELETE_DIRECT_BATCH_TABLES: &[SessionBatchDeleteStatement] = &[
              ORDER BY created_at ASC, request_id ASC
              LIMIT ?",
     },
+    SessionBatchDeleteStatement {
+        label: "model_request_context_events",
+        sql: "DELETE FROM model_request_context_events
+             WHERE session_id = ? AND user_id = ?
+             ORDER BY created_at ASC, event_id ASC
+             LIMIT ?",
+    },
 ];
 
 const SESSION_DELETE_TERMINAL_BATCH_TABLES: &[SessionBatchDeleteStatement] = &[
@@ -711,6 +774,106 @@ async fn clear_session_provenance_references(
         .map_err(|source| format!("delete_session.config_versions.first_seen_session: {source}"))
 }
 
+async fn delete_child_fork_state(
+    tx: &mut sqlx::Transaction<'_, MySql>,
+    session_id: &str,
+    user_id: &str,
+    outcome: &mut SessionDatabaseDeleteOutcome,
+) -> Result<Vec<(String, String)>, String> {
+    let forks = query(SESSION_DELETE_CHILD_FORKS_SELECT_SQL)
+        .bind(session_id)
+        .bind(user_id)
+        .fetch_all(&mut **tx)
+        .await
+        .map_err(|source| format!("delete_session.load_child_forks: {source}"))?;
+    let mut parent_scopes = Vec::with_capacity(forks.len());
+    for fork in forks {
+        let isolation_domain: String = fork
+            .try_get("isolation_domain")
+            .map_err(|source| format!("delete_session.decode_child_fork.isolation: {source}"))?;
+        let fork_id: String = fork
+            .try_get("fork_id")
+            .map_err(|source| format!("delete_session.decode_child_fork.id: {source}"))?;
+        let parent_session_id: String = fork
+            .try_get("parent_session_id")
+            .map_err(|source| format!("delete_session.decode_child_fork.parent: {source}"))?;
+
+        let rows = query(SESSION_DELETE_CHILD_FORK_EVENTS_SQL)
+            .bind(&isolation_domain)
+            .bind(user_id)
+            .bind(&fork_id)
+            .execute(&mut **tx)
+            .await
+            .map_err(|source| format!("delete_session.session_fork_events: {source}"))?
+            .rows_affected();
+        record_table_delete(outcome, "session_fork_events", rows)?;
+
+        let rows = query(SESSION_DELETE_CHILD_MANIFEST_PINS_SQL)
+            .bind(&isolation_domain)
+            .bind(user_id)
+            .bind(&fork_id)
+            .execute(&mut **tx)
+            .await
+            .map_err(|source| format!("delete_session.conversation_manifest_pins: {source}"))?
+            .rows_affected();
+        record_table_delete(outcome, "conversation_manifest_pins", rows)?;
+
+        let rows = query(SESSION_DELETE_CHILD_FORKS_SQL)
+            .bind(&isolation_domain)
+            .bind(user_id)
+            .bind(&fork_id)
+            .execute(&mut **tx)
+            .await
+            .map_err(|source| format!("delete_session.session_forks: {source}"))?
+            .rows_affected();
+        record_table_delete(outcome, "session_forks", rows)?;
+        parent_scopes.push((isolation_domain, parent_session_id));
+    }
+    parent_scopes.sort_unstable();
+    parent_scopes.dedup();
+    Ok(parent_scopes)
+}
+
+async fn delete_unpinned_orphan_manifests(
+    tx: &mut sqlx::Transaction<'_, MySql>,
+    user_id: &str,
+    parent_scopes: &[(String, String)],
+    outcome: &mut SessionDatabaseDeleteOutcome,
+) -> Result<(), String> {
+    for (isolation_domain, parent_session_id) in parent_scopes {
+        let rows = query(SESSION_DELETE_ORPHAN_MANIFESTS_SQL)
+            .bind(isolation_domain)
+            .bind(user_id)
+            .bind(parent_session_id)
+            .execute(&mut **tx)
+            .await
+            .map_err(|source| {
+                format!("delete_session.orphan_conversation_manifest_nodes: {source}")
+            })?
+            .rows_affected();
+        record_table_delete(outcome, "orphan_conversation_manifest_nodes", rows)?;
+    }
+    Ok(())
+}
+
+async fn delete_orphan_manifest_references_for_session(
+    tx: &mut sqlx::Transaction<'_, MySql>,
+    session_id: &str,
+    user_id: &str,
+    outcome: &mut SessionDatabaseDeleteOutcome,
+) -> Result<(), String> {
+    let rows = query(SESSION_DELETE_ORPHAN_MANIFEST_REFERENCES_SQL)
+        .bind(user_id)
+        .bind(session_id)
+        .execute(&mut **tx)
+        .await
+        .map_err(|source| {
+            format!("delete_session.orphan_conversation_manifest_segments: {source}")
+        })?
+        .rows_affected();
+    record_table_delete(outcome, "orphan_conversation_manifest_segments", rows)
+}
+
 pub(crate) async fn hard_delete_session_rows(
     tx: &mut sqlx::Transaction<'_, MySql>,
     session_id: &str,
@@ -801,6 +964,11 @@ pub(crate) async fn hard_delete_session_rows(
     outcome.session_references_cleared =
         clear_session_provenance_references(tx, session_id, user_id).await?;
 
+    // A child fork owns the pin that keeps its parent's exact prefix alive.
+    // Remove that dependency before deleting the child; parent deletion keeps
+    // the same records intact while any child still exists.
+    let fork_parent_scopes = delete_child_fork_state(tx, session_id, user_id, &mut outcome).await?;
+
     for statement in SESSION_DELETE_DIRECT_BATCH_TABLES {
         let rows_deleted = delete_session_rows_session_user_batched(
             tx,
@@ -847,6 +1015,15 @@ pub(crate) async fn hard_delete_session_rows(
         )
         .await?;
         record_table_delete(&mut outcome, statement.label, rows_deleted)?;
+    }
+
+    // If the parent session was deleted earlier, removing its last child pin
+    // makes the retained manifests collectible in this same transaction.
+    delete_unpinned_orphan_manifests(tx, user_id, &fork_parent_scopes, &mut outcome).await?;
+    delete_orphan_manifest_references_for_session(tx, session_id, user_id, &mut outcome).await?;
+    for (_, parent_session_id) in &fork_parent_scopes {
+        delete_orphan_manifest_references_for_session(tx, parent_session_id, user_id, &mut outcome)
+            .await?;
     }
 
     // A provider terminal that already owned the invocation lock can publish a
@@ -1197,6 +1374,7 @@ mod tests {
                 "inference_invocations",
                 "inference_provider_attempts",
                 "inference_routes",
+                "model_request_context_events",
                 "prompt_deltas",
                 "prompt_request_records",
                 "session_tool_output_batches",

--- a/crates/services/src/session_publish.rs
+++ b/crates/services/src/session_publish.rs
@@ -8,10 +8,10 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use astra_core::SharedPool;
 use astra_turn_types::{
-    ActorContextV1, CANONICAL_TURN_DELTA_SCHEMA_VERSION, CanonicalTurnDeltaV1,
-    ContextManifestNodeV1, ConversationCommitV1, ConversationDeltaV1, ConversationSegmentV1,
-    ConversationWriterLeaseV1, CoordinatorMutationV1, SessionContextHeadV1, SessionCursorV1,
-    SessionKeyV1, canonical_conversation_root, validate_canonical_tool_pairing,
+    ActorContextV1, CANONICAL_TURN_DELTA_SCHEMA_VERSION, CanonicalDeltaModeV1,
+    CanonicalTurnDeltaV1, ContextManifestNodeV1, ConversationCommitV1, ConversationDeltaV1,
+    ConversationSegmentV1, ConversationWriterLeaseV1, CoordinatorMutationV1, SessionContextHeadV1,
+    SessionCursorV1, SessionKeyV1, canonical_conversation_root, validate_canonical_tool_pairing,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sha2::{Digest, Sha256};
@@ -142,6 +142,7 @@ impl DatabaseSessionPublishService {
             None => Vec::new(),
         };
         let mut local_root = canonical_conversation_root(&local_messages);
+        let mut local_cursor = anchor.as_ref().map(|anchor| anchor.local_cursor.clone());
         if let Some(anchor) = &anchor {
             if anchor.local_cursor.canonical_root_hash != local_root {
                 return Err(SessionPublishError::NeedsRepair(
@@ -183,24 +184,24 @@ impl DatabaseSessionPublishService {
                 .iter()
                 .flat_map(|segment| segment.messages.iter().cloned())
                 .collect::<Vec<_>>();
-            match &item.commit.delta {
-                ConversationDeltaV1::Append { messages } if messages == &appended => {}
-                ConversationDeltaV1::Append { .. } => {
+            let mode = match &item.commit.delta {
+                ConversationDeltaV1::Append { messages } if messages == &appended => {
+                    CanonicalDeltaModeV1::Append
+                }
+                ConversationDeltaV1::Replace { messages, .. } if messages == &appended => {
+                    CanonicalDeltaModeV1::Replace
+                }
+                ConversationDeltaV1::Append { .. } | ConversationDeltaV1::Replace { .. } => {
                     return Err(SessionPublishError::Invalid(
                         "staged segments do not equal the ordered journal delta".into(),
                     ));
                 }
-                // A replacement requires the replacement-manifest work in
-                // Phase 6. Treating it as append would silently corrupt head
-                // consistency, so it is an explicit child-lineage case.
-                ConversationDeltaV1::Replace { .. } => {
-                    return Err(fork_required(
-                        item.commit.cursor.canonical_root_hash.clone(),
-                        simulated_head.as_ref(),
-                    ));
-                }
+            };
+            validate_local_commit_advance(local_cursor.as_ref(), &item.commit.cursor, mode)?;
+            match mode {
+                CanonicalDeltaModeV1::Append => local_messages.extend(appended),
+                CanonicalDeltaModeV1::Replace => local_messages = appended,
             }
-            local_messages.extend(appended);
             validate_canonical_tool_pairing(&local_messages)
                 .map_err(|error| SessionPublishError::Invalid(error.to_string()))?;
             local_root = canonical_conversation_root(&local_messages);
@@ -218,28 +219,50 @@ impl DatabaseSessionPublishService {
                     .map_or(1, |cursor| cursor.journal_event_seq.saturating_add(1)),
                 conversation_seq: base
                     .map_or(1, |cursor| cursor.conversation_seq.saturating_add(1)),
-                compaction_generation: base.map_or(0, |cursor| cursor.compaction_generation),
+                compaction_generation: match mode {
+                    CanonicalDeltaModeV1::Append => {
+                        base.map_or(0, |cursor| cursor.compaction_generation)
+                    }
+                    CanonicalDeltaModeV1::Replace => {
+                        base.map_or(1, |cursor| cursor.compaction_generation.saturating_add(1))
+                    }
+                },
                 config_version_id: item.commit.cursor.config_version_id.clone(),
+                mode,
                 logical_segments: segments
                     .iter()
                     .map(|segment| segment.messages.clone())
                     .collect(),
             };
-            let node = ContextManifestNodeV1::new(
-                request.key.clone(),
-                simulated_head
-                    .as_ref()
-                    .map(|head| head.latest_manifest_root.clone()),
-                delta.completed_turn,
-                delta.journal_event_seq,
-                delta.conversation_seq,
-                delta.compaction_generation,
-                delta.config_version_id.clone(),
-                segments
-                    .iter()
-                    .map(ConversationSegmentV1::reference)
-                    .collect(),
-            )
+            let parent = simulated_head
+                .as_ref()
+                .map(|head| head.latest_manifest_root.clone());
+            let references = segments
+                .iter()
+                .map(ConversationSegmentV1::reference)
+                .collect();
+            let node = match mode {
+                CanonicalDeltaModeV1::Append => ContextManifestNodeV1::new(
+                    request.key.clone(),
+                    parent,
+                    delta.completed_turn,
+                    delta.journal_event_seq,
+                    delta.conversation_seq,
+                    delta.compaction_generation,
+                    delta.config_version_id.clone(),
+                    references,
+                ),
+                CanonicalDeltaModeV1::Replace => ContextManifestNodeV1::new_replacement(
+                    request.key.clone(),
+                    parent,
+                    delta.completed_turn,
+                    delta.journal_event_seq,
+                    delta.conversation_seq,
+                    delta.compaction_generation,
+                    delta.config_version_id.clone(),
+                    references,
+                ),
+            }
             .map_err(|error| SessionPublishError::Invalid(error.to_string()))?;
             let server_cursor = node.cursor();
             plans.push(PublishPlan {
@@ -255,7 +278,9 @@ impl DatabaseSessionPublishService {
                 simulated_head.as_ref(),
                 &segments,
                 server_cursor,
+                mode,
             )?);
+            local_cursor = Some(item.commit.cursor.clone());
         }
 
         let expected_cursor = actual_head.as_ref().map(|head| &head.cursor);
@@ -660,6 +685,46 @@ fn suffix_start(
         })
 }
 
+fn validate_local_commit_advance(
+    prior: Option<&SessionCursorV1>,
+    cursor: &SessionCursorV1,
+    mode: CanonicalDeltaModeV1,
+) -> Result<(), SessionPublishError> {
+    let (
+        prior_completed_turn,
+        prior_journal_event_seq,
+        prior_conversation_seq,
+        prior_compaction_generation,
+    ) = prior.map_or((0, 0, 0, 0), |cursor| {
+        (
+            cursor.completed_turn,
+            cursor.journal_event_seq,
+            cursor.conversation_seq,
+            cursor.compaction_generation,
+        )
+    });
+    let expected_compaction_generation = match mode {
+        CanonicalDeltaModeV1::Append => prior_compaction_generation,
+        CanonicalDeltaModeV1::Replace => {
+            prior_compaction_generation.checked_add(1).ok_or_else(|| {
+                SessionPublishError::Invalid(
+                    "local compaction generation cannot advance beyond u64".into(),
+                )
+            })?
+        }
+    };
+    if cursor.completed_turn != prior_completed_turn.saturating_add(1)
+        || cursor.journal_event_seq != prior_journal_event_seq.saturating_add(1)
+        || cursor.conversation_seq != prior_conversation_seq.saturating_add(1)
+        || cursor.compaction_generation != expected_compaction_generation
+    {
+        return Err(SessionPublishError::Invalid(
+            "journal commit cursor does not advance its acknowledged local predecessor".into(),
+        ));
+    }
+    Ok(())
+}
+
 fn validate_request(
     request: &PublishSessionRequestV1,
     writer_ttl: Duration,
@@ -719,15 +784,24 @@ fn simulated_next_head(
     base: Option<&SessionContextHeadV1>,
     segments: &[ConversationSegmentV1],
     cursor: SessionCursorV1,
+    mode: CanonicalDeltaModeV1,
 ) -> Result<SessionContextHeadV1, SessionPublishError> {
-    let bytes = segments.iter().try_fold(
-        base.map_or(0, |head| head.total_canonical_bytes),
-        |total, segment| total.checked_add(segment.canonical_bytes),
-    );
-    let messages = segments.iter().try_fold(
-        base.map_or(0, |head| head.total_message_count),
-        |total, segment| total.checked_add(u64::from(segment.message_count)),
-    );
+    let base_bytes = if mode == CanonicalDeltaModeV1::Replace {
+        0
+    } else {
+        base.map_or(0, |head| head.total_canonical_bytes)
+    };
+    let base_messages = if mode == CanonicalDeltaModeV1::Replace {
+        0
+    } else {
+        base.map_or(0, |head| head.total_message_count)
+    };
+    let bytes = segments.iter().try_fold(base_bytes, |total, segment| {
+        total.checked_add(segment.canonical_bytes)
+    });
+    let messages = segments.iter().try_fold(base_messages, |total, segment| {
+        total.checked_add(u64::from(segment.message_count))
+    });
     Ok(SessionContextHeadV1 {
         schema_version: astra_turn_types::SESSION_COORDINATION_SCHEMA_VERSION,
         key: key.clone(),
@@ -863,6 +937,36 @@ mod tests {
             server_cursor: anchor.server_cursor,
         };
         assert_eq!(suffix_start(&[first, second], Some(&equal)).unwrap(), 2);
+    }
+
+    #[test]
+    fn local_publish_cursor_coordinates_follow_append_and_replace_protocol() {
+        let prior = item(
+            &canonical_conversation_root(&[]),
+            vec![json!({"role":"user","content":"first"})],
+            1,
+        )
+        .commit
+        .cursor;
+        let mut next = prior.clone();
+        next.completed_turn = 2;
+        next.journal_event_seq = 2;
+        next.conversation_seq = 2;
+        assert!(
+            validate_local_commit_advance(Some(&prior), &next, CanonicalDeltaModeV1::Append)
+                .is_ok()
+        );
+
+        next.compaction_generation = 1;
+        assert!(
+            validate_local_commit_advance(Some(&prior), &next, CanonicalDeltaModeV1::Replace)
+                .is_ok()
+        );
+        next.compaction_generation = 0;
+        assert!(matches!(
+            validate_local_commit_advance(Some(&prior), &next, CanonicalDeltaModeV1::Replace),
+            Err(SessionPublishError::Invalid(_))
+        ));
     }
 
     fn controller_lease(actor: ActorContextV1, lease_id: &str) -> ConversationWriterLeaseV1 {

--- a/crates/services/src/session_publish.rs
+++ b/crates/services/src/session_publish.rs
@@ -41,6 +41,10 @@ pub struct PublishSessionRequestV1 {
     pub idempotency_key: String,
     pub key: SessionKeyV1,
     pub actor: ActorContextV1,
+    /// A controller lease obtained from attach, fork, handoff, or a prior
+    /// publish. When present it must still be the exact active lease.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub writer_lease: Option<ConversationWriterLeaseV1>,
     pub items: Vec<PublishJournalItemV1>,
 }
 
@@ -255,29 +259,33 @@ impl DatabaseSessionPublishService {
         }
 
         let expected_cursor = actual_head.as_ref().map(|head| &head.cursor);
-        let acquire_idempotency_key = format!("publish:{}", request.idempotency_key);
         let active = self.coordinator.load_active_writer(&request.key).await?;
-        let lease = match active.filter(|lease| {
-            lease.actor == request.actor && lease.idempotency_key == acquire_idempotency_key
-        }) {
+        let lease = match reusable_publish_lease(
+            request.writer_lease.as_ref(),
+            active.as_ref(),
+            &request.actor,
+        )? {
             Some(lease) => lease,
-            None => match self
-                .coordinator
-                .acquire_writer(
-                    &request.key,
-                    expected_cursor,
-                    &request.actor,
-                    writer_ttl,
-                    &acquire_idempotency_key,
-                )
-                .await?
-            {
-                AcquireWriterOutcome::Acquired(lease)
-                | AcquireWriterOutcome::AlreadyAcquired(lease) => lease,
-                AcquireWriterOutcome::Conflict { .. } => {
-                    return Err(SessionPublishError::Conflict);
+            None => {
+                let acquire_idempotency_key = format!("publish:{}", request.idempotency_key);
+                match self
+                    .coordinator
+                    .acquire_writer(
+                        &request.key,
+                        expected_cursor,
+                        &request.actor,
+                        writer_ttl,
+                        &acquire_idempotency_key,
+                    )
+                    .await?
+                {
+                    AcquireWriterOutcome::Acquired(lease)
+                    | AcquireWriterOutcome::AlreadyAcquired(lease) => lease,
+                    AcquireWriterOutcome::Conflict { .. } => {
+                        return Err(SessionPublishError::Conflict);
+                    }
                 }
-            },
+            }
         };
 
         let mut current_cursor = expected_cursor.cloned();
@@ -527,6 +535,21 @@ impl DatabaseSessionPublishService {
     }
 }
 
+fn reusable_publish_lease(
+    presented: Option<&ConversationWriterLeaseV1>,
+    active: Option<&ConversationWriterLeaseV1>,
+    actor: &ActorContextV1,
+) -> Result<Option<ConversationWriterLeaseV1>, SessionPublishError> {
+    match (presented, active) {
+        (Some(presented), Some(active)) if presented == active && &active.actor == actor => {
+            Ok(Some(active.clone()))
+        }
+        (Some(_), _) => Err(SessionPublishError::Conflict),
+        (None, Some(active)) if &active.actor == actor => Ok(Some(active.clone())),
+        (None, _) => Ok(None),
+    }
+}
+
 #[derive(Clone)]
 struct VerifiedItem {
     request: PublishJournalItemV1,
@@ -649,6 +672,17 @@ fn validate_request(
         .actor
         .validate_for(&request.key)
         .map_err(|error| SessionPublishError::Invalid(error.to_string()))?;
+    if request.writer_lease.as_ref().is_some_and(|lease| {
+        lease.schema_version != astra_turn_types::SESSION_COORDINATION_SCHEMA_VERSION
+            || lease.key != request.key
+            || lease.actor != request.actor
+            || lease.lease_id.is_empty()
+            || lease.lease_id.len() > 512
+    }) {
+        return Err(SessionPublishError::Invalid(
+            "presented writer lease does not match the publish actor and branch".into(),
+        ));
+    }
     if request.idempotency_key.is_empty()
         || request.idempotency_key.len() > 384
         || request.idempotency_key.chars().any(char::is_control)
@@ -831,6 +865,58 @@ mod tests {
         assert_eq!(suffix_start(&[first, second], Some(&equal)).unwrap(), 2);
     }
 
+    fn controller_lease(actor: ActorContextV1, lease_id: &str) -> ConversationWriterLeaseV1 {
+        ConversationWriterLeaseV1 {
+            schema_version: astra_turn_types::SESSION_COORDINATION_SCHEMA_VERSION,
+            key: SessionKeyV1::owner_session("server", "owner-a", "session-a", "main"),
+            lease_id: lease_id.into(),
+            writer_epoch: 3,
+            actor,
+            expected_cursor: None,
+            acquired_at_unix_ms: 1_000,
+            expires_at_unix_ms: 60_000,
+            idempotency_key: "original-operation".into(),
+        }
+    }
+
+    #[test]
+    fn controller_lease_is_reused_across_distinct_publish_operations() {
+        let actor = ActorContextV1::owner_user(
+            "owner-a",
+            "device-a",
+            ActorKindV1::Cli,
+            SessionSurfaceV1::Cli,
+            Some("device-a".into()),
+            AuthorityEpochsV1::default(),
+        );
+        let active = controller_lease(actor.clone(), "lease-current");
+
+        assert_eq!(
+            reusable_publish_lease(None, Some(&active), &actor).unwrap(),
+            Some(active)
+        );
+    }
+
+    #[test]
+    fn stale_presented_lease_fails_closed_after_handoff() {
+        let actor = ActorContextV1::owner_user(
+            "owner-a",
+            "device-a",
+            ActorKindV1::Cli,
+            SessionSurfaceV1::Cli,
+            Some("device-a".into()),
+            AuthorityEpochsV1::default(),
+        );
+        let stale = controller_lease(actor.clone(), "lease-before-handoff");
+        let mut active = controller_lease(actor.clone(), "lease-after-handoff");
+        active.writer_epoch += 1;
+
+        assert!(matches!(
+            reusable_publish_lease(Some(&stale), Some(&active), &actor),
+            Err(SessionPublishError::Conflict)
+        ));
+    }
+
     async fn setup_publish_db_it() -> (SharedPool, astra_core::MatrixOneSettings) {
         assert_eq!(
             std::env::var("ASTRA_TEST_DB_IT").as_deref(),
@@ -949,6 +1035,7 @@ mod tests {
                 Some("device-a".into()),
                 AuthorityEpochsV1::default(),
             ),
+            writer_lease: None,
             items: vec![PublishJournalItemV1 {
                 event_id: event_id.clone(),
                 payload_hash: payload_hash.clone(),

--- a/crates/services/src/session_reaper.rs
+++ b/crates/services/src/session_reaper.rs
@@ -46,6 +46,18 @@ pub struct ReaperSweepResult {
     pub marked_ended: u64,
     /// Ended session rows deleted.
     pub deleted: u64,
+    /// Expired fork-retention pins released.
+    pub expired_fork_pins_released: u64,
+    /// Fork records whose child session no longer exists.
+    pub orphaned_forks_collected: u64,
+    /// Unpinned manifest nodes whose session no longer exists.
+    pub orphaned_manifests_collected: u64,
+    /// Segment references whose manifest node no longer exists.
+    pub orphaned_manifest_references_collected: u64,
+    /// Owner-deduplicated segment payloads outside the staging grace.
+    pub unreferenced_segments_collected: u64,
+    /// Detailed model-request context facts removed by age.
+    pub model_request_context_events_expired: u64,
     /// Total database rows deleted across session lifecycle tables.
     pub database_rows_deleted: u64,
     /// Session-scoped provenance references cleared without deleting durable owner-level rows.
@@ -189,6 +201,20 @@ pub async fn reap_sessions(
         }
     }
 
+    const MODEL_REQUEST_CONTEXT_RETENTION_DAYS: u32 = 30;
+    result.model_request_context_events_expired = sqlx::query(
+        "DELETE FROM model_request_context_events
+         WHERE created_at < DATE_SUB(NOW(6), INTERVAL ? DAY)
+         ORDER BY created_at ASC, event_id ASC
+         LIMIT ?",
+    )
+    .bind(MODEL_REQUEST_CONTEXT_RETENTION_DAYS)
+    .bind(policy.batch_limit)
+    .execute(pool)
+    .await
+    .map_err(|source| format!("session_reaper.expire_model_request_context: {source}"))?
+    .rows_affected();
+
     Ok(result)
 }
 
@@ -252,6 +278,7 @@ fn record_reaper_database_delete(
 /// shutdown by triggering `cancel` and awaiting the handle.
 pub fn spawn_session_reaper(
     pool: astra_core::SharedPool,
+    fork_coordinator: Option<std::sync::Arc<crate::DatabaseSessionForkCoordinator>>,
     cancel: tokio_util::sync::CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
     let reaper_interval = Duration::from_secs(5 * 60); // 5 minutes
@@ -271,7 +298,7 @@ pub fn spawn_session_reaper(
                 }
                 _ = interval.tick() => {}
             }
-            let r = match reap_sessions(pool.get(), &policy).await {
+            let mut r = match reap_sessions(pool.get(), &policy).await {
                 Ok(result) => result,
                 Err(error) => {
                     tracing::warn!(
@@ -282,13 +309,67 @@ pub fn spawn_session_reaper(
                     continue;
                 }
             };
-            let total = r.marked_idle + r.marked_ended + r.deleted;
+            if let Some(coordinator) = fork_coordinator.as_ref() {
+                r.expired_fork_pins_released = record_context_storage_maintenance(
+                    &mut r.cleanup_errors,
+                    "release_expired_fork_pins",
+                    coordinator
+                        .release_expired_grace_pins(policy.batch_limit)
+                        .await,
+                );
+                r.orphaned_forks_collected = record_context_storage_maintenance(
+                    &mut r.cleanup_errors,
+                    "collect_orphaned_fork_records",
+                    coordinator
+                        .collect_orphaned_fork_records(policy.batch_limit)
+                        .await,
+                );
+                r.orphaned_manifests_collected = record_context_storage_maintenance(
+                    &mut r.cleanup_errors,
+                    "collect_unpinned_orphan_manifests",
+                    coordinator
+                        .collect_unpinned_orphan_manifests(policy.batch_limit)
+                        .await,
+                );
+                r.orphaned_manifest_references_collected = record_context_storage_maintenance(
+                    &mut r.cleanup_errors,
+                    "collect_orphaned_manifest_segment_references",
+                    coordinator
+                        .collect_orphaned_manifest_segment_references(policy.batch_limit)
+                        .await,
+                );
+                r.unreferenced_segments_collected = record_context_storage_maintenance(
+                    &mut r.cleanup_errors,
+                    "collect_unreferenced_conversation_segments",
+                    coordinator
+                        .collect_unreferenced_conversation_segments(policy.batch_limit)
+                        .await,
+                );
+            }
+            let total = r
+                .marked_idle
+                .saturating_add(r.marked_ended)
+                .saturating_add(r.deleted)
+                .saturating_add(r.expired_fork_pins_released)
+                .saturating_add(r.orphaned_forks_collected)
+                .saturating_add(r.orphaned_manifests_collected)
+                .saturating_add(r.orphaned_manifest_references_collected)
+                .saturating_add(r.unreferenced_segments_collected)
+                .saturating_add(r.model_request_context_events_expired);
             if total > 0 {
                 tracing::info!(
                     target: "astra_services::session_reaper",
                     marked_idle = r.marked_idle,
                     marked_ended = r.marked_ended,
                     deleted = r.deleted,
+                    expired_fork_pins_released = r.expired_fork_pins_released,
+                    orphaned_forks_collected = r.orphaned_forks_collected,
+                    orphaned_manifests_collected = r.orphaned_manifests_collected,
+                    orphaned_manifest_references_collected =
+                        r.orphaned_manifest_references_collected,
+                    unreferenced_segments_collected = r.unreferenced_segments_collected,
+                    model_request_context_events_expired =
+                        r.model_request_context_events_expired,
                     database_rows_deleted = r.database_rows_deleted,
                     session_references_cleared = r.session_references_cleared,
                     workspace_cleanup_debts_enqueued = r.workspace_cleanup_debts_enqueued,
@@ -305,6 +386,26 @@ pub fn spawn_session_reaper(
             }
         }
     })
+}
+
+fn record_context_storage_maintenance(
+    errors: &mut Vec<String>,
+    operation: &'static str,
+    outcome: Result<u64, crate::SessionForkCoordinatorError>,
+) -> u64 {
+    match outcome {
+        Ok(rows) => rows,
+        Err(error) => {
+            tracing::warn!(
+                target: "astra_services::session_reaper",
+                %operation,
+                error = %error,
+                "context storage maintenance step failed"
+            );
+            errors.push(format!("{operation}: {error}"));
+            0
+        }
+    }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────

--- a/crates/services/src/session_restore.rs
+++ b/crates/services/src/session_restore.rs
@@ -1460,6 +1460,7 @@ fn build_resume_bundle(
         source,
         cursor,
         conversation_messages: messages,
+        materialized_conversation_root_hash: None,
         degraded_reasons,
         repair_actions: vec![
             astra_turn_types::ResumeRepairActionV1::InspectCanonicalJournal,
@@ -1539,8 +1540,38 @@ fn apply_selected_resume_bundle(session: &mut RestoredSession) {
     };
     let cursor = bundle.cursor.clone();
     let checkpoint = bundle.projections.checkpoint_at(&cursor).cloned();
-    let task = bundle.projections.task_at(&cursor).cloned();
-    let provider = bundle.projections.provider_at(&cursor).cloned();
+    let permits_degraded_projection_fallback = bundle.source.is_degraded()
+        && bundle
+            .degraded_reasons
+            .contains(&astra_turn_types::ResumeDegradedReasonV1::ProjectionCursorMissing);
+    let task = bundle.projections.task_at(&cursor).cloned().or_else(|| {
+        permits_degraded_projection_fallback
+            .then(|| bundle.projections.task.as_ref())
+            .flatten()
+            .filter(|projection| {
+                projection.schema_version
+                    == astra_turn_types::CAUSAL_PROJECTION_ENVELOPE_SCHEMA_VERSION
+                    && projection.source_cursor.is_none()
+                    && projection.verified_through_root.is_none()
+            })
+            .map(|projection| projection.payload.clone())
+    });
+    let provider = bundle
+        .projections
+        .provider_at(&cursor)
+        .cloned()
+        .or_else(|| {
+            permits_degraded_projection_fallback
+                .then(|| bundle.projections.provider.as_ref())
+                .flatten()
+                .filter(|projection| {
+                    projection.schema_version
+                        == astra_turn_types::CAUSAL_PROJECTION_ENVELOPE_SCHEMA_VERSION
+                        && projection.source_cursor.is_none()
+                        && projection.verified_through_root.is_none()
+                })
+                .map(|projection| projection.payload.clone())
+        });
     let activated_deferred_tool_names = bundle.activated_deferred_tool_names().to_vec();
 
     session.activated_deferred_tool_names = activated_deferred_tool_names;
@@ -1587,6 +1618,102 @@ fn apply_selected_resume_bundle(session: &mut RestoredSession) {
     session.plan_corrections.clear();
     session.last_context_trace = None;
     session.workspace = None;
+}
+
+/// Replace the resumable conversation with a coordinator-verified canonical
+/// bundle. Runtime-bearing side projections are re-admitted only when their
+/// own envelope proves the same causal boundary.
+pub fn install_canonical_resume_bundle(
+    session: &mut RestoredSession,
+    mut bundle: astra_turn_types::ResumeBundleV1,
+) -> Result<(), String> {
+    if bundle.source != astra_turn_types::ResumeSourceV1::CanonicalJournal
+        || !bundle.validates_root()
+    {
+        return Err("canonical resume bundle does not validate its materialized content".into());
+    }
+    if let Some(legacy) = session.resume_bundle.as_ref()
+        && resume_materializations_are_equivalent(legacy, &bundle)
+    {
+        transplant_equivalent_resume_projections(legacy, &mut bundle);
+    }
+    session.turn_count = bundle.cursor.completed_turn;
+    session.conversation_messages.clear();
+    session.resume_bundle = Some(bundle);
+    apply_selected_resume_bundle(session);
+    Ok(())
+}
+
+fn resume_materializations_are_equivalent(
+    legacy: &astra_turn_types::ResumeBundleV1,
+    canonical: &astra_turn_types::ResumeBundleV1,
+) -> bool {
+    let legacy_materialized_root =
+        astra_turn_types::canonical_conversation_root(&legacy.conversation_messages);
+    legacy.validates_root()
+        && legacy.cursor.owner_id == canonical.cursor.owner_id
+        && legacy.cursor.session_id == canonical.cursor.session_id
+        && legacy.cursor.branch_id == canonical.cursor.branch_id
+        && legacy.cursor.completed_turn == canonical.cursor.completed_turn
+        && canonical.materialized_conversation_root_hash.as_deref()
+            == Some(legacy_materialized_root.as_str())
+}
+
+fn transplant_equivalent_resume_projections(
+    legacy: &astra_turn_types::ResumeBundleV1,
+    canonical: &mut astra_turn_types::ResumeBundleV1,
+) {
+    let cursor = canonical.cursor.clone();
+    if canonical.projections.checkpoint.is_none()
+        && let Some(payload) = equivalent_projection_payload(legacy, &legacy.projections.checkpoint)
+    {
+        canonical.projections.checkpoint = Some(
+            astra_turn_types::CausalProjectionEnvelopeV1::at_cursor(cursor.clone(), payload),
+        );
+    }
+    if canonical.projections.task.is_none()
+        && let Some(payload) = equivalent_projection_payload(legacy, &legacy.projections.task)
+    {
+        canonical.projections.task = Some(astra_turn_types::CausalProjectionEnvelopeV1::at_cursor(
+            cursor.clone(),
+            payload,
+        ));
+    }
+    if canonical.projections.provider.is_none()
+        && let Some(payload) = equivalent_projection_payload(legacy, &legacy.projections.provider)
+    {
+        canonical.projections.provider = Some(
+            astra_turn_types::CausalProjectionEnvelopeV1::at_cursor(cursor.clone(), payload),
+        );
+    }
+    if canonical.projections.activation.is_none()
+        && let Some(payload) = equivalent_projection_payload(legacy, &legacy.projections.activation)
+    {
+        canonical.projections.activation = Some(
+            astra_turn_types::CausalProjectionEnvelopeV1::at_cursor(cursor, payload),
+        );
+    }
+}
+
+fn equivalent_projection_payload<T: Clone>(
+    bundle: &astra_turn_types::ResumeBundleV1,
+    projection: &Option<astra_turn_types::CausalProjectionEnvelopeV1<T>>,
+) -> Option<T> {
+    let projection = projection.as_ref()?;
+    if projection.is_admissible_at(&bundle.cursor)
+        || (bundle.source.is_degraded()
+            && bundle
+                .degraded_reasons
+                .contains(&astra_turn_types::ResumeDegradedReasonV1::ProjectionCursorMissing)
+            && projection.schema_version
+                == astra_turn_types::CAUSAL_PROJECTION_ENVELOPE_SCHEMA_VERSION
+            && projection.source_cursor.is_none()
+            && projection.verified_through_root.is_none())
+    {
+        Some(projection.payload.clone())
+    } else {
+        None
+    }
 }
 
 /// Reconcile two restore projections without combining history from different
@@ -3255,6 +3382,7 @@ mod tests {
                 source: astra_turn_types::ResumeSourceV1::Checkpoint,
                 cursor,
                 conversation_messages: messages,
+                materialized_conversation_root_hash: None,
                 degraded_reasons: Vec::new(),
                 repair_actions: Vec::new(),
                 projections: astra_turn_types::ResumeProjectionSetV1::default(),
@@ -4249,6 +4377,156 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.contains("no valid resume candidate"), "{error}");
+    }
+
+    #[test]
+    fn degraded_cloud_resume_preserves_its_own_unversioned_session_snapshot() {
+        let messages = vec![serde_json::json!({"role": "user", "content": "resume"})];
+        let cursor = typed_resume_bundle_from_messages(
+            "owner-1",
+            "legacy-cloud-session",
+            3,
+            messages.clone(),
+        )
+        .cursor;
+        let heavy = CloudHeavyCheckpointState {
+            conversation_cursor: Some(cursor),
+            messages: messages.clone(),
+            ..Default::default()
+        };
+        let bundle = build_resume_bundle(
+            "owner-1",
+            "legacy-cloud-session",
+            3,
+            messages,
+            true,
+            Some(&heavy),
+            ResumeBundleSupplementalProjections {
+                task: astra_turn_types::ResumeTaskProjectionV1 {
+                    executing_plan_json: Some(r#"{"goal":"resume"}"#.into()),
+                    contract_json: Some(r#"{"state":"active"}"#.into()),
+                    ..Default::default()
+                },
+                provider: astra_turn_types::ResumeProviderProjectionV1 {
+                    model: Some("model-a".into()),
+                    permission_mode: Some("plan".into()),
+                    config_version_id: None,
+                },
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert!(bundle.projections.task_at(&bundle.cursor).is_none());
+        assert!(
+            bundle
+                .degraded_reasons
+                .contains(&astra_turn_types::ResumeDegradedReasonV1::ProjectionCursorMissing)
+        );
+
+        let mut restored = RestoredSession {
+            session_id: "legacy-cloud-session".into(),
+            resume_bundle: Some(bundle),
+            ..Default::default()
+        };
+        apply_selected_resume_bundle(&mut restored);
+
+        assert_eq!(restored.model.as_deref(), Some("model-a"));
+        assert_eq!(restored.permission_mode.as_deref(), Some("plan"));
+        assert_eq!(
+            restored.executing_plan_json.as_deref(),
+            Some(r#"{"goal":"resume"}"#)
+        );
+        assert_eq!(
+            restored.contract_json.as_deref(),
+            Some(r#"{"state":"active"}"#)
+        );
+    }
+
+    #[test]
+    fn canonical_resume_transplants_side_state_only_for_equivalent_materialization() {
+        let messages = vec![serde_json::json!({"role": "user", "content": "resume"})];
+        let heavy = CloudHeavyCheckpointState {
+            messages: messages.clone(),
+            blocked_tools: vec!["write".into()],
+            ..Default::default()
+        };
+        let legacy = build_resume_bundle(
+            "owner-1",
+            "canonical-session",
+            3,
+            messages.clone(),
+            true,
+            Some(&heavy),
+            ResumeBundleSupplementalProjections {
+                task: astra_turn_types::ResumeTaskProjectionV1 {
+                    executing_plan_json: Some(r#"{"goal":"resume"}"#.into()),
+                    contract_json: Some(r#"{"state":"active"}"#.into()),
+                    ..Default::default()
+                },
+                provider: astra_turn_types::ResumeProviderProjectionV1 {
+                    model: Some("model-a".into()),
+                    permission_mode: Some("plan".into()),
+                    config_version_id: None,
+                },
+            },
+        )
+        .unwrap()
+        .unwrap();
+        let legacy_cursor = legacy.cursor.clone();
+        let canonical_bundle = |materialized_messages: Vec<serde_json::Value>| {
+            let mut cursor = legacy_cursor.clone();
+            cursor.schema_version = astra_turn_types::SESSION_CURSOR_SCHEMA_VERSION;
+            cursor.projection_schema =
+                astra_turn_types::SEGMENTED_CONVERSATION_PROJECTION_SCHEMA_VERSION;
+            cursor.canonical_root_hash = "a".repeat(64);
+            let materialized_root =
+                astra_turn_types::canonical_conversation_root(&materialized_messages);
+            astra_turn_types::select_resume_bundle(
+                Some(&cursor),
+                [astra_turn_types::ResumeCandidateV1 {
+                    source: astra_turn_types::ResumeSourceV1::CanonicalJournal,
+                    cursor: cursor.clone(),
+                    conversation_messages: materialized_messages,
+                    materialized_conversation_root_hash: Some(materialized_root),
+                    degraded_reasons: Vec::new(),
+                    repair_actions: Vec::new(),
+                    projections: Default::default(),
+                }],
+            )
+            .unwrap()
+        };
+
+        let mut equivalent = RestoredSession {
+            session_id: "canonical-session".into(),
+            resume_bundle: Some(legacy.clone()),
+            ..Default::default()
+        };
+        install_canonical_resume_bundle(&mut equivalent, canonical_bundle(messages)).unwrap();
+        assert_eq!(equivalent.model.as_deref(), Some("model-a"));
+        assert_eq!(equivalent.permission_mode.as_deref(), Some("plan"));
+        assert_eq!(
+            equivalent.executing_plan_json.as_deref(),
+            Some(r#"{"goal":"resume"}"#)
+        );
+        assert_eq!(equivalent.blocked_tools, ["write"]);
+
+        let mut divergent = RestoredSession {
+            session_id: "canonical-session".into(),
+            resume_bundle: Some(legacy),
+            model: Some("must-be-cleared".into()),
+            ..Default::default()
+        };
+        install_canonical_resume_bundle(
+            &mut divergent,
+            canonical_bundle(vec![serde_json::json!({
+                "role": "user",
+                "content": "different"
+            })]),
+        )
+        .unwrap();
+        assert_eq!(divergent.model, None);
+        assert!(divergent.executing_plan_json.is_none());
+        assert!(divergent.blocked_tools.is_empty());
     }
 
     #[test]

--- a/crates/services/src/session_restore.rs
+++ b/crates/services/src/session_restore.rs
@@ -1546,7 +1546,7 @@ fn apply_selected_resume_bundle(session: &mut RestoredSession) {
             .contains(&astra_turn_types::ResumeDegradedReasonV1::ProjectionCursorMissing);
     let task = bundle.projections.task_at(&cursor).cloned().or_else(|| {
         permits_degraded_projection_fallback
-            .then(|| bundle.projections.task.as_ref())
+            .then_some(bundle.projections.task.as_ref())
             .flatten()
             .filter(|projection| {
                 projection.schema_version
@@ -1562,7 +1562,7 @@ fn apply_selected_resume_bundle(session: &mut RestoredSession) {
         .cloned()
         .or_else(|| {
             permits_degraded_projection_fallback
-                .then(|| bundle.projections.provider.as_ref())
+                .then_some(bundle.projections.provider.as_ref())
                 .flatten()
                 .filter(|projection| {
                     projection.schema_version

--- a/crates/services/src/storage.rs
+++ b/crates/services/src/storage.rs
@@ -51,7 +51,7 @@ pub const AGENT_ID_LEN: usize = 255;
 pub const AGENT_EVENT_ID_LEN: usize = 128;
 static CORE_SCHEMA_INIT_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 const CORE_SCHEMA_CONTRACT_COMPONENT: &str = "astra-core";
-pub const CORE_SCHEMA_CONTRACT_VERSION: &str = "2026-07-31-v23";
+pub const CORE_SCHEMA_CONTRACT_VERSION: &str = "2026-07-31-v24";
 const CORE_SCHEMA_CONTRACT_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS astra_schema_contracts (
     component VARCHAR(64) NOT NULL PRIMARY KEY,
     contract_version VARCHAR(64) NOT NULL,
@@ -2459,6 +2459,90 @@ pub async fn ensure_core_schema(
     }
 }
 
+async fn backfill_conversation_manifest_segments(
+    pool: &sqlx::Pool<MySql>,
+) -> Result<(), sqlx::Error> {
+    const BACKFILL_BATCH: i64 = 128;
+    loop {
+        let rows = query(
+            "SELECT isolation_domain, owner_user_id, session_id, branch_id,
+                    manifest_root, CAST(manifest_json AS CHAR) AS manifest_json
+               FROM conversation_manifest_nodes node
+              WHERE NOT EXISTS (
+                        SELECT 1 FROM conversation_manifest_segments segment
+                         WHERE segment.isolation_domain = node.isolation_domain
+                           AND segment.owner_user_id = node.owner_user_id
+                           AND segment.session_id = node.session_id
+                           AND segment.branch_id = node.branch_id
+                           AND segment.manifest_root = node.manifest_root
+                    )
+              ORDER BY node.created_at ASC, node.manifest_root ASC
+              LIMIT ?",
+        )
+        .bind(BACKFILL_BATCH)
+        .fetch_all(pool)
+        .await?;
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        for row in rows {
+            let isolation_domain: String = row.try_get("isolation_domain")?;
+            let owner_user_id: String = row.try_get("owner_user_id")?;
+            let session_id: String = row.try_get("session_id")?;
+            let branch_id: String = row.try_get("branch_id")?;
+            let manifest_root: String = row.try_get("manifest_root")?;
+            let manifest_json: String = row.try_get("manifest_json")?;
+            let manifest: astra_turn_types::ContextManifestNodeV1 =
+                serde_json::from_str(&manifest_json).map_err(|source| {
+                    sqlx::Error::Protocol(format!(
+                        "decode manifest segment backfill row {manifest_root}: {source}"
+                    ))
+                })?;
+            manifest.validate().map_err(|source| {
+                sqlx::Error::Protocol(format!(
+                    "validate manifest segment backfill row {manifest_root}: {source}"
+                ))
+            })?;
+            if manifest.key.isolation_domain != isolation_domain
+                || manifest.key.owner_user_id != owner_user_id
+                || manifest.key.session_id != session_id
+                || manifest.key.branch_id != branch_id
+                || manifest.manifest_root != manifest_root
+            {
+                return Err(sqlx::Error::Protocol(format!(
+                    "manifest segment backfill identity mismatch for {manifest_root}"
+                )));
+            }
+
+            // One manifest's reference index is installed atomically. If
+            // bootstrap is interrupted, the next leased run sees either all
+            // positions or none and can safely retry.
+            let mut tx = pool.begin().await?;
+            let mut builder = QueryBuilder::<MySql>::new(
+                "INSERT IGNORE INTO conversation_manifest_segments
+                 (isolation_domain, owner_user_id, session_id, branch_id,
+                  manifest_root, segment_position, segment_hash) ",
+            );
+            builder.push_values(
+                manifest.appended_segments.iter().enumerate(),
+                |mut values, (position, segment)| {
+                    values
+                        .push_bind(&isolation_domain)
+                        .push_bind(&owner_user_id)
+                        .push_bind(&session_id)
+                        .push_bind(&branch_id)
+                        .push_bind(&manifest_root)
+                        .push_bind(i64::try_from(position).unwrap_or(i64::MAX))
+                        .push_bind(&segment.segment_hash);
+                },
+            );
+            builder.build().execute(&mut *tx).await?;
+            tx.commit().await?;
+        }
+    }
+}
+
 async fn ensure_core_schema_while_leased(
     settings: &MatrixOneSettings,
     pool: sqlx::Pool<MySql>,
@@ -3181,6 +3265,7 @@ async fn ensure_core_schema_while_leased(
             parent_manifest_root CHAR(64) NULL,
             completed_turn BIGINT NOT NULL,
             conversation_seq BIGINT NOT NULL,
+            compaction_generation BIGINT NOT NULL DEFAULT 0,
             canonical_segment_bytes BIGINT NOT NULL,
             total_canonical_bytes BIGINT NOT NULL,
             total_message_count BIGINT NOT NULL,
@@ -3189,7 +3274,9 @@ async fn ensure_core_schema_while_leased(
             created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
             PRIMARY KEY (isolation_domain, owner_user_id, session_id, branch_id, manifest_root),
             INDEX idx_context_manifest_parent (isolation_domain, owner_user_id, session_id, branch_id, parent_manifest_root),
-            INDEX idx_context_manifest_sequence (isolation_domain, owner_user_id, session_id, branch_id, conversation_seq)
+            INDEX idx_context_manifest_sequence (isolation_domain, owner_user_id, session_id, branch_id, conversation_seq),
+            INDEX idx_context_manifest_reachable_sequence (isolation_domain, owner_user_id, session_id, branch_id, reachable, conversation_seq),
+            INDEX idx_context_manifest_generation_sequence (isolation_domain, owner_user_id, session_id, branch_id, compaction_generation, reachable, conversation_seq)
         )",
     )
     .execute(&pool)
@@ -3207,6 +3294,10 @@ async fn ensure_core_schema_while_leased(
             "reachable",
             "ALTER TABLE conversation_manifest_nodes ADD COLUMN reachable TINYINT NOT NULL DEFAULT 0",
         ),
+        (
+            "compaction_generation",
+            "ALTER TABLE conversation_manifest_nodes ADD COLUMN compaction_generation BIGINT NOT NULL DEFAULT 0",
+        ),
     ] {
         add_column_if_missing(
             &pool,
@@ -3217,6 +3308,39 @@ async fn ensure_core_schema_while_leased(
         )
         .await?;
     }
+    ensure_index_shape(
+        &pool,
+        &settings.database,
+        "conversation_manifest_nodes",
+        "idx_context_manifest_reachable_sequence",
+        &[
+            "isolation_domain",
+            "owner_user_id",
+            "session_id",
+            "branch_id",
+            "reachable",
+            "conversation_seq",
+        ],
+        "ALTER TABLE conversation_manifest_nodes ADD INDEX idx_context_manifest_reachable_sequence (isolation_domain, owner_user_id, session_id, branch_id, reachable, conversation_seq)",
+    )
+    .await?;
+    ensure_index_shape(
+        &pool,
+        &settings.database,
+        "conversation_manifest_nodes",
+        "idx_context_manifest_generation_sequence",
+        &[
+            "isolation_domain",
+            "owner_user_id",
+            "session_id",
+            "branch_id",
+            "compaction_generation",
+            "reachable",
+            "conversation_seq",
+        ],
+        "ALTER TABLE conversation_manifest_nodes ADD INDEX idx_context_manifest_generation_sequence (isolation_domain, owner_user_id, session_id, branch_id, compaction_generation, reachable, conversation_seq)",
+    )
+    .await?;
     query(
         "UPDATE conversation_manifest_nodes n
          INNER JOIN session_context_heads h
@@ -3230,6 +3354,35 @@ async fn ensure_core_schema_while_leased(
     )
     .execute(&pool)
     .await?;
+
+    core_schema_create!(
+        pool,
+        "conversation_manifest_segments",
+        "CREATE TABLE IF NOT EXISTS conversation_manifest_segments (
+            isolation_domain VARCHAR(128) NOT NULL,
+            owner_user_id VARCHAR(128) NOT NULL,
+            session_id VARCHAR(128) NOT NULL,
+            branch_id VARCHAR(128) NOT NULL,
+            manifest_root CHAR(64) NOT NULL,
+            segment_position BIGINT NOT NULL,
+            segment_hash CHAR(64) NOT NULL,
+            created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+            PRIMARY KEY (
+                isolation_domain, owner_user_id, session_id, branch_id,
+                manifest_root, segment_position
+            ),
+            INDEX idx_manifest_segments_hash (
+                isolation_domain, owner_user_id, segment_hash, manifest_root
+            ),
+            INDEX idx_manifest_segments_session (
+                owner_user_id, session_id, branch_id, manifest_root
+            ),
+            INDEX idx_manifest_segments_created (created_at)
+        )",
+    )
+    .execute(&pool)
+    .await?;
+    backfill_conversation_manifest_segments(&pool).await?;
 
     core_schema_create!(
         pool,
@@ -5782,6 +5935,8 @@ async fn ensure_core_schema_while_leased(
                 (user_id, attempt_id, event_stage),
             INDEX idx_model_request_context_owner_session_created
                 (user_id, session_id, created_at, event_id),
+            INDEX idx_model_request_context_owner_harness_created
+                (user_id, harness_run_id, created_at, event_id),
             INDEX idx_model_request_context_metrics
                 (topology, provider, model_family, purpose, created_at),
             INDEX idx_model_request_context_terminal_status
@@ -5789,6 +5944,15 @@ async fn ensure_core_schema_while_leased(
         )",
     )
     .execute(&pool)
+    .await?;
+    ensure_index_shape(
+        &pool,
+        &settings.database,
+        "model_request_context_events",
+        "idx_model_request_context_owner_harness_created",
+        &["user_id", "harness_run_id", "created_at", "event_id"],
+        "ALTER TABLE model_request_context_events ADD INDEX idx_model_request_context_owner_harness_created (user_id, harness_run_id, created_at, event_id)",
+    )
     .await?;
 
     // Terminal request metrics are accumulated transactionally with their

--- a/crates/services/tests/schema_assertions.rs
+++ b/crates/services/tests/schema_assertions.rs
@@ -1258,8 +1258,25 @@ async fn phase1_run_durability_schema_contract() {
         ],
         "manifest lookup must carry complete owner/session/branch identity"
     );
+    assert_eq!(
+        primary_key_columns(&pool, &schema, "conversation_manifest_segments").await,
+        [
+            "isolation_domain",
+            "owner_user_id",
+            "session_id",
+            "branch_id",
+            "manifest_root",
+            "segment_position"
+        ],
+        "segment reachability must be indexed by the immutable manifest identity"
+    );
     let manifest_nodes = column_names(&pool, &schema, "conversation_manifest_nodes").await;
-    for expected in ["total_canonical_bytes", "total_message_count", "reachable"] {
+    for expected in [
+        "total_canonical_bytes",
+        "total_message_count",
+        "reachable",
+        "compaction_generation",
+    ] {
         assert!(
             manifest_nodes.iter().any(|column| column == expected),
             "conversation_manifest_nodes missing O(1) retained-fork coordinate {expected}"


### PR DESCRIPTION
## What changed

- Make resume selection causal across canonical conversation state, model/provider config, plan, contract, checkpoint, and legacy projections.
- Close writer-lease and execution-grant error paths, preserve cancellation semantics, and make blocked handoff retries idempotent.
- Bound and connect retention/cleanup for model request context events, conversation segments, fork records, manifest pins, and segment uploads.
- Make the current `/chat/turn` bridge a revision-fenced migration adapter: Server-owned canonical head assembly, one reserved visible turn across tool rounds, CAS delta commit, active-turn lease renewal, and bounded idempotent release retries.
- Move the close/resume product journey to a real durable boundary and assert canonical hydration instead of accepting an empty-session status-only resume.

## Why

The affected paths had three systemic gaps: unversioned recovery payloads were silently inadmissible, error/cleanup paths did not share the happy-path authority lifetime, and the legacy bridge persisted only transcript projections while assuming clients resent the full conversation. Together these could restore default policy, pin sessions behind stale leases, misclassify cancellation, retain orphaned data, or resume without a canonical conversation.

The bridge now treats the Server head as the sole durable history. A request must either carry that exact prefix or a structurally valid current-turn suffix; no text similarity or intent matching is used.

## Impact

Networked sessions retain model/policy and typed conversation state across resume, concurrent writers are fenced by cursor/epoch/turn reservation, abandoned or failed work has bounded lease behavior, and long active turns renew authority without creating an indefinitely renewed abandoned tool-round lock.

## Validation

- `make check` — passed
- `make test-offline` — passed before the final bridge adapter commit (19,417 workspace tests plus bridge/SDK/Web lanes)
- strict runtime clippy with bridge E2E hooks and `-D warnings` — passed after the final changes
- focused canonical packing/cancellation/compaction tests — 4 passed
- focused bridge admission/fencing/error-path tests — 2 passed
- live MatrixOne product resume journey plus two-HTTP-round tool causal-order journey — 2 passed
- initial full `make test-online`: core DB and performance lanes passed; the single integration failure exposed the bridge canonical-history gap fixed and revalidated above