### PR TITLE
feat(edge): edge token renewal, auth external mapping, memoria proxy fix

### DIFF
--- a/crates/astra-cli/src/cli/durable_bridge.rs
+++ b/crates/astra-cli/src/cli/durable_bridge.rs
@@ -18,12 +18,11 @@ use crate::cli::theme;
 
 /// Build a reqwest client for the durable-task bridge.
 ///
-/// Durable-bridge traffic is local-only (CLI ↔ local API server), so we always
-/// skip any system proxy. Only the LLM HTTP client (runtime `llm_client.rs`)
-/// honours env proxy vars.
-fn build_client_for_url(_url: &str) -> reqwest::Client {
-    reqwest::Client::builder()
-        .no_proxy()
+/// Loopback targets (CLI ↔ local API server) bypass any system proxy; remote
+/// targets keep env-aware proxy behavior so mandatory-egress-proxy sandboxes
+/// (e.g. OpenShell) can reach the remote bridge.
+fn build_client_for_url(url: &str) -> reqwest::Client {
+    astra_core::net::client_builder_for_target(url)
         .connect_timeout(std::time::Duration::from_secs(10))
         .timeout(std::time::Duration::from_secs(30))
         .build()

--- a/crates/astra-cli/src/cli/http_task_service.rs
+++ b/crates/astra-cli/src/cli/http_task_service.rs
@@ -53,9 +53,8 @@ impl HttpTaskService {
     /// matching the `TaskService` trait error type.
     async fn rpc(&self, method: &str, args: Value) -> Result<Value, String> {
         let url = self.rpc_url();
-        let client = reqwest::Client::builder()
+        let client = astra_core::net::client_builder_for_target(&url)
             .timeout(std::time::Duration::from_secs(TASK_HTTP_TIMEOUT_SECS))
-            .no_proxy()
             .build()
             .map_err(|e| format!("http client init: {e}"))?;
         let mut req = client
@@ -425,12 +424,12 @@ impl HttpTaskLeaseService {
         body: Value,
         edge_id: Option<&str>,
     ) -> Result<Value, String> {
-        let client = reqwest::Client::builder()
+        let url = self.url(path);
+        let client = astra_core::net::client_builder_for_target(&url)
             .timeout(std::time::Duration::from_secs(TASK_HTTP_TIMEOUT_SECS))
-            .no_proxy()
             .build()
             .map_err(|e| format!("http client init: {e}"))?;
-        let mut req = client.post(self.url(path)).json(&body);
+        let mut req = client.post(url).json(&body);
         if let Some(edge_id) = edge_id.filter(|edge_id| !edge_id.trim().is_empty()) {
             req = req.header(ASTRA_EDGE_ID_HEADER, edge_id);
         }
@@ -452,12 +451,12 @@ impl HttpTaskLeaseService {
     }
 
     async fn get(&self, path: &str) -> Result<Value, String> {
-        let client = reqwest::Client::builder()
+        let url = self.url(path);
+        let client = astra_core::net::client_builder_for_target(&url)
             .timeout(std::time::Duration::from_secs(TASK_HTTP_TIMEOUT_SECS))
-            .no_proxy()
             .build()
             .map_err(|e| format!("http client init: {e}"))?;
-        let mut req = client.get(self.url(path));
+        let mut req = client.get(url);
         if let Some(tok) = self.token.as_deref() {
             req = req.bearer_auth(tok);
         }

--- a/crates/astra-cli/src/cli/http_team_store.rs
+++ b/crates/astra-cli/src/cli/http_team_store.rs
@@ -157,9 +157,8 @@ impl HttpTeamStore {
         let token =
             crate::cli::session::session_runtime::current_access_token(self.profile.as_deref())
                 .ok_or(TeamHttpError::AuthenticationRequired)?;
-        let client = reqwest::Client::builder()
+        let client = astra_core::net::client_builder_for_target(&self.cloud_base)
             .timeout(std::time::Duration::from_secs(TEAM_HTTP_TIMEOUT_SECS))
-            .no_proxy()
             .build()
             .map_err(|e| TeamHttpError::ClientInit(e.to_string()))?;
         Ok((client, token))

--- a/crates/astra-cli/src/cli/preferences_client.rs
+++ b/crates/astra-cli/src/cli/preferences_client.rs
@@ -30,9 +30,8 @@ fn build_request(
     url: &str,
     token: Option<&str>,
 ) -> Result<reqwest::RequestBuilder, String> {
-    let client = reqwest::Client::builder()
+    let client = astra_core::net::client_builder_for_target(url)
         .timeout(std::time::Duration::from_secs(PREFS_HTTP_TIMEOUT_SECS))
-        .no_proxy()
         .build()
         .map_err(|e| format!("http client init: {e}"))?;
     let mut req = client.request(method, url);

--- a/crates/astra-cli/src/cli/session/session_todo_client.rs
+++ b/crates/astra-cli/src/cli/session/session_todo_client.rs
@@ -137,9 +137,8 @@ fn build_request(
     url: &str,
     token: Option<&str>,
 ) -> Result<reqwest::RequestBuilder, String> {
-    let client = reqwest::Client::builder()
+    let client = astra_core::net::client_builder_for_target(url)
         .timeout(std::time::Duration::from_secs(TODOS_HTTP_TIMEOUT_SECS))
-        .no_proxy()
         .build()
         .map_err(|e| format!("http client init: {e}"))?;
     let mut req = client.request(method, url);

--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -10356,6 +10356,10 @@ mod tests {
     /// (b) `ToolExecutor::new` never panics when those envs are set — which
     /// was the actual risk if a caller forgot to call `apply_env_proxy` and
     /// reqwest rejected a malformed env URL at build time.
+    // serial_test: proxy env mutations race with any parallel test whose
+    // HTTP client is env-proxy-aware (e.g. cloud_sync's remote-target
+    // clients after the client_builder_for_target policy).
+    #[serial_test::serial]
     #[test]
     fn github_client_honours_proxy_env_without_panicking() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/astra-cli/src/edge_tools/memoria.rs
+++ b/crates/astra-cli/src/edge_tools/memoria.rs
@@ -76,9 +76,8 @@ async fn memoria_proxy_request(
     body: Option<&Value>,
 ) -> Result<String, String> {
     let (base, token) = current_memoria_proxy_target()?;
-    let client = reqwest::Client::builder()
+    let client = astra_core::net::client_builder_for_target(&base)
         .timeout(timeout)
-        .no_proxy()
         .build()
         .map_err(|e| format!("build client: {e}"))?;
     let url = format!("{}{}", base.trim_end_matches('/'), path);
@@ -416,9 +415,8 @@ impl ToolExecutor {
             Some(token) => token,
             None => return vec![],
         };
-        let client = match reqwest::Client::builder()
+        let client = match astra_core::net::client_builder_for_target(&cloud_base)
             .timeout(Duration::from_millis(800))
-            .no_proxy()
             .build()
         {
             Ok(c) => c,
@@ -489,9 +487,8 @@ impl ToolExecutor {
             None => return,
         };
         tokio::spawn(async move {
-            let client = match reqwest::Client::builder()
+            let client = match astra_core::net::client_builder_for_target(&cloud_base)
                 .timeout(Duration::from_secs(5))
-                .no_proxy()
                 .build()
             {
                 Ok(c) => c,

--- a/crates/astra-cli/src/tests/cloud_sync_tests.rs
+++ b/crates/astra-cli/src/tests/cloud_sync_tests.rs
@@ -180,6 +180,7 @@ fn display_sync_status_no_crash_full_data() {
     slash_health::display_sync_status(&status);
 }
 
+#[serial_test::serial]
 #[tokio::test]
 async fn slash_health_offline_shows_cloud_section() {
     let api = astra_thin_client::ThinClient::new("http://unused", None).unwrap();
@@ -709,6 +710,7 @@ async fn drain_empty_sync_outbox_does_not_require_cloud_credentials() {
     assert_eq!(report.user_notice(), None);
 }
 
+#[serial_test::serial]
 #[tokio::test]
 async fn try_cloud_pull_returns_empty_without_matrixone() {
     unsafe {
@@ -721,6 +723,7 @@ async fn try_cloud_pull_returns_empty_without_matrixone() {
     );
 }
 
+#[serial_test::serial]
 #[tokio::test]
 async fn try_cloud_pull_preferences_is_noop_without_matrixone() {
     unsafe {
@@ -732,6 +735,7 @@ async fn try_cloud_pull_preferences_is_noop_without_matrixone() {
     assert!(keys.is_empty());
 }
 
+#[serial_test::serial]
 #[tokio::test]
 async fn try_cloud_push_preferences_is_noop_without_matrixone() {
     unsafe {

--- a/crates/astra-edge/Cargo.toml
+++ b/crates/astra-edge/Cargo.toml
@@ -39,3 +39,8 @@ astra-tools.workspace = true
 astra-server-types.workspace = true
 astra-turn-types.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+# `test-util` enables `#[tokio::test(start_paused = true)]` and virtual-time
+# advancement used by the token-renewal retry-schedule test.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/astra-edge/Cargo.toml
+++ b/crates/astra-edge/Cargo.toml
@@ -32,12 +32,10 @@ base64 = { workspace = true }
 fastrand = "2"
 fs2.workspace = true
 reqwest = { workspace = true }
+tempfile.workspace = true
 astra-runtime-env.workspace = true
 astra-credentials.workspace = true
 astra-tools.workspace = true
 astra-server-types.workspace = true
 astra-turn-types.workspace = true
 thiserror.workspace = true
-
-[dev-dependencies]
-tempfile.workspace = true

--- a/crates/astra-edge/src/main.rs
+++ b/crates/astra-edge/src/main.rs
@@ -10,6 +10,8 @@
 //! ```
 
 mod invocation_journal;
+mod token_manager;
+mod token_renewal;
 
 use astra_credentials::{CredentialStore, CredentialsFile};
 use astra_runtime_env::{
@@ -88,10 +90,12 @@ struct Args {
     reconnect: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct EdgeConfig {
     server_url: String,
-    token: String,
+    /// Single owner of the token state machine: memory value, token file,
+    /// startup fallback and persistence debt (see token_manager.rs).
+    token_manager: Arc<token_manager::TokenManager>,
     workspace_dir: PathBuf,
     edge_id: String,
     reconnect: bool,
@@ -318,14 +322,100 @@ fn resolve_token(args: &Args) -> Result<String, String> {
 fn resolve_config(args: Args) -> Result<EdgeConfig, String> {
     let raw_server_url = args.server_url.clone().unwrap_or_else(default_server_url);
     let workspace_dir = canonical_workspace_dir(&args.workspace_dir)?;
-    let token = resolve_token(&args)?;
+    // Prefer a valid persisted moi-user-token-v1 (written by a prior renewal)
+    // over the env/flag token; astra JWT flows are untouched.
+    let token_file = token_renewal::resolve_token_file_path(&workspace_dir);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    // Pick whichever unexpired token expires LATER. A recreated Runner that
+    // reuses the workspace volume injects a fresh env token while the file
+    // still holds the previous (revoked-but-unexpired) one; preferring the
+    // file unconditionally would leave the edge permanently rejected.
+    let env_token = resolve_token(&args);
+    let file_token = token_renewal::read_valid_file_token(&token_file, now);
+    let mut fallback_token = None;
+    let token = match (file_token, &env_token) {
+        (Some(file_token), Ok(env)) => {
+            // Generation order is (iat, exp); expiry seconds alone cannot
+            // order double-renew siblings. Exact ties keep the file (with the
+            // env token retained as the one-shot auth-failure fallback), and
+            // the AuthOk heal-write converges the file to whatever actually
+            // authenticates.
+            let file_claims = token_renewal::parse_moi_token_claims(&file_token);
+            let env_claims = token_renewal::parse_moi_token_claims(env);
+            match (file_claims, env_claims) {
+                (_, None) => {
+                    // The explicit credential is NOT a moi-user-token (plain
+                    // Astra token / profile identity): it wins absolutely. A
+                    // leftover sandbox token file must never replace an
+                    // explicitly chosen identity, and the two are different
+                    // identity domains — no fallback between them either.
+                    tracing::info!(
+                        "using explicit non-MOI credential (persisted MOI token file ignored)"
+                    );
+                    env.clone()
+                }
+                (None, Some(_)) => {
+                    // File token is not a parseable moi-user-token but the
+                    // explicit credential is: prefer the explicit token.
+                    tracing::info!("using env/flag edge token (persisted token file unparseable)");
+                    env.clone()
+                }
+                (Some(fc), Some(ec)) if !token_renewal::same_moi_identity(&fc, &ec) => {
+                    // Different identity (e.g. the workspace volume was reused
+                    // by another user/tenant). Generation order is meaningless
+                    // across identities: the explicit env token wins and the
+                    // stale file token is ignored — never used, never a fallback.
+                    tracing::info!(
+                        "using explicit edge token (persisted token file has a different identity — ignored)"
+                    );
+                    env.clone()
+                }
+                (Some(fc), Some(ec)) => {
+                    // Same identity: order by generation (iat, exp). Expiry
+                    // seconds alone cannot order double-renew siblings; exact
+                    // ties keep the file (env retained as one-shot fallback) and
+                    // the AuthOk heal-write converges the file to whatever
+                    // actually authenticates.
+                    let file_gen = (fc.iat, fc.exp);
+                    let env_gen = (ec.iat, ec.exp);
+                    if env_gen > file_gen {
+                        tracing::info!(
+                            "using env/flag edge token (newer than persisted token file)"
+                        );
+                        fallback_token = Some(file_token);
+                        env.clone()
+                    } else {
+                        tracing::info!(
+                            path = %token_file.display(),
+                            "using persisted edge token from token file"
+                        );
+                        if env != &file_token {
+                            fallback_token = Some(env.clone());
+                        }
+                        file_token
+                    }
+                }
+            }
+        }
+        (Some(file_token), Err(_)) => {
+            tracing::info!(
+                path = %token_file.display(),
+                "using persisted edge token from token file"
+            );
+            file_token
+        }
+        (None, _) => env_token?,
+    };
     let edge_id = args
         .edge_id
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| default_edge_id(&workspace_dir));
     Ok(EdgeConfig {
         server_url: edge_ws_url(&raw_server_url)?,
-        token,
+        token_manager: token_manager::TokenManager::new(token, fallback_token, token_file),
         workspace_dir,
         edge_id,
         reconnect: args.reconnect,
@@ -777,8 +867,11 @@ async fn run_edge_connection(config: &EdgeConfig) -> Result<(), Box<dyn std::err
         })
     };
 
+    // Snapshot the live token per connection attempt: the renewal task may
+    // have replaced it since the previous (re)connect.
+    let token_snapshot = config.token_manager.snapshot().await;
     let ws_stream = if let Some(ref proxy_url) = proxy {
-        connect_via_proxy(&url, proxy_url, &config.token)
+        connect_via_proxy(&url, proxy_url, &token_snapshot)
             .await
             .map_err(|e| {
                 tracing::error!(
@@ -792,7 +885,7 @@ async fn run_edge_connection(config: &EdgeConfig) -> Result<(), Box<dyn std::err
                 e
             })?
     } else {
-        let request = edge_ws_request(&url, &config.token)?;
+        let request = edge_ws_request(&url, &token_snapshot)?;
         let (ws, _) = connect_async(request).await.map_err(|e| {
             tracing::error!(
                 target: "astra.edge",
@@ -836,6 +929,16 @@ async fn run_edge_connection(config: &EdgeConfig) -> Result<(), Box<dyn std::err
         {
             Ok(EdgeServerMessage::AuthOk { user_id }) => {
                 tracing::info!(user_id = %user_id, "Authenticated successfully");
+                // The token that just proved itself is the SNAPSHOT this
+                // connection authenticated with — not the current shared value
+                // (a renewal during the handshake may have swapped in a newer,
+                // unproven token). Persist exactly what was proven — but only
+                // for MOI tokens, and never REGRESS the file over a token with
+                // a later expiry (the renewal task owns forward progress).
+                // The token that just proved itself is the SNAPSHOT this
+                // connection authenticated with. The manager applies the
+                // generation rule and owns any persistence retry.
+                config.token_manager.mark_proven(&token_snapshot).await;
             }
             Ok(EdgeServerMessage::AuthError { message }) => {
                 tracing::error!(
@@ -1186,6 +1289,9 @@ async fn main() {
     eprintln!("  workspace: {}", config.workspace_dir.display());
     eprintln!();
 
+    // Background self-renewal of moi-user-token-v1 edge-registration tokens.
+    token_renewal::spawn_renewal_task(config.token_manager.clone());
+
     let mut exit_with_error = false;
     let mut reconnect_delay_secs: u64 = 1;
     let max_reconnect_delay_secs: u64 = 60;
@@ -1208,6 +1314,17 @@ async fn main() {
             }
             Err(e) => {
                 if is_permanent_connection_error(e.as_ref()) {
+                    // The chosen startup token may be revoked (e.g. a renewal
+                    // rotated it away but the persist was lost). Before giving
+                    // up, try the other startup candidate once.
+                    if config.token_manager.swap_to_fallback().await {
+                        tracing::warn!(
+                            error = %e,
+                            "Authentication failed with the selected token — retrying with the alternate startup token"
+                        );
+                        reconnect_delay_secs = 1;
+                        continue;
+                    }
                     tracing::error!(
                         error = %e,
                         "Permanent authentication failure — not retrying"

--- a/crates/astra-edge/src/token_manager.rs
+++ b/crates/astra-edge/src/token_manager.rs
@@ -1,0 +1,520 @@
+//! Single owner of the edge token state machine.
+//!
+//! Four things used to race each other across scattered CAS patches and
+//! guards: the in-memory token, the persisted token file, the one-shot
+//! startup fallback candidate, and in-flight renewal responses. Review rounds
+//! 8–11 each found another interleaving. This module ends that class of bug
+//! structurally: **every transition happens under ONE async mutex**, so the
+//! invariants below hold by construction instead of by per-call-site
+//! vigilance.
+//!
+//! Invariants (all enforced inside the lock):
+//!   1. `current` only changes via: startup selection, a renewal whose
+//!      request snapshot still equals `current` (stale responses are
+//!      discarded), or a one-shot fallback swap after a permanent auth
+//!      failure.
+//!   2. The token FILE never regresses **within this process**: renewal and
+//!      retry writes carry `current`; heal-writes (AuthOk) carry the proven
+//!      connection snapshot, gated by the generation rule
+//!      ([`should_persist_proven`]) so a stale snapshot can never overwrite a
+//!      strictly newer persisted token.
+//!   3. A failed file write marks the state dirty; the dirty flag can never
+//!      be lost to a concurrent transition because clearing it happens in the
+//!      same critical section that re-reads `current` and writes the file.
+//!   4. Non-MOI explicit credentials never mix with the MOI token file
+//!      (enforced at startup selection in `resolve_config` and by the
+//!      generation rule).
+//!
+//! Known limitation (documented, accepted): the guarantees are
+//! **single-process**. Two processes sharing a workspace (rolling restart
+//! overlap) cannot regress each other's atomic writes ([`write_token_atomic`]
+//! uses unique temp names + rename), but the read-check-write in
+//! [`TokenManager::mark_proven`] is not cross-process atomic, so a
+//! transiently stale write can win the rename race; the next successful
+//! authentication heals it. A cross-process flock is the upgrade path if
+//! overlapping runs become a supported topology.
+//!
+//! File IO runs synchronously inside the async mutex — a deliberate tradeoff:
+//! writes are tiny and rare, the critical section has no nested locks and no
+//! external awaits (verified: no deadlock), and it is exactly what makes the
+//! read-check-write sequences atomic in-process. Revisit with spawn_blocking
+//! only if slow volumes show up in practice.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::token_renewal::{
+    read_valid_file_token, should_persist_proven, token_file_needs_permission_repair,
+    write_token_atomic,
+};
+
+/// Result of applying a renewal response.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RenewApply {
+    /// Installed as the current token and persisted.
+    Applied,
+    /// Installed as the current token, but the file write failed — the state
+    /// is dirty and the caller should schedule fast persistence retries.
+    AppliedUnpersisted,
+    /// The shared token changed while the renewal was in flight (fallback
+    /// swap or another writer). The response was discarded; renew again from
+    /// the new current token.
+    Discarded,
+}
+
+struct TokenState {
+    current: String,
+    /// One-shot alternate startup credential (same identity domain). Consumed
+    /// by the first permanent auth failure.
+    fallback: Option<String>,
+    /// The token file is behind `current` (a write failed). Persistence
+    /// retries clear this in the same critical section that writes the file.
+    dirty: bool,
+}
+
+/// Single owner of the edge token: memory value, token file, fallback
+/// candidate and persistence debt all live behind one lock.
+pub struct TokenManager {
+    state: tokio::sync::Mutex<TokenState>,
+    token_file: PathBuf,
+    /// Wakes the persistence-retry consumer when the state becomes dirty.
+    persist_notify: tokio::sync::Notify,
+}
+
+impl std::fmt::Debug for TokenManager {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TokenManager")
+            .field("token_file", &self.token_file)
+            .finish()
+    }
+}
+
+impl TokenManager {
+    pub fn new(initial: String, fallback: Option<String>, token_file: PathBuf) -> Arc<Self> {
+        Arc::new(Self {
+            state: tokio::sync::Mutex::new(TokenState {
+                current: initial,
+                fallback,
+                dirty: false,
+            }),
+            token_file,
+            persist_notify: tokio::sync::Notify::new(),
+        })
+    }
+
+    /// The token to use for a new connection attempt / renewal request.
+    pub async fn snapshot(&self) -> String {
+        self.state.lock().await.current.clone()
+    }
+
+    /// A connection authenticated successfully with `proven`. Heal the token
+    /// file when the generation rule allows it (never regress past a strictly
+    /// newer persisted token; ties go to the proven token; non-MOI tokens
+    /// never touch the file). When the file already contains exactly `proven`,
+    /// rewrite it if needed to enforce private credential-file permissions.
+    pub async fn mark_proven(&self, proven: &str) {
+        let mut state = self.state.lock().await;
+        // Expired file tokens are treated as absent: a dead token must not win
+        // the generation comparison against a token that just proved itself.
+        let now_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let existing = read_valid_file_token(&self.token_file, now_unix);
+        let repair_permissions = existing.as_deref() == Some(proven)
+            && token_file_needs_permission_repair(&self.token_file);
+        if !repair_permissions && !should_persist_proven(existing.as_deref(), proven) {
+            return;
+        }
+        match write_token_atomic(&self.token_file, proven) {
+            Ok(()) => {
+                // The file now holds `proven`; when that IS the current token,
+                // any outstanding debt has just been settled by this write.
+                if state.current == proven {
+                    state.dirty = false;
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "astra.edge",
+                    path = %self.token_file.display(),
+                    error = %error,
+                    "failed to persist proven-good edge token — persistence retry scheduled"
+                );
+                // Only mark dirty when the proven token IS the current one:
+                // retries always write `current`, and overwriting the file
+                // with a stale proven snapshot via the retry path would
+                // regress it.
+                if state.current == proven {
+                    state.dirty = true;
+                    self.persist_notify.notify_one();
+                }
+            }
+        }
+    }
+
+    /// Apply a renewal response that was requested with `requested_with`.
+    /// Discarded (without side effects) when the current token changed while
+    /// the request was in flight — the concurrent switch wins.
+    pub async fn apply_renewed(&self, requested_with: &str, new_token: String) -> RenewApply {
+        let mut state = self.state.lock().await;
+        if state.current != requested_with {
+            return RenewApply::Discarded;
+        }
+        state.current = new_token;
+        if let Err(error) = write_token_atomic(&self.token_file, &state.current) {
+            tracing::warn!(
+                target: "astra.edge",
+                path = %self.token_file.display(),
+                error = %error,
+                "failed to persist renewed edge token — persistence retry scheduled"
+            );
+            state.dirty = true;
+            self.persist_notify.notify_one();
+            return RenewApply::AppliedUnpersisted;
+        }
+        state.dirty = false;
+        RenewApply::Applied
+    }
+
+    /// Swap to the one-shot fallback credential after a permanent auth
+    /// failure. Returns false when no fallback is available (caller gives up).
+    /// The fallback is not persisted here: it must prove itself first
+    /// (`mark_proven` on its first successful authentication).
+    pub async fn swap_to_fallback(&self) -> bool {
+        let mut state = self.state.lock().await;
+        match state.fallback.take() {
+            Some(fallback) => {
+                state.current = fallback;
+                // The file intentionally keeps the previous credential until
+                // the fallback proves itself. Dropping any outstanding debt is
+                // deliberate: retrying would persist the UNPROVEN fallback,
+                // and the failed previous current is not worth writing either.
+                state.dirty = false;
+                // Wake the renewal loop: the fallback is by definition the
+                // older startup candidate and may be close to expiry — it
+                // must not wait out the 6h check interval (M2, round 12).
+                self.persist_notify.notify_one();
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Attempt to clear persistence debt: re-reads `current` and writes it in
+    /// the SAME critical section, so a token switched in after a previous
+    /// failed write can never be skipped. Returns true when the state is
+    /// clean afterwards.
+    pub async fn retry_persist(&self) -> bool {
+        let mut state = self.state.lock().await;
+        if !state.dirty {
+            return true;
+        }
+        match write_token_atomic(&self.token_file, &state.current) {
+            Ok(()) => {
+                state.dirty = false;
+                tracing::info!(
+                    target: "astra.edge",
+                    path = %self.token_file.display(),
+                    "edge token persistence recovered"
+                );
+                true
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "astra.edge",
+                    path = %self.token_file.display(),
+                    error = %error,
+                    "retry of edge token persistence failed"
+                );
+                false
+            }
+        }
+    }
+
+    /// Await a persistence-debt wakeup (used by the retry consumers).
+    pub async fn persist_debt_notified(&self) {
+        self.persist_notify.notified().await;
+    }
+
+    /// Whether the token file is currently behind memory.
+    pub async fn persist_pending(&self) -> bool {
+        self.state.lock().await.dirty
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Synthetic tokens use a far-future epoch base so the real-clock expiry
+    /// check in mark_proven never treats them as dead.
+    const TEST_EPOCH_BASE: i64 = 4_000_000_000;
+
+    fn make_moi_token(iat: i64, exp: i64, jti: &str) -> String {
+        use base64::Engine as _;
+        let claims = serde_json::json!({
+            "iat": TEST_EPOCH_BASE + iat,
+            "exp": TEST_EPOCH_BASE + exp,
+            "jti": jti,
+        });
+        let encoded =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims.to_string().as_bytes());
+        format!("moi-user-token-v1.{encoded}.sig")
+    }
+
+    fn temp_token_path(tag: &str) -> PathBuf {
+        std::env::temp_dir()
+            .join(format!(
+                "astra-edge-token-manager-{tag}-{}-{:x}",
+                std::process::id(),
+                fastrand::u64(..)
+            ))
+            .join("token")
+    }
+
+    #[tokio::test]
+    async fn stale_renewal_response_is_discarded() {
+        let a = make_moi_token(100, 200, "A");
+        let b = make_moi_token(100, 200, "B");
+        let c = make_moi_token(101, 201, "C");
+        let manager = TokenManager::new(a.clone(), Some(b.clone()), temp_token_path("stale"));
+
+        // Renewal was requested with A; a fallback swap to B raced in.
+        assert!(manager.swap_to_fallback().await);
+        assert_eq!(manager.snapshot().await, b);
+        assert_eq!(manager.apply_renewed(&a, c).await, RenewApply::Discarded);
+        assert_eq!(
+            manager.snapshot().await,
+            b,
+            "the concurrent switch must win"
+        );
+    }
+
+    #[tokio::test]
+    async fn renewal_applies_and_persists_when_snapshot_matches() {
+        let a = make_moi_token(100, 200, "A");
+        let c = make_moi_token(101, 201, "C");
+        let path = temp_token_path("apply");
+        let manager = TokenManager::new(a.clone(), None, path.clone());
+
+        assert_eq!(
+            manager.apply_renewed(&a, c.clone()).await,
+            RenewApply::Applied
+        );
+        assert_eq!(manager.snapshot().await, c);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), c);
+        assert!(!manager.persist_pending().await);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn dirty_state_persists_the_latest_current_not_the_failed_one() {
+        // The round-10 lost-update scenario, now structurally impossible:
+        // a failed write marks dirty; before the retry runs, the current
+        // token changes again; the retry writes the LATEST current because
+        // read + write + clear share one critical section.
+        let a = make_moi_token(100, 200, "A");
+        let c = make_moi_token(101, 201, "C");
+        let d = make_moi_token(102, 202, "D");
+        let path = temp_token_path("dirty");
+        let manager = TokenManager::new(a.clone(), None, path.clone());
+
+        // Force a failed write by making the target's PARENT a file.
+        let parent = path.parent().unwrap().to_path_buf();
+        std::fs::create_dir_all(parent.parent().unwrap()).unwrap();
+        std::fs::write(&parent, "not a dir").unwrap();
+        assert_eq!(
+            manager.apply_renewed(&a, c.clone()).await,
+            RenewApply::AppliedUnpersisted
+        );
+        assert!(manager.persist_pending().await);
+
+        // Memory moves on to D while the debt is outstanding.
+        assert_eq!(
+            manager.apply_renewed(&c, d.clone()).await,
+            RenewApply::AppliedUnpersisted
+        );
+
+        // Unblock the filesystem; the retry must write D (latest), not C.
+        std::fs::remove_file(&parent).unwrap();
+        assert!(manager.retry_persist().await);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), d);
+        assert!(!manager.persist_pending().await);
+        let _ = std::fs::remove_dir_all(parent);
+    }
+
+    #[tokio::test]
+    async fn proven_heal_respects_generation_rule() {
+        let old = make_moi_token(100, 200, "A");
+        let newer = make_moi_token(101, 201, "B");
+        let path = temp_token_path("proven");
+        let manager = TokenManager::new(old.clone(), None, path.clone());
+
+        // File holds a STRICTLY newer token (renewal forward progress): a
+        // proven-but-older snapshot must not regress it.
+        write_token_atomic(&path, &newer).unwrap();
+        manager.mark_proven(&old).await;
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), newer);
+
+        // Same-generation sibling (double-renew): the proven token wins.
+        let sibling = make_moi_token(101, 201, "B2");
+        manager.mark_proven(&sibling).await;
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), sibling);
+
+        // Non-MOI tokens never touch the file.
+        manager.mark_proven("plain-astra-token").await;
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), sibling);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn proven_token_repairs_insecure_existing_file_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let token = make_moi_token(100, 200, "A");
+        let path = temp_token_path("permissions");
+        write_token_atomic(&path, &token).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let manager = TokenManager::new(token.clone(), None, path.clone());
+
+        manager.mark_proven(&token).await;
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), token);
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+        assert!(!manager.persist_pending().await);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn stale_proven_write_failure_must_not_arm_the_retry_path() {
+        // proven != current: a heal-write failure must NOT set dirty, because
+        // the retry path writes `current` — arming it from a stale proven
+        // snapshot would be pointless (and confusing in logs).
+        let a = make_moi_token(100, 200, "A");
+        let c = make_moi_token(101, 201, "C");
+        let path = temp_token_path("stale-proven");
+        // Block writes: parent is a file.
+        let parent = path.parent().unwrap().to_path_buf();
+        std::fs::create_dir_all(parent.parent().unwrap()).unwrap();
+        std::fs::write(&parent, "not a dir").unwrap();
+        let manager = TokenManager::new(c.clone(), None, path.clone());
+
+        manager.mark_proven(&a).await; // proven A, current C, write fails
+        assert!(
+            !manager.persist_pending().await,
+            "stale proven must not arm dirty"
+        );
+        let _ = std::fs::remove_file(&parent);
+    }
+
+    #[tokio::test]
+    async fn fallback_swap_drops_outstanding_debt_by_design() {
+        // An unpersisted current that just failed authentication is not worth
+        // persisting, and the unproven fallback must not be persisted either:
+        // the swap clears the debt and the file keeps the last persisted
+        // value until the fallback proves itself via mark_proven.
+        let a = make_moi_token(100, 200, "A");
+        let b = make_moi_token(99, 199, "B");
+        let c = make_moi_token(101, 201, "C");
+        let path = temp_token_path("swap-debt");
+        let parent = path.parent().unwrap().to_path_buf();
+        std::fs::create_dir_all(parent.parent().unwrap()).unwrap();
+        std::fs::write(&parent, "not a dir").unwrap();
+        let manager = TokenManager::new(a.clone(), Some(b.clone()), path.clone());
+
+        assert_eq!(
+            manager.apply_renewed(&a, c).await,
+            RenewApply::AppliedUnpersisted
+        );
+        assert!(manager.persist_pending().await);
+        assert!(manager.swap_to_fallback().await);
+        assert!(
+            !manager.persist_pending().await,
+            "swap must drop the stale debt"
+        );
+        assert_eq!(manager.snapshot().await, b);
+        let _ = std::fs::remove_file(&parent);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_mixed_operations_preserve_invariants() {
+        // True-concurrency smoke test: renewal chains, proven heals and
+        // persistence retries race across tasks. Afterwards the state must be
+        // internally consistent: clean state ⇒ the file holds exactly the
+        // current token.
+        let base = make_moi_token(100, 200, "gen-0");
+        let path = temp_token_path("stress");
+        let manager = TokenManager::new(base.clone(), None, path.clone());
+
+        let mut handles = Vec::new();
+        // Renewal chain: each task renews from whatever snapshot it sees.
+        // Generations are globally monotonic (like real renewals, where the
+        // backend always signs now+TTL > the source token's iat/exp).
+        let generation = Arc::new(std::sync::atomic::AtomicI64::new(101));
+        for round in 0..4u32 {
+            let manager = Arc::clone(&manager);
+            let generation = Arc::clone(&generation);
+            handles.push(tokio::spawn(async move {
+                for step in 0..25u32 {
+                    let snapshot = manager.snapshot().await;
+                    let iat = generation.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let next = make_moi_token(iat, iat + 100, &format!("gen-{round}-{step}"));
+                    let _ = manager.apply_renewed(&snapshot, next).await;
+                }
+            }));
+        }
+        // Heal writers racing with renewals.
+        for _ in 0..2 {
+            let manager = Arc::clone(&manager);
+            handles.push(tokio::spawn(async move {
+                for _ in 0..25 {
+                    let snapshot = manager.snapshot().await;
+                    manager.mark_proven(&snapshot).await;
+                }
+            }));
+        }
+        // Retry consumer.
+        {
+            let manager = Arc::clone(&manager);
+            handles.push(tokio::spawn(async move {
+                for _ in 0..50 {
+                    let _ = manager.retry_persist().await;
+                    tokio::task::yield_now().await;
+                }
+            }));
+        }
+        for handle in handles {
+            handle.await.expect("task panicked");
+        }
+        // Converge and verify: clean ⇒ file == current.
+        assert!(manager.retry_persist().await);
+        let current = manager.snapshot().await;
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("token file"),
+            current,
+            "clean state must mean the file holds the current token"
+        );
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn fallback_is_one_shot_and_unpersisted_until_proven() {
+        let a = make_moi_token(100, 200, "A");
+        let b = make_moi_token(99, 199, "B");
+        let path = temp_token_path("fallback");
+        write_token_atomic(&path, &a).unwrap();
+        let manager = TokenManager::new(a.clone(), Some(b.clone()), path.clone());
+
+        assert!(manager.swap_to_fallback().await);
+        assert_eq!(manager.snapshot().await, b);
+        // File still holds A until B proves itself.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), a);
+        // Second failure: no more candidates.
+        assert!(!manager.swap_to_fallback().await);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+}

--- a/crates/astra-edge/src/token_manager.rs
+++ b/crates/astra-edge/src/token_manager.rs
@@ -254,10 +254,15 @@ mod tests {
 
     fn make_moi_token(iat: i64, exp: i64, jti: &str) -> String {
         use base64::Engine as _;
+        // sub/workspace_id are required for a token the server (and now
+        // read_valid_file_token) would accept. All tokens here share one
+        // identity, so same-identity generation ordering still applies.
         let claims = serde_json::json!({
             "iat": TEST_EPOCH_BASE + iat,
             "exp": TEST_EPOCH_BASE + exp,
             "jti": jti,
+            "sub": "user-1",
+            "workspace_id": "workspace-1",
         });
         let encoded =
             base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims.to_string().as_bytes());

--- a/crates/astra-edge/src/token_renewal.rs
+++ b/crates/astra-edge/src/token_renewal.rs
@@ -1,0 +1,939 @@
+//! Edge-token self-renewal for `moi-user-token-v1` registration tokens.
+//!
+//! Long-lived sandboxes authenticate with a 30-day edge-registration token.
+//! This module renews the token before expiry against the backend endpoint
+//! configured via `ASTRA_TOKEN_RENEW_URL`, persists the renewed token to a
+//! token file (`ASTRA_TOKEN_FILE`, default `<workspace>/.astra/token`), and
+//! updates the shared in-process token so reconnects pick it up.
+//!
+//! No signature verification is performed — the edge does not hold the
+//! signing key; claims are parsed only to learn the expiry.
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Prefix identifying an edge-registration token: `moi-user-token-v1.<claims>.<sig>`.
+pub const MOI_TOKEN_PREFIX: &str = "moi-user-token-v1.";
+
+const CHECK_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+const STARTUP_DELAY: Duration = Duration::from_secs(30);
+const DEFAULT_RENEW_THRESHOLD_SECS: i64 = 7 * 24 * 60 * 60;
+/// Upper bound for the configurable renewal threshold. Caps pathological values
+/// (e.g. i64::MAX) that would otherwise overflow the exp-based scheduling math.
+const MAX_RENEW_THRESHOLD_SECS: i64 = 30 * 24 * 60 * 60;
+const RENEW_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+/// Fast-retry schedule after a transient renewal failure. Must fit inside the
+/// backend's rotation grace window (5 minutes) so a lost rotation response can
+/// recover via the previous-jti renewal path.
+const TRANSIENT_RETRY_SECS: &[u64] = &[30, 60, 120];
+
+/// Claims embedded in the middle segment of a `moi-user-token-v1` token.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct TokenClaims {
+    pub exp: i64,
+    #[serde(default)]
+    pub iat: i64,
+    #[serde(default)]
+    pub jti: Option<String>,
+    #[serde(default)]
+    pub sub: String,
+    #[serde(default)]
+    pub workspace_id: String,
+    #[serde(default)]
+    pub iss: String,
+    #[serde(default)]
+    pub edge_agent_id: String,
+    #[serde(default)]
+    pub purpose: String,
+}
+
+/// Parse the claims of a `moi-user-token-v1.<claims>.<sig>` token.
+///
+/// Returns `None` for non-moi tokens or malformed claims ("expiry unknown").
+pub fn parse_moi_token_claims(token: &str) -> Option<TokenClaims> {
+    use base64::Engine as _;
+    let rest = token.strip_prefix(MOI_TOKEN_PREFIX)?;
+    let (claims_b64, signature) = rest.split_once('.')?;
+    if claims_b64.is_empty() || signature.is_empty() {
+        return None;
+    }
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(claims_b64)
+        .ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Decide whether an authentication-PROVEN token should overwrite the token
+/// file. Skip only when the file already holds the proven token itself, or a
+/// STRICTLY newer generation (by iat, then exp). Anything else — including a
+/// different jti with the SAME iat/exp, which double-renew / grace recovery
+/// can legitimately produce — is overwritten: expiry seconds do not order
+/// generations, but an AuthOk is hard proof the token works.
+pub fn should_persist_proven(existing: Option<&str>, proven: &str) -> bool {
+    let Some(proven_claims) = parse_moi_token_claims(proven) else {
+        // Non-MOI tokens never touch the MOI token file.
+        return false;
+    };
+    let Some(existing) = existing else {
+        return true;
+    };
+    if existing == proven {
+        return false;
+    }
+    let Some(existing_claims) = parse_moi_token_claims(existing) else {
+        return true;
+    };
+    let existing_gen = (existing_claims.iat, existing_claims.exp);
+    let proven_gen = (proven_claims.iat, proven_claims.exp);
+    // Strictly newer file wins (renewal owns forward progress); ties go to
+    // the PROVEN token — a same-generation sibling in the file may be the
+    // superseded jti of a double renew and would brick the next restart.
+    existing_gen <= proven_gen
+}
+
+/// Whether the token's remaining lifetime is below the renewal threshold.
+pub fn should_renew(claims: &TokenClaims, now_unix: i64, threshold_secs: i64) -> bool {
+    // saturating_sub: abnormal claims (huge/negative exp) must not overflow-panic
+    // in debug or wrap in release.
+    claims.exp.saturating_sub(now_unix) < threshold_secs
+}
+
+fn now_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Purpose claim of an edge-registration token; the server requires a non-empty
+/// jti for tokens carrying it.
+const EDGE_REGISTRATION_PURPOSE: &str = "edge_registration";
+
+/// Structural check mirroring the server's `verify_user_token`: a moi-user token
+/// must be exactly `moi-user-token-v1.<claims>.<sig>` — three dot-separated
+/// segments, no more. The lenient `parse_moi_token_claims` accepts extra
+/// trailing segments, so the renewal decision re-checks here to avoid persisting
+/// a token the server would reject as malformed.
+fn is_wellformed_moi_token(token: &str) -> bool {
+    let expected_prefix = MOI_TOKEN_PREFIX.trim_end_matches('.');
+    let mut parts = token.split('.');
+    matches!(
+        (parts.next(), parts.next(), parts.next(), parts.next()),
+        (Some(prefix), Some(claims), Some(sig), None)
+            if prefix == expected_prefix && !claims.is_empty() && !sig.is_empty()
+    )
+}
+
+fn parse_usable_renewed_token(
+    token: &str,
+    current_token: &str,
+    current: &TokenClaims,
+    now_unix: i64,
+) -> Option<TokenClaims> {
+    parse_moi_token_claims(token).filter(|renewed| {
+        token != current_token
+            && renewed.exp > now_unix
+            && (renewed.iat, renewed.exp) >= (current.iat, current.exp)
+            && renewed.sub == current.sub
+            && renewed.workspace_id == current.workspace_id
+            && renewed.iss == current.iss
+            && renewed.edge_agent_id == current.edge_agent_id
+            && renewed.purpose == current.purpose
+            // Match the server's acceptance rules before overwriting the persisted
+            // identity: an exactly-three-segment token, and (for edge-registration
+            // tokens) a non-empty jti. A token that passes the generation/identity
+            // checks but the server would reject would brick the edge on restart.
+            && is_wellformed_moi_token(token)
+            && (renewed.purpose != EDGE_REGISTRATION_PURPOSE
+                || renewed.jti.as_deref().is_some_and(|jti| !jti.is_empty()))
+    })
+}
+
+/// True when two parsed moi-user-token claims share the SAME identity
+/// (user + workspace + edge agent + issuer + purpose). Generation ordering via
+/// (iat, exp) is only meaningful between same-identity tokens; a token of a
+/// different identity must never override or become a fallback for another
+/// (e.g. a reused workspace volume holding a previous tenant's token).
+pub fn same_moi_identity(a: &TokenClaims, b: &TokenClaims) -> bool {
+    a.sub == b.sub
+        && a.workspace_id == b.workspace_id
+        && a.iss == b.iss
+        && a.edge_agent_id == b.edge_agent_id
+        && a.purpose == b.purpose
+}
+
+fn renew_threshold_secs() -> i64 {
+    std::env::var("ASTRA_TOKEN_RENEW_THRESHOLD_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<i64>().ok())
+        .filter(|v| *v > 0)
+        .map(|v| v.min(MAX_RENEW_THRESHOLD_SECS))
+        .unwrap_or(DEFAULT_RENEW_THRESHOLD_SECS)
+}
+
+// ─── Token file persistence ──────────────────────────────────────────────────
+
+/// Token file path: `ASTRA_TOKEN_FILE` env override, else `<workspace>/.astra/token`.
+pub fn resolve_token_file_path(workspace_dir: &Path) -> PathBuf {
+    match std::env::var("ASTRA_TOKEN_FILE") {
+        Ok(value) if !value.trim().is_empty() => PathBuf::from(value),
+        _ => workspace_dir.join(".astra").join("token"),
+    }
+}
+
+/// Read the token file and return its token only if it is a `moi-user-token-v1`
+/// token with parseable claims that have not expired.
+pub fn read_valid_file_token(path: &Path, now_unix: i64) -> Option<String> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let token = contents.trim();
+    if token.is_empty() {
+        return None;
+    }
+    let claims = parse_moi_token_claims(token)?;
+    if claims.exp <= now_unix {
+        return None;
+    }
+    Some(token.to_string())
+}
+
+/// Returns true when an existing token path should be atomically replaced to
+/// enforce the Unix credential-file invariant: a regular file with mode 0600.
+///
+/// `symlink_metadata` deliberately does not follow symlinks. Replacing a
+/// symlink through [`write_token_atomic`] publishes a private regular file at
+/// the configured path instead of changing permissions on the symlink target.
+#[cfg(unix)]
+pub(crate) fn token_file_needs_permission_repair(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return false;
+    };
+    metadata.file_type().is_symlink() || metadata.permissions().mode() & 0o777 != 0o600
+}
+
+#[cfg(not(unix))]
+pub(crate) fn token_file_needs_permission_repair(_path: &Path) -> bool {
+    false
+}
+
+/// Atomically write the token: parent dir created, unique same-directory temp
+/// file + rename, permissions 0600 on unix.
+///
+/// The temp file uses a collision-resistant random sibling name so two
+/// edge/renew processes sharing a workspace (rolling restarts, double-run)
+/// cannot delete or rename each other's in-flight file; the final replace is
+/// atomic, so the published file is always one writer's complete token.
+pub fn write_token_atomic(path: &Path, token: &str) -> std::io::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("token");
+    let mut staged = tempfile::Builder::new()
+        .prefix(&format!(".{file_name}."))
+        .suffix(".tmp")
+        .tempfile_in(parent)?;
+    {
+        use std::io::Write as _;
+        staged.write_all(token.as_bytes())?;
+        staged.as_file_mut().sync_all()?;
+    }
+    // NamedTempFile::persist uses an overwrite-capable atomic replace on
+    // Windows (MoveFileExW + MOVEFILE_REPLACE_EXISTING) and rename on Unix.
+    // A failed persist retains and then removes the staged file on drop.
+    staged
+        .persist(path)
+        .map(|_| ())
+        .map_err(|error| error.error)
+}
+
+// ─── Renewal HTTP call ───────────────────────────────────────────────────────
+
+enum RenewOutcome {
+    Renewed {
+        token: String,
+        expires_at: Option<String>,
+    },
+    /// HTTP 401 — token rejected; keep the current token.
+    Rejected,
+    /// Transport error / 503 / unexpected response — retry next cycle.
+    Transient(String),
+}
+
+async fn renew_once(client: &reqwest::Client, url: &str, current_token: &str) -> RenewOutcome {
+    let response = match client
+        .post(url)
+        .json(&serde_json::json!({ "token": current_token }))
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => return RenewOutcome::Transient(format!("request failed: {error}")),
+    };
+    let status = response.status();
+    if status.as_u16() == 401 {
+        return RenewOutcome::Rejected;
+    }
+    if !status.is_success() {
+        return RenewOutcome::Transient(format!("unexpected status {status}"));
+    }
+    let body: serde_json::Value = match response.json().await {
+        Ok(body) => body,
+        Err(error) => return RenewOutcome::Transient(format!("invalid JSON body: {error}")),
+    };
+    // Defensive parse: prefer data.token, fall back to top-level token.
+    let token = body
+        .pointer("/data/token")
+        .and_then(|v| v.as_str())
+        .or_else(|| body.get("token").and_then(|v| v.as_str()));
+    match token {
+        Some(token) if !token.trim().is_empty() => RenewOutcome::Renewed {
+            token: token.trim().to_string(),
+            expires_at: body
+                .pointer("/data/expires_at")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        },
+        _ => RenewOutcome::Transient("response body contains no token".to_string()),
+    }
+}
+
+/// True when the renewal URL is safe to POST the edge token to: HTTPS for any
+/// remote host, HTTP allowed only for loopback (local dev). Unparseable URLs
+/// are rejected.
+fn renew_url_scheme_ok(url: &str) -> bool {
+    match reqwest::Url::parse(url) {
+        // HTTPS to anywhere, or plain HTTP only to a loopback host. Any other
+        // scheme (ftp://localhost, ws://…) is rejected — url_is_loopback alone
+        // ignores the scheme.
+        Ok(parsed) => {
+            parsed.scheme() == "https"
+                || (parsed.scheme() == "http" && astra_core::net::url_is_loopback(url))
+        }
+        Err(_) => false,
+    }
+}
+
+// ─── Renewal loop ────────────────────────────────────────────────────────────
+
+/// Spawn the background renewal task. Call once at startup, at the same
+/// supervision level as the main connection loop.
+///
+/// `manager` owns the token state machine: renewal reads its snapshot,
+/// applies responses through it (stale responses are discarded) and relies on
+/// it for persistence-debt bookkeeping.
+pub fn spawn_renewal_task(manager: Arc<crate::token_manager::TokenManager>) {
+    let renew_url = match std::env::var("ASTRA_TOKEN_RENEW_URL") {
+        Ok(url) if !url.trim().is_empty() => url.trim().to_string(),
+        _ => {
+            tracing::info!(
+                target: "astra.edge",
+                "ASTRA_TOKEN_RENEW_URL not set — edge token renewal disabled"
+            );
+            // Renewal is off, but persistence debt (AuthOk heal-write
+            // failures) still needs a consumer — run a minimal retry loop so
+            // the dirty flag always has an owner.
+            tokio::spawn(async move {
+                loop {
+                    manager.persist_debt_notified().await;
+                    while !manager.retry_persist().await {
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                    }
+                }
+            });
+            return;
+        }
+    };
+    // Never send the long-lived edge token over plaintext to a remote host.
+    // Require HTTPS for remote URLs (loopback may use HTTP for local dev).
+    if !renew_url_scheme_ok(&renew_url) {
+        tracing::error!(
+            target: "astra.edge",
+            url = %renew_url,
+            "ASTRA_TOKEN_RENEW_URL must be HTTPS for remote hosts (loopback HTTP allowed) — \
+             refusing to send the edge token over plaintext; renewal disabled"
+        );
+        tokio::spawn(async move {
+            loop {
+                manager.persist_debt_notified().await;
+                while !manager.retry_persist().await {
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                }
+            }
+        });
+        return;
+    }
+    let threshold_secs = renew_threshold_secs();
+    tokio::spawn(async move {
+        let client = match astra_core::net::client_builder_for_target(&renew_url)
+            .timeout(RENEW_HTTP_TIMEOUT)
+            // Disallow redirects: a 307/308 must never forward the POST body
+            // (which carries the token) to a different origin.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+        {
+            Ok(client) => client,
+            Err(error) => {
+                tracing::warn!(
+                    target: "astra.edge",
+                    error = %error,
+                    "failed to build HTTP client — edge token renewal disabled; \
+                     keeping persistence-only retry loop"
+                );
+                // Renewal is off, but later mark_proven() writes can still fail
+                // and set the dirty flag. Own the debt permanently like the
+                // unconfigured-URL branch — waiting on each notification —
+                // instead of draining once and exiting.
+                loop {
+                    manager.persist_debt_notified().await;
+                    while !manager.retry_persist().await {
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                    }
+                }
+            }
+        };
+        let mut warned_malformed = false;
+        let mut warned_expired = false;
+        // Only delay startup for a healthy token. A token already inside the
+        // renewal window (or with < STARTUP_DELAY remaining) must be processed
+        // immediately or it could expire before the first pass. Unparseable
+        // tokens also skip the delay (the first cycle just warns).
+        let delay_startup = parse_moi_token_claims(&manager.snapshot().await)
+            .map(|c| !should_renew(&c, now_unix(), threshold_secs))
+            .unwrap_or(false);
+        if delay_startup {
+            tokio::time::sleep(STARTUP_DELAY).await;
+        }
+        loop {
+            // A transient transport failure may mean the backend already
+            // rotated the jti and the response was lost. The backend keeps the
+            // old jti renewable for a short grace window (dual-valid rotation),
+            // so retry quickly with backoff instead of waiting CHECK_INTERVAL —
+            // the fast retries are what make the recovery path reachable.
+            let mut transient_backoff = TRANSIENT_RETRY_SECS.iter();
+            let mut rejected = false;
+            loop {
+                let transient = renewal_cycle(
+                    &client,
+                    &renew_url,
+                    threshold_secs,
+                    &manager,
+                    &mut warned_malformed,
+                    &mut warned_expired,
+                    &mut rejected,
+                )
+                .await;
+                if !transient {
+                    break;
+                }
+                let Some(delay_secs) = transient_backoff.next() else {
+                    break;
+                };
+                tracing::info!(
+                    target: "astra.edge",
+                    retry_in_secs = delay_secs,
+                    "retrying edge token renewal after transient failure"
+                );
+                tokio::time::sleep(Duration::from_secs(*delay_secs)).await;
+            }
+            // Wake early when someone (renewal itself or the AuthOk heal
+            // path) records persistence debt. Outstanding debt must NEVER
+            // sleep the full check interval: the Notify permit may already be
+            // consumed, and the token file has to catch up within the
+            // backend's 5-minute rotation grace window — keep polling at 30s
+            // until the write lands (H1, review round 12).
+            let base = if manager.persist_pending().await {
+                Duration::from_secs(30)
+            } else {
+                CHECK_INTERVAL
+            };
+            let wait = if rejected {
+                // Token permanently rejected (401). Do NOT apply the exp-based
+                // cap — that would pin an in-window rejected token to a 30s hot
+                // loop forever. Wait the full interval (or 30s if we still owe a
+                // persist); a token/fallback change wakes the connection path,
+                // and persist_debt_notified() still interrupts the select below.
+                base
+            } else {
+                // Never sleep past the renewal deadline: a token with less than
+                // CHECK_INTERVAL remaining would otherwise expire before the next
+                // pass. Cap the wait at exp - threshold, floored at 30s so we
+                // don't busy-loop once inside the renew window (the next
+                // renewal_cycle then renews). saturating_sub guards abnormal
+                // claims / large thresholds from overflow.
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0);
+                let exp_bound = parse_moi_token_claims(&manager.snapshot().await)
+                    .map(|c| {
+                        let secs = c
+                            .exp
+                            .saturating_sub(threshold_secs)
+                            .saturating_sub(now)
+                            .max(0);
+                        Duration::from_secs(secs as u64)
+                    })
+                    .unwrap_or(CHECK_INTERVAL);
+                base.min(exp_bound.max(Duration::from_secs(30)))
+            };
+            tokio::select! {
+                _ = tokio::time::sleep(wait) => {}
+                _ = manager.persist_debt_notified() => {}
+            }
+        }
+    });
+}
+
+/// One renewal pass. Returns true when a fast retry is warranted (transient
+/// transport failure or outstanding persistence debt).
+async fn renewal_cycle(
+    client: &reqwest::Client,
+    renew_url: &str,
+    threshold_secs: i64,
+    manager: &crate::token_manager::TokenManager,
+    warned_malformed: &mut bool,
+    warned_expired: &mut bool,
+    rejected: &mut bool,
+) -> bool {
+    // Set on a 401: the token is permanently rejected, so the scheduler must
+    // back off to the full interval instead of hammering every 30s.
+    *rejected = false;
+    // Persistence debt first: the manager re-reads its current token and
+    // clears the flag inside one critical section, so no concurrent switch
+    // can be skipped.
+    if manager.persist_pending().await && !manager.retry_persist().await {
+        return true;
+    }
+    let current_token = manager.snapshot().await;
+    let Some(claims) = parse_moi_token_claims(&current_token) else {
+        if !*warned_malformed {
+            *warned_malformed = true;
+            tracing::warn!(
+                target: "astra.edge",
+                "current token is not a parseable moi-user-token-v1 — expiry unknown, renewal not scheduled"
+            );
+        }
+        return false;
+    };
+    *warned_malformed = false;
+    let now = now_unix();
+    if !should_renew(&claims, now, threshold_secs) {
+        tracing::debug!(
+            target: "astra.edge",
+            remaining_secs = claims.exp.saturating_sub(now),
+            threshold_secs,
+            "edge token renewal not due yet"
+        );
+        return false;
+    }
+    if claims.exp <= now && !*warned_expired {
+        *warned_expired = true;
+        tracing::warn!(
+            target: "astra.edge",
+            expired_at = claims.exp,
+            "edge token already expired at {}; renewal will be rejected — \
+             re-provision the token (delete the token file / recreate the sandbox)",
+            claims.exp
+        );
+    }
+    // Still attempt — a server 401 confirms the diagnosis.
+    match renew_once(client, renew_url, &current_token).await {
+        RenewOutcome::Renewed { token, expires_at } => {
+            // Validate before handing to the manager: must be a parseable,
+            // unexpired moi-user-token-v1 token.
+            let new_claims =
+                parse_usable_renewed_token(&token, &current_token, &claims, now_unix());
+            let Some(new_claims) = new_claims else {
+                tracing::warn!(
+                    target: "astra.edge",
+                    "renewal endpoint returned an unusable token — keeping current token"
+                );
+                // A syntactically successful response can still be a transient
+                // backend/proxy failure. Retry while the current token remains
+                // usable instead of sleeping for the six-hour check interval.
+                return true;
+            };
+            let new_jti = new_claims.jti;
+            match manager.apply_renewed(&current_token, token).await {
+                crate::token_manager::RenewApply::Discarded => {
+                    tracing::warn!(
+                        target: "astra.edge",
+                        "shared token changed while renewal was in flight — discarding renewed token"
+                    );
+                    return false;
+                }
+                crate::token_manager::RenewApply::AppliedUnpersisted => {
+                    *warned_expired = false;
+                    tracing::info!(
+                        target: "astra.edge",
+                        old_jti = claims.jti.as_deref().unwrap_or("<none>"),
+                        new_jti = new_jti.as_deref().unwrap_or("<none>"),
+                        expires_at = expires_at.as_deref().unwrap_or("<unknown>"),
+                        "edge token renewed (persistence pending)"
+                    );
+                    // File must catch up before the backend's grace sweeper
+                    // revokes the old jti — fast retries.
+                    return true;
+                }
+                crate::token_manager::RenewApply::Applied => {
+                    *warned_expired = false;
+                    tracing::info!(
+                        target: "astra.edge",
+                        old_jti = claims.jti.as_deref().unwrap_or("<none>"),
+                        new_jti = new_jti.as_deref().unwrap_or("<none>"),
+                        expires_at = expires_at.as_deref().unwrap_or("<unknown>"),
+                        "edge token renewed"
+                    );
+                }
+            }
+        }
+        RenewOutcome::Rejected => {
+            *rejected = true;
+            tracing::warn!(
+                target: "astra.edge",
+                "edge token renewal rejected (401) — keeping current token; \
+                 backing off (token/fallback must change to recover)"
+            );
+        }
+        RenewOutcome::Transient(detail) => {
+            tracing::warn!(
+                target: "astra.edge",
+                detail = %detail,
+                "edge token renewal failed transiently — fast retry scheduled"
+            );
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renew_url_scheme_ok_requires_https_or_loopback_http() {
+        assert!(renew_url_scheme_ok("https://catalog.example.com/renew"));
+        assert!(renew_url_scheme_ok("http://localhost:8081/renew"));
+        assert!(renew_url_scheme_ok("http://127.0.0.1:8081/renew"));
+        assert!(renew_url_scheme_ok("http://[::1]:8081/renew"));
+        // Remote plaintext HTTP: rejected.
+        assert!(!renew_url_scheme_ok("http://catalog.example.com/renew"));
+        // Non-http(s) schemes, even to loopback: rejected.
+        assert!(!renew_url_scheme_ok("ftp://localhost/renew"));
+        assert!(!renew_url_scheme_ok("ws://localhost/renew"));
+        assert!(!renew_url_scheme_ok("not a url"));
+    }
+
+    fn make_token(claims: &serde_json::Value) -> String {
+        use base64::Engine as _;
+        let encoded =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims.to_string().as_bytes());
+        format!("{MOI_TOKEN_PREFIX}{encoded}.sig")
+    }
+
+    #[test]
+    fn renewed_token_must_preserve_identity_and_not_regress_generation() {
+        let now = 1_000_000;
+        let current_json = serde_json::json!({
+            "iat": 100,
+            "exp": now + 60,
+            "jti": "old-jti",
+            "sub": "user-1",
+            "workspace_id": "workspace-1",
+            "iss": "moi-backend",
+            "edge_agent_id": "edge-1",
+            "purpose": "edge_registration",
+        });
+        let current_token = make_token(&current_json);
+        let current = parse_moi_token_claims(&current_token).expect("current claims parse");
+        let mut renewed_json = current_json.clone();
+        renewed_json["iat"] = serde_json::json!(101);
+        renewed_json["exp"] = serde_json::json!(now + 3600);
+        renewed_json["jti"] = serde_json::json!("new-jti");
+
+        let renewed = make_token(&renewed_json);
+        assert!(parse_usable_renewed_token(&renewed, &current_token, &current, now).is_some());
+        assert!(
+            parse_usable_renewed_token(&current_token, &current_token, &current, now).is_none()
+        );
+
+        let mut expired_json = renewed_json.clone();
+        expired_json["exp"] = serde_json::json!(now);
+        assert!(
+            parse_usable_renewed_token(&make_token(&expired_json), &current_token, &current, now)
+                .is_none()
+        );
+
+        let mut older_json = renewed_json.clone();
+        older_json["iat"] = serde_json::json!(99);
+        assert!(
+            parse_usable_renewed_token(&make_token(&older_json), &current_token, &current, now)
+                .is_none()
+        );
+
+        for field in ["sub", "workspace_id", "iss", "edge_agent_id", "purpose"] {
+            let mut changed_identity = renewed_json.clone();
+            changed_identity[field] = serde_json::json!("different");
+            assert!(
+                parse_usable_renewed_token(
+                    &make_token(&changed_identity),
+                    &current_token,
+                    &current,
+                    now
+                )
+                .is_none(),
+                "renewal must reject changed identity field {field}"
+            );
+        }
+
+        assert!(
+            parse_usable_renewed_token("not-a-valid-moi-token", &current_token, &current, now)
+                .is_none()
+        );
+    }
+
+    // The lenient claims parser accepts extra trailing segments and a missing
+    // jti, but the server rejects both. The renewal decision must not overwrite
+    // the persisted identity with such a token or the edge bricks on restart.
+    #[test]
+    fn renewal_rejects_tokens_the_server_would_refuse() {
+        let now = 1_000_000;
+        let current_json = serde_json::json!({
+            "iat": 100,
+            "exp": now + 60,
+            "jti": "old-jti",
+            "sub": "user-1",
+            "workspace_id": "workspace-1",
+            "iss": "moi-backend",
+            "edge_agent_id": "edge-1",
+            "purpose": "edge_registration",
+        });
+        let current_token = make_token(&current_json);
+        let current = parse_moi_token_claims(&current_token).expect("current claims parse");
+
+        let mut valid_json = current_json.clone();
+        valid_json["iat"] = serde_json::json!(101);
+        valid_json["exp"] = serde_json::json!(now + 3600);
+        valid_json["jti"] = serde_json::json!("new-jti");
+
+        // Sanity: the otherwise-valid renewal is accepted.
+        assert!(
+            parse_usable_renewed_token(&make_token(&valid_json), &current_token, &current, now)
+                .is_some()
+        );
+
+        // Four segments (extra dot in the signature) — server requires exactly 3.
+        let four_segment = format!("{}.extra", make_token(&valid_json));
+        assert!(
+            parse_usable_renewed_token(&four_segment, &current_token, &current, now).is_none(),
+            "renewal must reject a >3-segment token"
+        );
+
+        // Missing jti on an edge-registration token — server requires it.
+        let mut no_jti_json = valid_json.clone();
+        no_jti_json.as_object_mut().unwrap().remove("jti");
+        assert!(
+            parse_usable_renewed_token(&make_token(&no_jti_json), &current_token, &current, now)
+                .is_none(),
+            "renewal must reject an edge-registration token without jti"
+        );
+
+        // Empty jti string — also rejected.
+        let mut empty_jti_json = valid_json.clone();
+        empty_jti_json["jti"] = serde_json::json!("");
+        assert!(
+            parse_usable_renewed_token(&make_token(&empty_jti_json), &current_token, &current, now)
+                .is_none(),
+            "renewal must reject an edge-registration token with empty jti"
+        );
+    }
+
+    #[test]
+    fn write_token_atomic_concurrent_writers_publish_a_complete_token() {
+        let dir = std::env::temp_dir().join(format!(
+            "astra-edge-token-race-{}-{:x}",
+            std::process::id(),
+            fastrand::u64(..)
+        ));
+        let path = dir.join("token");
+        let tokens: Vec<String> = (0..8)
+            .map(|i| format!("token-value-{i}-{}", "x".repeat(64)))
+            .collect();
+        let mut handles = Vec::new();
+        for token in tokens.clone() {
+            let path = path.clone();
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..50 {
+                    write_token_atomic(&path, &token).expect("concurrent write must not fail");
+                }
+            }));
+        }
+        for handle in handles {
+            handle.join().expect("writer thread panicked");
+        }
+        let published = std::fs::read_to_string(&path).expect("token file must exist");
+        assert!(
+            tokens.iter().any(|t| t == &published),
+            "published file must be exactly one writer's complete token, got {} bytes",
+            published.len()
+        );
+        // No leaked temp files.
+        let leftovers: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "stale temp files left behind: {leftovers:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn should_persist_proven_generation_rules() {
+        let tok = |iat: i64, exp: i64, jti: &str| {
+            make_token(&serde_json::json!({ "iat": iat, "exp": exp, "jti": jti }))
+        };
+        let proven = tok(100, 200, "jti-A");
+        // Empty / unparseable file → persist.
+        assert!(should_persist_proven(None, &proven));
+        assert!(should_persist_proven(Some("garbage"), &proven));
+        // Identical token → no-op.
+        assert!(!should_persist_proven(Some(&proven), &proven));
+        // Different jti, SAME iat/exp (double renew sibling) → the PROVEN
+        // token must win: expiry seconds do not order generations.
+        let sibling = tok(100, 200, "jti-B");
+        assert!(should_persist_proven(Some(&sibling), &proven));
+        // Strictly newer file (renewal forward progress) → keep the file.
+        let newer = tok(101, 201, "jti-C");
+        assert!(!should_persist_proven(Some(&newer), &proven));
+        // Strictly older file → persist the proven token.
+        let older = tok(99, 199, "jti-D");
+        assert!(should_persist_proven(Some(&older), &proven));
+        // Non-MOI proven token never touches the file.
+        assert!(!should_persist_proven(None, "plain-astra-token"));
+    }
+
+    #[test]
+    fn parse_valid_claims() {
+        let token = make_token(&serde_json::json!({ "exp": 1234567890, "jti": "abc" }));
+        let claims = parse_moi_token_claims(&token).expect("parse");
+        assert_eq!(claims.exp, 1234567890);
+        assert_eq!(claims.jti.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn parse_claims_without_jti() {
+        let token = make_token(&serde_json::json!({ "exp": 42 }));
+        let claims = parse_moi_token_claims(&token).expect("parse");
+        assert_eq!(claims.exp, 42);
+        assert!(claims.jti.is_none());
+    }
+
+    #[test]
+    fn parse_rejects_malformed_tokens() {
+        assert!(parse_moi_token_claims("").is_none());
+        assert!(parse_moi_token_claims("not-a-token").is_none());
+        // JWT-style token without the moi prefix
+        assert!(parse_moi_token_claims("eyJhbGciOi.eyJleHAiOjB9.sig").is_none());
+        // Missing signature segment
+        assert!(parse_moi_token_claims("moi-user-token-v1.eyJleHAiOjB9").is_none());
+        // Invalid base64 claims
+        assert!(parse_moi_token_claims("moi-user-token-v1.!!!.sig").is_none());
+        // Claims missing exp
+        let no_exp = make_token(&serde_json::json!({ "jti": "x" }));
+        assert!(parse_moi_token_claims(&no_exp).is_none());
+    }
+
+    #[test]
+    fn should_renew_threshold_decision() {
+        let claims = TokenClaims {
+            iat: 0,
+            exp: 1_000_000,
+            jti: None,
+            ..TokenClaims::default()
+        };
+        let week = 7 * 24 * 60 * 60;
+        // 10 days remaining — not due.
+        assert!(!should_renew(&claims, 1_000_000 - 10 * 86_400, week));
+        // 3 days remaining — due.
+        assert!(should_renew(&claims, 1_000_000 - 3 * 86_400, week));
+        // Already expired — due.
+        assert!(should_renew(&claims, 1_000_000 + 1, week));
+    }
+
+    #[test]
+    fn file_token_preference_logic() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(".astra").join("token");
+        let now = 1_000_000;
+
+        // Missing file → none.
+        assert!(read_valid_file_token(&path, now).is_none());
+
+        // Valid unexpired moi token → preferred.
+        let valid = make_token(&serde_json::json!({ "exp": now + 86_400 }));
+        write_token_atomic(&path, &valid).expect("write");
+        assert_eq!(
+            read_valid_file_token(&path, now).as_deref(),
+            Some(valid.as_str())
+        );
+
+        // Expired token → rejected.
+        let expired = make_token(&serde_json::json!({ "exp": now - 1 }));
+        write_token_atomic(&path, &expired).expect("write");
+        assert!(read_valid_file_token(&path, now).is_none());
+
+        // Non-moi content → rejected.
+        write_token_atomic(&path, "some-jwt-token").expect("write");
+        assert!(read_valid_file_token(&path, now).is_none());
+
+        // Empty / whitespace file → rejected.
+        write_token_atomic(&path, "  \n").expect("write");
+        assert!(read_valid_file_token(&path, now).is_none());
+    }
+
+    #[test]
+    fn atomic_write_creates_parent_and_sets_mode() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("dir").join("token");
+        write_token_atomic(&path, "secret").expect("write");
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), "secret");
+        // No leftover tmp file.
+        assert!(!path.with_extension("tmp").exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).expect("meta").permissions().mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+
+        // A stale temp file from ANOTHER writer must not block or be touched:
+        // temp names are per-writer unique, so foreign leftovers are ignored
+        // and the write still lands atomically.
+        std::fs::write(path.with_extension("tmp"), "stale").expect("stale tmp");
+        write_token_atomic(&path, "secret2").expect("rewrite");
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), "secret2");
+        assert_eq!(
+            std::fs::read_to_string(path.with_extension("tmp")).expect("foreign tmp"),
+            "stale",
+            "another writer's temp file must be left untouched"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).expect("meta").permissions().mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+    }
+}

--- a/crates/astra-edge/src/token_renewal.rs
+++ b/crates/astra-edge/src/token_renewal.rs
@@ -253,6 +253,14 @@ pub fn resolve_token_file_path(workspace_dir: &Path) -> PathBuf {
 /// env fallback, selecting such a file would let the edge pick a token it is
 /// then permanently rejected on, so the structural/claim checks are applied here.
 pub fn read_valid_file_token(path: &Path, now_unix: i64) -> Option<String> {
+    // Credential file: it must be a regular file. Reject symlinks (which the
+    // write path treats as needing repair — see token_file_needs_permission_repair)
+    // and cap the read so a planted symlink to a huge target cannot be slurped
+    // into memory. symlink_metadata does not follow the link.
+    let metadata = std::fs::symlink_metadata(path).ok()?;
+    if !metadata.file_type().is_file() || metadata.len() > 16 * 1024 {
+        return None;
+    }
     let contents = std::fs::read_to_string(path).ok()?;
     let token = contents.trim();
     if token.is_empty() {
@@ -1102,6 +1110,32 @@ mod tests {
         // Empty / whitespace file → rejected.
         write_token_atomic(&path, "  \n").expect("write");
         assert!(read_valid_file_token(&path, now).is_none());
+    }
+
+    // A credential file must be a regular file: a symlink to an otherwise-valid
+    // token is rejected (never followed), matching the write path's treatment of
+    // symlinks as needing repair.
+    #[cfg(unix)]
+    #[test]
+    fn read_valid_file_token_rejects_symlink() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let now = 1_000_000;
+        let target = dir.path().join("real-token");
+        let valid = make_token(&serde_json::json!({
+            "exp": now + 86_400,
+            "sub": "user-1",
+            "workspace_id": "workspace-1",
+        }));
+        write_token_atomic(&target, &valid).expect("write");
+        // Through the regular file directly: accepted.
+        assert_eq!(
+            read_valid_file_token(&target, now).as_deref(),
+            Some(valid.as_str())
+        );
+        // Through a symlink to it: rejected.
+        let link = dir.path().join("token-link");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+        assert!(read_valid_file_token(&link, now).is_none());
     }
 
     #[test]

--- a/crates/astra-edge/src/token_renewal.rs
+++ b/crates/astra-edge/src/token_renewal.rs
@@ -28,6 +28,34 @@ const RENEW_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 /// backend's rotation grace window (5 minutes) so a lost rotation response can
 /// recover via the previous-jti renewal path.
 const TRANSIENT_RETRY_SECS: &[u64] = &[30, 60, 120];
+/// The backend keeps a rotated jti renewable for this long after it hands out a
+/// successor (dual-valid rotation). A lost rotation response can only be
+/// recovered by a fast retry that both BEGINS and completes within this window,
+/// measured from the first retry attempt; past it the old jti is swept and
+/// every subsequent renewal is rejected. Fast retries are budgeted against this
+/// deadline so the last attempt cannot start at or after the boundary.
+const ROTATION_GRACE_WINDOW: Duration = Duration::from_secs(5 * 60);
+
+/// Sleep to apply before the next fast retry so the attempt after it still
+/// begins — and, budgeting one `request_timeout`, completes — within the
+/// rotation grace window measured from the first attempt.
+///
+/// `elapsed` is the time since the first retry attempt began. Returns `None`
+/// once no further attempt can complete before the deadline (stop fast
+/// retrying); otherwise the requested `backoff`, clamped so the next attempt
+/// leaves a full `request_timeout` of headroom before the deadline.
+fn retry_delay_within_grace(
+    elapsed: Duration,
+    backoff: Duration,
+    grace: Duration,
+    request_timeout: Duration,
+) -> Option<Duration> {
+    let remaining = grace.checked_sub(elapsed)?;
+    if remaining <= request_timeout {
+        return None;
+    }
+    Some(backoff.min(remaining - request_timeout))
+}
 
 /// Claims embedded in the middle segment of a `moi-user-token-v1` token.
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -67,10 +95,12 @@ pub fn parse_moi_token_claims(token: &str) -> Option<TokenClaims> {
 
 /// Decide whether an authentication-PROVEN token should overwrite the token
 /// file. Skip only when the file already holds the proven token itself, or a
-/// STRICTLY newer generation (by iat, then exp). Anything else — including a
-/// different jti with the SAME iat/exp, which double-renew / grace recovery
-/// can legitimately produce — is overwritten: expiry seconds do not order
-/// generations, but an AuthOk is hard proof the token works.
+/// same-identity, STRICTLY newer generation (by iat, then exp). Anything else —
+/// including a different jti with the SAME iat/exp, which double-renew / grace
+/// recovery can legitimately produce, or a token of a DIFFERENT MOI identity —
+/// is overwritten: expiry seconds do not order generations, and generations of
+/// different identities are not comparable at all, but an AuthOk is hard proof
+/// the proven token works for the current identity.
 pub fn should_persist_proven(existing: Option<&str>, proven: &str) -> bool {
     let Some(proven_claims) = parse_moi_token_claims(proven) else {
         // Non-MOI tokens never touch the MOI token file.
@@ -85,6 +115,16 @@ pub fn should_persist_proven(existing: Option<&str>, proven: &str) -> bool {
     let Some(existing_claims) = parse_moi_token_claims(existing) else {
         return true;
     };
+    // Different MOI identity (e.g. a reused workspace volume still holding a
+    // previous tenant's token): generation ordering via (iat, exp) is
+    // meaningless across identities. Comparing them could leave a
+    // later-generation previous-tenant token on disk, which a later env-less
+    // startup would then select and be permanently rejected on. The proven
+    // token is hard AuthOk proof for the CURRENT identity — replace the stale
+    // foreign-identity file rather than generation-comparing it.
+    if !same_moi_identity(&existing_claims, &proven_claims) {
+        return true;
+    }
     let existing_gen = (existing_claims.iat, existing_claims.exp);
     let proven_gen = (proven_claims.iat, proven_claims.exp);
     // Strictly newer file wins (renewal owns forward progress); ties go to
@@ -110,6 +150,32 @@ fn now_unix() -> i64 {
 /// Purpose claim of an edge-registration token; the server requires a non-empty
 /// jti for tokens carrying it.
 const EDGE_REGISTRATION_PURPOSE: &str = "edge_registration";
+
+/// Issuer that mints edge-registration tokens exclusively. The server rejects a
+/// token from this issuer that does not declare the edge-registration purpose
+/// (a pre-binding historical runner token).
+const ISSUER_MOI_BACKEND: &str = "moi-backend";
+
+/// Mirror the server's `Verify` (crate `astraauth`) acceptance rules that the
+/// edge CAN check without the signing key: exactly three segments, non-empty
+/// `sub`/`workspace_id`, the moi-backend-issuer / edge-registration coupling,
+/// and the edge-registration binding (`edge_agent_id` + `jti`). Signature and
+/// expiry are checked by the caller. A token failing these is one the server
+/// would reject, so the edge must neither select it from the token file nor
+/// persist it from a renewal — with no env fallback, doing so bricks the edge.
+fn matches_server_acceptance(token: &str, claims: &TokenClaims) -> bool {
+    is_wellformed_moi_token(token)
+        && !claims.sub.is_empty()
+        && !claims.workspace_id.is_empty()
+        // moi-backend issues edge-registration tokens exclusively; any other
+        // purpose from that issuer is a pre-binding historical token the server
+        // rejects.
+        && !(claims.iss == ISSUER_MOI_BACKEND && claims.purpose != EDGE_REGISTRATION_PURPOSE)
+        // Edge-registration tokens must bind an edge_agent_id and carry a jti.
+        && (claims.purpose != EDGE_REGISTRATION_PURPOSE
+            || (!claims.edge_agent_id.is_empty()
+                && claims.jti.as_deref().is_some_and(|jti| !jti.is_empty())))
+}
 
 /// Structural check mirroring the server's `verify_user_token`: a moi-user token
 /// must be exactly `moi-user-token-v1.<claims>.<sig>` — three dot-separated
@@ -141,13 +207,10 @@ fn parse_usable_renewed_token(
             && renewed.iss == current.iss
             && renewed.edge_agent_id == current.edge_agent_id
             && renewed.purpose == current.purpose
-            // Match the server's acceptance rules before overwriting the persisted
-            // identity: an exactly-three-segment token, and (for edge-registration
-            // tokens) a non-empty jti. A token that passes the generation/identity
+            // Match the server's acceptance rules before overwriting the
+            // persisted identity. A token that passes the generation/identity
             // checks but the server would reject would brick the edge on restart.
-            && is_wellformed_moi_token(token)
-            && (renewed.purpose != EDGE_REGISTRATION_PURPOSE
-                || renewed.jti.as_deref().is_some_and(|jti| !jti.is_empty()))
+            && matches_server_acceptance(token, renewed)
     })
 }
 
@@ -184,7 +247,11 @@ pub fn resolve_token_file_path(workspace_dir: &Path) -> PathBuf {
 }
 
 /// Read the token file and return its token only if it is a `moi-user-token-v1`
-/// token with parseable claims that have not expired.
+/// token with parseable claims that have not expired AND that the server would
+/// accept ([`matches_server_acceptance`]). The lenient claims parser tolerates
+/// extra segments and defaulted identity fields the server rejects; without an
+/// env fallback, selecting such a file would let the edge pick a token it is
+/// then permanently rejected on, so the structural/claim checks are applied here.
 pub fn read_valid_file_token(path: &Path, now_unix: i64) -> Option<String> {
     let contents = std::fs::read_to_string(path).ok()?;
     let token = contents.trim();
@@ -193,6 +260,9 @@ pub fn read_valid_file_token(path: &Path, now_unix: i64) -> Option<String> {
     }
     let claims = parse_moi_token_claims(token)?;
     if claims.exp <= now_unix {
+        return None;
+    }
+    if !matches_server_acceptance(token, &claims) {
         return None;
     }
     Some(token.to_string())
@@ -419,6 +489,12 @@ pub fn spawn_renewal_task(manager: Arc<crate::token_manager::TokenManager>) {
             // the fast retries are what make the recovery path reachable.
             let mut transient_backoff = TRANSIENT_RETRY_SECS.iter();
             let mut rejected = false;
+            // Anchor the grace deadline at the first attempt of this cycle. A
+            // lost rotation response is only recoverable while the old jti is
+            // still dual-valid, so retries are driven off this absolute deadline
+            // rather than the raw backoff schedule (whose last sleep could push
+            // an attempt to or past the boundary once request duration counts).
+            let retry_start = tokio::time::Instant::now();
             loop {
                 let transient = renewal_cycle(
                     &client,
@@ -433,15 +509,31 @@ pub fn spawn_renewal_task(manager: Arc<crate::token_manager::TokenManager>) {
                 if !transient {
                     break;
                 }
-                let Some(delay_secs) = transient_backoff.next() else {
+                let Some(backoff_secs) = transient_backoff.next() else {
+                    break;
+                };
+                let elapsed = tokio::time::Instant::now().duration_since(retry_start);
+                let Some(delay) = retry_delay_within_grace(
+                    elapsed,
+                    Duration::from_secs(*backoff_secs),
+                    ROTATION_GRACE_WINDOW,
+                    RENEW_HTTP_TIMEOUT,
+                ) else {
+                    // No further attempt can complete inside the rotation grace
+                    // window; stop fast-retrying and fall to the outer wait
+                    // (which still polls at 30s while persistence debt remains).
+                    tracing::info!(
+                        target: "astra.edge",
+                        "edge token renewal fast-retries exhausted the rotation grace window"
+                    );
                     break;
                 };
                 tracing::info!(
                     target: "astra.edge",
-                    retry_in_secs = delay_secs,
+                    retry_in_secs = delay.as_secs(),
                     "retrying edge token renewal after transient failure"
                 );
-                tokio::time::sleep(Duration::from_secs(*delay_secs)).await;
+                tokio::time::sleep(delay).await;
             }
             // Wake early when someone (renewal itself or the AuthOk heal
             // path) records persistence debt. Outstanding debt must NEVER
@@ -824,6 +916,42 @@ mod tests {
         assert!(!should_persist_proven(None, "plain-astra-token"));
     }
 
+    // Reused-workspace regression: the file holds a previous tenant's token of a
+    // LATER generation than the token that just authenticated for the current
+    // tenant. Generation ordering is meaningless across identities — comparing
+    // (iat, exp) would keep the stale foreign token, which a later env-less
+    // startup would then select and be permanently rejected on. The proven
+    // current-tenant token must overwrite it.
+    #[test]
+    fn should_persist_proven_replaces_stale_other_identity() {
+        let identity_tok = |sub: &str, workspace: &str, iat: i64, exp: i64| {
+            make_token(&serde_json::json!({
+                "iat": iat,
+                "exp": exp,
+                "jti": format!("jti-{sub}"),
+                "sub": sub,
+                "workspace_id": workspace,
+                "iss": "moi-backend",
+                "edge_agent_id": format!("edge-{sub}"),
+                "purpose": "edge_registration",
+            }))
+        };
+        // Tenant A's leftover file token is a LATER generation than tenant B's
+        // freshly-proven token.
+        let tenant_a_file = identity_tok("tenant-a", "ws-a", 5_000, 9_000);
+        let tenant_b_proven = identity_tok("tenant-b", "ws-b", 100, 200);
+        assert!(
+            should_persist_proven(Some(&tenant_a_file), &tenant_b_proven),
+            "a proven current-identity token must overwrite a later-generation \
+             previous-tenant token left in a reused workspace"
+        );
+
+        // Sanity: same identity still obeys generation ordering (a strictly
+        // newer same-identity file is kept).
+        let same_newer = identity_tok("tenant-b", "ws-b", 300, 400);
+        assert!(!should_persist_proven(Some(&same_newer), &tenant_b_proven));
+    }
+
     #[test]
     fn parse_valid_claims() {
         let token = make_token(&serde_json::json!({ "exp": 1234567890, "jti": "abc" }));
@@ -881,17 +1009,90 @@ mod tests {
         // Missing file → none.
         assert!(read_valid_file_token(&path, now).is_none());
 
-        // Valid unexpired moi token → preferred.
-        let valid = make_token(&serde_json::json!({ "exp": now + 86_400 }));
+        // Valid unexpired moi token with the server-required identity claims →
+        // preferred. (No iss/purpose ⇒ not an edge-registration token, so no
+        // edge_agent_id/jti required.)
+        let valid = make_token(&serde_json::json!({
+            "exp": now + 86_400,
+            "sub": "user-1",
+            "workspace_id": "workspace-1",
+        }));
         write_token_atomic(&path, &valid).expect("write");
         assert_eq!(
             read_valid_file_token(&path, now).as_deref(),
             Some(valid.as_str())
         );
 
+        // A valid edge-registration token (iss=moi-backend + purpose) needs the
+        // edge_agent_id and jti binding the server requires.
+        let valid_edge = make_token(&serde_json::json!({
+            "exp": now + 86_400,
+            "sub": "user-1",
+            "workspace_id": "workspace-1",
+            "iss": "moi-backend",
+            "purpose": "edge_registration",
+            "edge_agent_id": "edge-1",
+            "jti": "jti-1",
+        }));
+        write_token_atomic(&path, &valid_edge).expect("write");
+        assert_eq!(
+            read_valid_file_token(&path, now).as_deref(),
+            Some(valid_edge.as_str())
+        );
+
         // Expired token → rejected.
-        let expired = make_token(&serde_json::json!({ "exp": now - 1 }));
+        let expired = make_token(&serde_json::json!({
+            "exp": now - 1,
+            "sub": "user-1",
+            "workspace_id": "workspace-1",
+        }));
         write_token_atomic(&path, &expired).expect("write");
+        assert!(read_valid_file_token(&path, now).is_none());
+
+        // The lenient parser accepts these, but the server would reject them, so
+        // the file selector must too (no env fallback ⇒ selecting one bricks the
+        // edge). Each mutates the otherwise-valid token in exactly one way.
+
+        // Extra (4th) segment — server requires exactly three.
+        write_token_atomic(&path, &format!("{valid}.extra")).expect("write");
+        assert!(read_valid_file_token(&path, now).is_none());
+
+        // Missing sub — required for every token type.
+        let no_sub = make_token(&serde_json::json!({
+            "exp": now + 86_400,
+            "workspace_id": "workspace-1",
+        }));
+        write_token_atomic(&path, &no_sub).expect("write");
+        assert!(read_valid_file_token(&path, now).is_none());
+
+        // Missing workspace_id — required for every token type.
+        let no_workspace = make_token(&serde_json::json!({
+            "exp": now + 86_400,
+            "sub": "user-1",
+        }));
+        write_token_atomic(&path, &no_workspace).expect("write");
+        assert!(read_valid_file_token(&path, now).is_none());
+
+        // moi-backend issuer without the edge_registration purpose — a
+        // pre-binding historical token the server rejects.
+        let backend_non_edge = make_token(&serde_json::json!({
+            "exp": now + 86_400,
+            "sub": "user-1",
+            "workspace_id": "workspace-1",
+            "iss": "moi-backend",
+        }));
+        write_token_atomic(&path, &backend_non_edge).expect("write");
+        assert!(read_valid_file_token(&path, now).is_none());
+
+        // edge_registration purpose without edge_agent_id / jti — rejected.
+        let edge_no_binding = make_token(&serde_json::json!({
+            "exp": now + 86_400,
+            "sub": "user-1",
+            "workspace_id": "workspace-1",
+            "iss": "moi-backend",
+            "purpose": "edge_registration",
+        }));
+        write_token_atomic(&path, &edge_no_binding).expect("write");
         assert!(read_valid_file_token(&path, now).is_none());
 
         // Non-moi content → rejected.
@@ -901,6 +1102,110 @@ mod tests {
         // Empty / whitespace file → rejected.
         write_token_atomic(&path, "  \n").expect("write");
         assert!(read_valid_file_token(&path, now).is_none());
+    }
+
+    #[test]
+    fn retry_delay_within_grace_budgets_request_timeout() {
+        let grace = Duration::from_secs(300);
+        let timeout = Duration::from_secs(30);
+        // Early in the window: the full backoff is granted.
+        assert_eq!(
+            retry_delay_within_grace(
+                Duration::from_secs(30),
+                Duration::from_secs(30),
+                grace,
+                timeout
+            ),
+            Some(Duration::from_secs(30))
+        );
+        // Late enough that the raw backoff would overrun: clamped so the next
+        // attempt keeps a full request timeout of headroom before the deadline.
+        assert_eq!(
+            retry_delay_within_grace(
+                Duration::from_secs(180),
+                Duration::from_secs(120),
+                grace,
+                timeout
+            ),
+            Some(Duration::from_secs(90))
+        );
+        // Not enough room for another completing attempt → stop retrying.
+        assert_eq!(
+            retry_delay_within_grace(
+                Duration::from_secs(280),
+                Duration::from_secs(30),
+                grace,
+                timeout
+            ),
+            None
+        );
+        // Exactly one request timeout of room left (remaining == timeout) → stop.
+        assert_eq!(
+            retry_delay_within_grace(
+                Duration::from_secs(270),
+                Duration::from_secs(10),
+                grace,
+                timeout
+            ),
+            None
+        );
+        // Elapsed already past the grace window → None (saturating, no panic).
+        assert_eq!(
+            retry_delay_within_grace(
+                Duration::from_secs(400),
+                Duration::from_secs(30),
+                grace,
+                timeout
+            ),
+            None
+        );
+    }
+
+    // Paused-time regression for the retry schedule: driving the real backoff
+    // constants through the grace-deadline helper, every attempt — including the
+    // last — must BEGIN early enough to complete within the rotation grace
+    // window even when each attempt burns the full request timeout before it
+    // fails. The pre-fix fixed schedule [30,60,120] pushed the 4th attempt to
+    // t=300, at the boundary.
+    #[tokio::test(start_paused = true)]
+    async fn fast_retries_stay_within_rotation_grace_window() {
+        let grace = ROTATION_GRACE_WINDOW;
+        let timeout = RENEW_HTTP_TIMEOUT;
+        let start = tokio::time::Instant::now();
+        let mut backoff = TRANSIENT_RETRY_SECS.iter().copied();
+        let mut attempt_offsets = vec![Duration::ZERO];
+        loop {
+            // Worst case: the attempt runs the full request timeout before it
+            // reports the transient failure.
+            tokio::time::sleep(timeout).await;
+            let Some(backoff_secs) = backoff.next() else {
+                break;
+            };
+            let elapsed = tokio::time::Instant::now().duration_since(start);
+            let Some(delay) = retry_delay_within_grace(
+                elapsed,
+                Duration::from_secs(backoff_secs),
+                grace,
+                timeout,
+            ) else {
+                break;
+            };
+            tokio::time::sleep(delay).await;
+            attempt_offsets.push(tokio::time::Instant::now().duration_since(start));
+        }
+        for offset in &attempt_offsets {
+            assert!(
+                *offset + timeout <= grace,
+                "attempt starting at {offset:?} cannot complete within the {grace:?} grace window"
+            );
+        }
+        // The window is genuinely used for several recovery attempts, not
+        // collapsed to a single try.
+        assert!(
+            attempt_offsets.len() >= 2,
+            "expected multiple in-window retries, got {}",
+            attempt_offsets.len()
+        );
     }
 
     #[test]

--- a/crates/astra-skills/src/loader.rs
+++ b/crates/astra-skills/src/loader.rs
@@ -1127,9 +1127,11 @@ Hooked body."#;
         std::fs::create_dir_all(project.join(".git")).unwrap();
 
         let paths = isolated_project_skill_search_paths(&cwd);
+        let canonical_project = std::fs::canonicalize(&project).unwrap();
+        let canonical_home = std::fs::canonicalize(&home).unwrap();
 
-        assert!(paths.contains(&project.join(".astra/skills")));
-        assert!(!paths.contains(&home.join(".astra/skills")));
+        assert!(paths.contains(&canonical_project.join(".astra/skills")));
+        assert!(!paths.contains(&canonical_home.join(".astra/skills")));
     }
 
     #[test]
@@ -1141,9 +1143,11 @@ Hooked body."#;
         std::fs::create_dir_all(cwd.join(".astra/skills")).unwrap();
 
         let paths = isolated_project_skill_search_paths(&cwd);
+        let canonical_cwd = std::fs::canonicalize(&cwd).unwrap();
+        let canonical_parent = std::fs::canonicalize(&parent).unwrap();
 
-        assert!(paths.contains(&cwd.join(".astra/skills")));
-        assert!(!paths.contains(&parent.join(".astra/skills")));
+        assert!(paths.contains(&canonical_cwd.join(".astra/skills")));
+        assert!(!paths.contains(&canonical_parent.join(".astra/skills")));
     }
 
     #[test]

--- a/crates/astra-tools/src/memoria.rs
+++ b/crates/astra-tools/src/memoria.rs
@@ -1295,9 +1295,8 @@ impl MemoriaToolGateway {
         if let Some(sid) = session_id {
             body["session_id"] = json!(sid);
         }
-        let client = reqwest::Client::builder()
+        let client = astra_core::net::client_builder_for_target(&mem.base_url)
             .timeout(Duration::from_secs(2))
-            .no_proxy()
             .build()
             .ok()?;
         let request = client
@@ -1445,9 +1444,8 @@ impl MemoriaToolGateway {
             self.apply_focus_hints(sid, &mut payload);
         }
 
-        let raw_text = match reqwest::Client::builder()
+        let raw_text = match astra_core::net::client_builder_for_target(&endpoint)
             .timeout(timeout)
-            .no_proxy()
             .build()
         {
             Ok(client) => {
@@ -1647,9 +1645,8 @@ impl MemoriaToolGateway {
         let Some(token) = self.cloud_token.as_deref() else {
             return memoria_snapshot_create(name).await.map(|_| ());
         };
-        let client = reqwest::Client::builder()
+        let client = astra_core::net::client_builder_for_target(cloud_base)
             .timeout(Duration::from_secs(5))
-            .no_proxy()
             .build()
             .map_err(|e| format!("build client: {e}"))?;
         let resp = client
@@ -1707,9 +1704,8 @@ impl MemoriaToolGateway {
             Some(token) => token,
             None => return vec![],
         };
-        let client = match reqwest::Client::builder()
+        let client = match astra_core::net::client_builder_for_target(cloud_base)
             .timeout(Duration::from_millis(800))
-            .no_proxy()
             .build()
         {
             Ok(c) => c,
@@ -2459,9 +2455,8 @@ fn format_remember_conflict(arr: &[Value], floor: f64) -> Option<String> {
 pub fn memoria_oneshot_client(timeout_secs: u64) -> Option<(reqwest::Client, String, String)> {
     let mem = astra_core::MemoriaSettings::from_env();
     let key = mem.master_key?;
-    let client = reqwest::Client::builder()
+    let client = astra_core::net::client_builder_for_target(&mem.base_url)
         .timeout(Duration::from_secs(timeout_secs))
-        .no_proxy()
         .build()
         .ok()?;
     Some((client, mem.base_url, key))

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -344,6 +344,72 @@ pub struct AuthConfig {
     pub token_encryption_key: Option<String>,
     /// Local authentication rules for provider-originated API calls.
     pub provider_request_auth: Vec<ProviderRequestAuthConfig>,
+    /// Edge-registration token verification (MOI sandbox/runner edge agents).
+    pub edge_token_auth: EdgeTokenAuthConfig,
+    /// External providers serving the model catalog / runtime-context scope
+    /// callbacks for edge-registration principals (e.g. MOI's
+    /// /api/v1/astra/external-catalog).
+    pub external_providers: Vec<ExternalProviderEntryConfig>,
+}
+
+/// One external provider entry for edge-scope catalog callbacks.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(default)]
+pub struct ExternalProviderEntryConfig {
+    /// Provider id ("moi" is looked up first by the auth service).
+    pub id: String,
+    /// Display name (defaults to the id when empty).
+    pub display_name: String,
+    /// Callback endpoint receiving the {action, provider_id, ...} POSTs.
+    pub external_auth_endpoint: String,
+    /// Optional bearer key sent as `Authorization: Bearer <key>` on callback
+    /// requests. Supports `${ENV}` placeholder resolution. Callbacks that mint
+    /// runtime credentials (issue_runtime_context_by_scope) should always be
+    /// key-protected.
+    pub auth_key: String,
+}
+
+impl std::fmt::Debug for ExternalProviderEntryConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ExternalProviderEntryConfig")
+            .field("id", &self.id)
+            .field("display_name", &self.display_name)
+            .field("external_auth_endpoint", &self.external_auth_endpoint)
+            .field(
+                "auth_key",
+                &if self.auth_key.is_empty() {
+                    ""
+                } else {
+                    "[REDACTED]"
+                },
+            )
+            .finish()
+    }
+}
+
+/// Edge-registration token verification (MOI sandbox/runner edge agents).
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(default)]
+pub struct EdgeTokenAuthConfig {
+    /// Shared HMAC key for moi-user-token-v1 edge tokens (= MOI jwt_secret).
+    /// Supports `${ASTRA_EDGE_TOKEN_HMAC_KEY}` placeholder resolution.
+    pub key: String,
+    /// moi-core revocation-check endpoint, required whenever `key` is set
+    /// (e.g. https://catalog/api/v1/astra/edge-tokens/check). `validate()` rejects
+    /// a key without it so revocation cannot be silently skipped. Astra checks jti
+    /// revocation on every surface that accepts an edge token (WS connect + every
+    /// HTTP request; fail-closed).
+    pub check_endpoint: String,
+}
+
+impl fmt::Debug for EdgeTokenAuthConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EdgeTokenAuthConfig")
+            .field("key", &(!self.key.is_empty()).then_some("[REDACTED]"))
+            .field("check_endpoint", &self.check_endpoint)
+            .finish()
+    }
 }
 
 /// Server-side provider request authentication configuration.
@@ -385,6 +451,8 @@ impl fmt::Debug for AuthConfig {
                 &self.token_encryption_key.as_ref().map(|_| "[REDACTED]"),
             )
             .field("provider_request_auth", &self.provider_request_auth)
+            .field("edge_token_auth", &self.edge_token_auth)
+            .field("external_providers", &self.external_providers)
             .finish()
     }
 }
@@ -403,6 +471,19 @@ impl AuthConfig {
         if !other.provider_request_auth.is_empty() {
             self.provider_request_auth = other.provider_request_auth.clone();
         }
+        // Field-merge so a layer overriding only one field (e.g. user config
+        // sets check_endpoint) does not clear a field (key) set by a lower
+        // layer — replacing the whole struct would blank the untouched field
+        // and fail startup.
+        if !other.edge_token_auth.key.is_empty() {
+            self.edge_token_auth.key = other.edge_token_auth.key.clone();
+        }
+        if !other.edge_token_auth.check_endpoint.is_empty() {
+            self.edge_token_auth.check_endpoint = other.edge_token_auth.check_endpoint.clone();
+        }
+        if !other.external_providers.is_empty() {
+            self.external_providers = other.external_providers.clone();
+        }
     }
     fn apply_env_overrides(&mut self) {
         apply_env_override_str(&mut self.jwt_secret, "ASTRA_JWT_SECRET");
@@ -413,6 +494,10 @@ impl AuthConfig {
         apply_env_override_str(&mut self.token_encryption_key, "ASTRA_TOKEN_ENCRYPTION_KEY");
         for request_auth in &mut self.provider_request_auth {
             apply_env_override_placeholder(&mut request_auth.key);
+        }
+        apply_env_override_placeholder(&mut self.edge_token_auth.key);
+        for provider in &mut self.external_providers {
+            apply_env_override_placeholder(&mut provider.auth_key);
         }
     }
 
@@ -444,6 +529,52 @@ impl AuthConfig {
                     request_auth.provider
                 ));
             }
+        }
+        if !self.edge_token_auth.key.is_empty()
+            && let Some(env_name) = exact_env_placeholder(&self.edge_token_auth.key)
+        {
+            return Err(format!(
+                "auth.edge_token_auth.key references an unset environment variable: {env_name}"
+            ));
+        }
+        let mut external_ids = std::collections::HashSet::new();
+        for provider in &self.external_providers {
+            validate_exact_non_empty("auth.external_providers[].id", &provider.id)?;
+            validate_exact_non_empty(
+                "auth.external_providers[].external_auth_endpoint",
+                &provider.external_auth_endpoint,
+            )?;
+            // Reject duplicate ids: runtime lookup uses .find() and would
+            // silently pick the first, making the endpoint/auth key depend on
+            // list order. Mirror provider_request_auth's duplicate rejection.
+            if !external_ids.insert(provider.id.as_str()) {
+                return Err(format!(
+                    "auth.external_providers id '{}' is duplicated",
+                    provider.id
+                ));
+            }
+            if !provider.auth_key.is_empty()
+                && let Some(env_name) = exact_env_placeholder(&provider.auth_key)
+            {
+                return Err(format!(
+                    "auth.external_providers[].auth_key references an unset environment variable: {env_name}"
+                ));
+            }
+        }
+        if !self.edge_token_auth.check_endpoint.is_empty() && self.edge_token_auth.key.is_empty() {
+            return Err(
+                "auth.edge_token_auth.check_endpoint requires auth.edge_token_auth.key".to_string(),
+            );
+        }
+        // Fail closed: accepting long-lived edge-registration tokens without a
+        // revocation endpoint means a token revoked in MOI keeps working until
+        // it expires (up to 30 days). If the HMAC key is configured, the
+        // revocation endpoint is mandatory — a config omission must not
+        // silently disable revocation.
+        if !self.edge_token_auth.key.is_empty() && self.edge_token_auth.check_endpoint.is_empty() {
+            return Err(
+                "auth.edge_token_auth.check_endpoint is required when auth.edge_token_auth.key is set (edge token revocation must fail closed)".to_string(),
+            );
         }
         Ok(())
     }
@@ -838,6 +969,8 @@ pub struct AppSettings {
     pub bridge_secret: String,
     pub token_encryption_key: Option<String>,
     pub provider_request_auth: Vec<ProviderRequestAuthConfig>,
+    pub edge_token_auth: EdgeTokenAuthConfig,
+    pub external_providers: Vec<ExternalProviderEntryConfig>,
     pub database_bootstrap_catalog: String,
     /// Deployment-declared provider capabilities.
     pub provider_capabilities: HashMap<String, Vec<String>>,
@@ -919,6 +1052,8 @@ impl AppSettings {
         settings.provider_capabilities = sc.deployment.provider_capabilities.clone();
         settings.provider_allowed_tools = sc.deployment.provider_allowed_tools.clone();
         settings.provider_request_auth = sc.auth.provider_request_auth.clone();
+        settings.edge_token_auth = sc.auth.edge_token_auth.clone();
+        settings.external_providers = sc.auth.external_providers.clone();
         validate_provider_capabilities(&settings.provider_capabilities)
             .map_err(ConfigError::Validation)?;
         validate_tool_offer_ids(&settings.disabled_tool_offers).map_err(ConfigError::Validation)?;
@@ -1006,6 +1141,8 @@ impl AppSettings {
             )?,
             token_encryption_key: lookup("ASTRA_TOKEN_ENCRYPTION_KEY"),
             provider_request_auth: Vec::new(),
+            edge_token_auth: EdgeTokenAuthConfig::default(),
+            external_providers: Vec::new(),
             disabled_tool_offers: Self::disabled_tool_offers_from_lookup(&lookup),
             provider_capabilities: HashMap::new(),
             provider_allowed_tools: HashMap::new(),
@@ -2146,6 +2283,68 @@ auth_mode = "legacy"
                 err.contains("auth.provider_request_auth provider 'moi'.key references an unset environment variable")
             );
         });
+    }
+
+    #[test]
+    fn server_config_env_override_edge_token_hmac_key() {
+        temp_env::with_var(
+            "ASTRA_EDGE_TOKEN_HMAC_KEY",
+            Some("env-edge-token-hmac-key"),
+            || {
+                let mut config = ServerConfig::default();
+                config.auth.edge_token_auth.key = "${ASTRA_EDGE_TOKEN_HMAC_KEY}".to_string();
+                // check_endpoint is mandatory whenever the key is set (revocation
+                // must fail closed).
+                config.auth.edge_token_auth.check_endpoint =
+                    "http://catalog/api/v1/astra/edge-tokens/check".to_string();
+                config.apply_env_overrides();
+                assert_eq!(config.auth.edge_token_auth.key, "env-edge-token-hmac-key");
+                config.auth.validate().expect("auth config should validate");
+            },
+        );
+    }
+
+    #[test]
+    fn server_config_validate_rejects_unresolved_edge_token_hmac_key_env() {
+        temp_env::with_var("ASTRA_EDGE_TOKEN_HMAC_KEY", None::<&str>, || {
+            let mut config = ServerConfig::default();
+            config.auth.edge_token_auth.key = "${ASTRA_EDGE_TOKEN_HMAC_KEY}".to_string();
+            config.apply_env_overrides();
+            let err = config
+                .auth
+                .validate()
+                .expect_err("unresolved edge token key env should be rejected");
+            assert!(
+                err.contains("auth.edge_token_auth.key references an unset environment variable")
+            );
+        });
+    }
+
+    #[test]
+    fn server_config_validate_rejects_check_endpoint_without_key() {
+        let mut config = ServerConfig::default();
+        config.auth.edge_token_auth.check_endpoint =
+            "http://catalog/api/v1/astra/edge-tokens/check".to_string();
+        let err = config
+            .auth
+            .validate()
+            .expect_err("check_endpoint without key should be rejected");
+        assert!(
+            err.contains("auth.edge_token_auth.check_endpoint requires auth.edge_token_auth.key")
+        );
+    }
+
+    #[test]
+    fn server_config_validate_rejects_key_without_check_endpoint() {
+        let mut config = ServerConfig::default();
+        config.auth.edge_token_auth.key = "edge-hmac-key".to_string();
+        let err = config
+            .auth
+            .validate()
+            .expect_err("edge token key without check_endpoint must fail closed");
+        assert!(err.contains(
+            "auth.edge_token_auth.check_endpoint is required when auth.edge_token_auth.key is set"
+        ));
     }
 
     #[test]

--- a/crates/core/src/net.rs
+++ b/crates/core/src/net.rs
@@ -1,17 +1,27 @@
 //! Shared HTTP networking utilities.
 //!
-//! # Proxy policy (commit 3e3d6fa8)
+//! # Proxy policy
 //!
-//! Only **external** HTTP traffic — the LLM client and provider connectivity
-//! probes — is allowed to honour `HTTPS_PROXY` / `ALL_PROXY`. All other reqwest
-//! clients in the workspace are considered internal (edge ↔ services, memoria,
-//! durable task, app state, etc.) and MUST call `.no_proxy()` on their
-//! builders. See `astra_runtime::turn::llm_client` module docs for the full
-//! rationale.
+//! Three tiers, by traffic destination — pick the matching helper instead of
+//! hand-rolling proxy handling:
 //!
-//! [`apply_env_proxy`] is the single authoritative implementation. Both the
-//! LLM client and `validate_connectivity` in `astra-services` call it. Do not
-//! duplicate this logic elsewhere — add a new caller instead.
+//! 1. **Server-internal, always-local traffic** (runtime ↔ services on the
+//!    same host: memoria, durable task, app state, ...): MUST bypass env
+//!    proxies — use [`build_internal_http_client`].
+//! 2. **Target-dependent traffic** (astra-cli / edge clients that may talk to
+//!    either a local or a REMOTE astra server): use
+//!    [`client_builder_for_target`] — loopback targets bypass proxies, remote
+//!    targets honour the environment. Mandatory-egress-proxy sandboxes
+//!    (OpenShell) depend on this: an unconditional `.no_proxy()` there makes
+//!    remote calls hang.
+//! 3. **External provider traffic** (the LLM client, provider connectivity
+//!    probes): honours `HTTPS_PROXY`/`ALL_PROXY` via [`apply_env_proxy`] — the
+//!    single authoritative env-proxy implementation; add callers rather than
+//!    duplicating it.
+//!
+//! The historical rule "everything except the LLM client must .no_proxy()"
+//! (commit 3e3d6fa8) applies ONLY to tier 1; tier 2 superseded it for client
+//! code that can target remote servers.
 
 /// Build an internal `reqwest` client that must never honor env proxy vars.
 ///
@@ -97,6 +107,64 @@ pub fn apply_env_proxy(mut builder: reqwest::ClientBuilder) -> reqwest::ClientBu
         }
     }
     builder
+}
+
+/// Returns `true` when `url` targets the local host (`localhost`,
+/// `*.localhost`, or a loopback IP literal).
+pub fn url_is_loopback(url: &str) -> bool {
+    let Ok(parsed) = reqwest::Url::parse(url) else {
+        return false;
+    };
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .strip_suffix(".localhost")
+            .is_some_and(|prefix| !prefix.is_empty())
+        || host
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
+/// Start a `reqwest` client builder whose proxy policy is decided by the
+/// target URL: loopback targets are process-local control-plane calls and
+/// always bypass env proxies; remote targets keep reqwest's
+/// environment-aware proxy behavior (`HTTP(S)_PROXY` / `NO_PROXY`).
+///
+/// Mandatory-egress-proxy environments (e.g. OpenShell sandboxes) block
+/// direct remote connections, so clients that may talk to a remote service
+/// must never force `.no_proxy()` unconditionally — use this helper instead.
+pub fn client_builder_for_target(url: &str) -> reqwest::ClientBuilder {
+    let builder = reqwest::Client::builder();
+    if url_is_loopback(url) {
+        builder.no_proxy()
+    } else {
+        builder
+    }
+}
+
+#[cfg(test)]
+mod client_builder_for_target_tests {
+    use super::url_is_loopback;
+
+    #[test]
+    fn loopback_targets_are_detected() {
+        assert!(url_is_loopback("http://localhost:8080/x"));
+        assert!(url_is_loopback("http://api.localhost/x"));
+        assert!(url_is_loopback("http://127.0.0.1:17001/x"));
+        assert!(url_is_loopback("http://[::1]:17001/x"));
+    }
+
+    #[test]
+    fn remote_and_invalid_targets_are_not_loopback() {
+        assert!(!url_is_loopback("http://astra.example.com/x"));
+        assert!(!url_is_loopback("http://10.0.0.8:17001/x"));
+        assert!(!url_is_loopback("not a url"));
+        assert!(!url_is_loopback("http://.localhost/x"));
+    }
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/server/state_builder/core.rs
+++ b/crates/runtime/src/server/state_builder/core.rs
@@ -3,6 +3,7 @@ use crate::server::deployment_tool_policy::{
     DeploymentToolPolicy, apply_deployment_tool_policy, load_deployment_tool_policy,
 };
 use crate::server::tool_transport::ToolExecutionService;
+use astra_services::ExternalAuthProviderConfig;
 
 pub(super) fn build_auth_service(
     settings: &AppSettings,
@@ -13,7 +14,24 @@ pub(super) fn build_auth_service(
         DatabaseAuthService::new(settings.matrixone.clone(), settings.jwt.clone())
             .with_pool(shared_pool.clone())
             .with_encryptor(shared_encryptor.as_ref().clone())
-            .with_provider_request_auth(settings.provider_request_auth.clone()),
+            .with_provider_request_auth(settings.provider_request_auth.clone())
+            .with_edge_token_auth(settings.edge_token_auth.clone())
+            .with_external_providers(
+                settings
+                    .external_providers
+                    .iter()
+                    .map(|provider| ExternalAuthProviderConfig {
+                        id: provider.id.clone(),
+                        display_name: if provider.display_name.is_empty() {
+                            provider.id.clone()
+                        } else {
+                            provider.display_name.clone()
+                        },
+                        external_auth_endpoint: provider.external_auth_endpoint.clone(),
+                        auth_key: provider.auth_key.clone(),
+                    })
+                    .collect(),
+            ),
     ))
 }
 

--- a/crates/services/src/auth/external.rs
+++ b/crates/services/src/auth/external.rs
@@ -8,6 +8,9 @@ pub struct ExternalAuthProviderConfig {
     pub id: String,
     pub display_name: String,
     pub external_auth_endpoint: String,
+    /// Optional bearer key sent on callback requests. Callbacks that mint
+    /// runtime credentials must be key-protected; empty sends no header.
+    pub auth_key: String,
 }
 use async_trait::async_trait;
 use axum::{Json, http::StatusCode};
@@ -561,26 +564,93 @@ pub trait ExternalProviderClient: Send + Sync {
     ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)>;
 }
 
-#[derive(Clone)]
-pub struct HttpExternalProviderClient {
-    client: reqwest::Client,
+/// Outcome of an edge-token revocation check against moi-core.
+#[derive(Debug)]
+pub enum EdgeTokenRevocationCheckError {
+    /// The token is revoked or explicitly denied by moi-core.
+    Denied(String),
+    /// The revocation endpoint could not give a definitive answer
+    /// (transport error, timeout, 5xx, malformed response). Fail closed.
+    Unavailable(String),
 }
 
-impl Default for HttpExternalProviderClient {
-    fn default() -> Self {
-        Self {
-            client: reqwest::Client::builder()
-                .no_proxy()
-                .timeout(Duration::from_secs(30))
-                .build()
-                .expect("external provider HTTP client configuration is static"),
-        }
+/// Ask moi-core whether an edge token (jti) has been revoked.
+///
+/// POSTs `{"token": "<token>"}` to `endpoint`
+/// (e.g. `https://catalog/api/v1/astra/edge-tokens/check`). A 2xx response
+/// with body `{"code":0,"data":{"ok":true}}` means the token is still valid.
+/// HTTP 401/403 or a non-zero code / `ok != true` means the token is revoked
+/// (`Denied`); everything else is `Unavailable`.
+pub async fn check_edge_token_revocation(
+    endpoint: &str,
+    token: &str,
+) -> Result<(), EdgeTokenRevocationCheckError> {
+    // Proxy policy follows the shared target-based rule: loopback endpoints
+    // (local dev) bypass env proxies; remote catalog endpoints honour them,
+    // so a mandatory-egress-proxy astra-server does not fail closed forever.
+    let client = astra_core::net::client_builder_for_target(endpoint)
+        .timeout(Duration::from_secs(10))
+        // Never let a 307/308 forward this POST (which carries the full edge
+        // token) to a different origin.
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|error| {
+            EdgeTokenRevocationCheckError::Unavailable(format!(
+                "failed to build revocation-check HTTP client: {error}"
+            ))
+        })?;
+    let response = client
+        .post(endpoint)
+        .json(&serde_json::json!({ "token": token }))
+        .send()
+        .await
+        .map_err(|error| {
+            EdgeTokenRevocationCheckError::Unavailable(format!(
+                "edge token revocation check request failed: {error}"
+            ))
+        })?;
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(EdgeTokenRevocationCheckError::Denied(format!(
+            "edge token revocation check denied with HTTP {status}"
+        )));
+    }
+    if !status.is_success() {
+        return Err(EdgeTokenRevocationCheckError::Unavailable(format!(
+            "edge token revocation check returned HTTP {status}"
+        )));
+    }
+    let body: Value = response.json().await.map_err(|error| {
+        EdgeTokenRevocationCheckError::Unavailable(format!(
+            "edge token revocation check response is malformed: {error}"
+        ))
+    })?;
+    let code_ok = body.get("code").and_then(Value::as_i64) == Some(0);
+    let token_ok = body
+        .get("data")
+        .and_then(|data| data.get("ok"))
+        .and_then(Value::as_bool)
+        == Some(true);
+    if code_ok && token_ok {
+        Ok(())
+    } else {
+        Err(EdgeTokenRevocationCheckError::Denied(format!(
+            "edge token revocation check rejected the token (code {:?}, ok {:?})",
+            body.get("code"),
+            body.get("data").and_then(|data| data.get("ok")),
+        )))
     }
 }
 
+// No shared client: the proxy decision is per-target (loopback bypasses the
+// env proxy, remote honours it), so the client is built per external-provider
+// endpoint via astra_core::net::client_builder_for_target in post_action.
+#[derive(Clone)]
+pub struct HttpExternalProviderClient;
+
 impl HttpExternalProviderClient {
     pub fn shared() -> Arc<dyn ExternalProviderClient> {
-        Arc::new(Self::default())
+        Arc::new(Self)
     }
 
     async fn post_action<T, R>(
@@ -598,22 +668,39 @@ impl HttpExternalProviderClient {
             provider_id: &provider.id,
             payload,
         };
-        let response = self
-            .client
-            .post(&provider.external_auth_endpoint)
-            .json(&request)
-            .send()
-            .await
+        // Build a target-aware client per endpoint: loopback callbacks bypass
+        // the env proxy, remote catalog/runtime-context endpoints honour it.
+        // (A shared client cannot make this per-target decision.)
+        let client = astra_core::net::client_builder_for_target(&provider.external_auth_endpoint)
+            .timeout(Duration::from_secs(30))
+            // Never let a 307/308 forward this POST (provider payload + Bearer
+            // auth key) to a different origin.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
             .map_err(|error| {
                 error_response_coded(
                     StatusCode::BAD_GATEWAY,
                     format!(
-                        "external provider '{}' action '{}' request failed: {error}",
+                        "external provider '{}' action '{}' client build failed: {error}",
                         provider.id, action
                     ),
                     "external_provider_request_failed",
                 )
             })?;
+        let mut http_request = client.post(&provider.external_auth_endpoint).json(&request);
+        if !provider.auth_key.is_empty() {
+            http_request = http_request.bearer_auth(&provider.auth_key);
+        }
+        let response = http_request.send().await.map_err(|error| {
+            error_response_coded(
+                StatusCode::BAD_GATEWAY,
+                format!(
+                    "external provider '{}' action '{}' request failed: {error}",
+                    provider.id, action
+                ),
+                "external_provider_request_failed",
+            )
+        })?;
         let status = response.status();
         let body = response.text().await.map_err(|error| {
             error_response_coded(
@@ -1221,6 +1308,7 @@ mod tests {
             id: "moi".to_string(),
             display_name: "MOI".to_string(),
             external_auth_endpoint: endpoint,
+            auth_key: String::new(),
         }
     }
 
@@ -1258,7 +1346,7 @@ mod tests {
                 .expect("serve test provider");
         });
 
-        let client = HttpExternalProviderClient::default();
+        let client = HttpExternalProviderClient;
         let authorized = client
             .authorize_request(
                 &provider(endpoint.clone()),
@@ -1438,7 +1526,7 @@ mod tests {
                 .expect("serve test provider");
         });
 
-        let client = HttpExternalProviderClient::default();
+        let client = HttpExternalProviderClient;
         let err = client
             .logout(
                 &provider(endpoint),

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -1,7 +1,7 @@
 use crate::storage::database_user_from_row;
 use astra_core::{
-    ErrorResponse, JwtSettings, MatrixOneSettings, ProviderRequestAuthConfig, SharedPool,
-    bearer_token, error_response, error_response_coded,
+    EdgeTokenAuthConfig, ErrorResponse, JwtSettings, MatrixOneSettings, ProviderRequestAuthConfig,
+    SharedPool, bearer_token, error_response, error_response_coded,
     identity::{USER_ID_MAX_LEN, USERNAME_MAX_LEN},
     internal_error, is_duplicate_key_error,
 };
@@ -12,6 +12,7 @@ use axum::{
 };
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use bcrypt::{hash as bcrypt_hash, verify as bcrypt_verify};
+use futures_util::FutureExt as _;
 use hmac::{Hmac, Mac};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -78,6 +79,9 @@ pub use session::{
 use validation::validate_register_request;
 
 type AuthHttpError = (StatusCode, Json<ErrorResponse>);
+type EdgeRevocationResult = Result<(), AuthHttpError>;
+type EdgeRevocationFlight =
+    futures_util::future::Shared<futures_util::future::BoxFuture<'static, EdgeRevocationResult>>;
 type ExternalRequestAuthHeaders = Option<(String, String, String)>;
 type ParsedTokenSession = (String, String, Option<String>);
 type HmacSha256 = Hmac<Sha256>;
@@ -86,6 +90,89 @@ const PROVIDER_REQUEST_MAX_TTL_SECONDS: i64 = 300;
 const PROVIDER_REQUEST_CLOCK_SKEW_SECONDS: i64 = 60;
 const REAUTHENTICATION_PROOF_TTL_SECONDS: i64 = 300;
 const AUTH_PASSWORD_MAX_BYTES: usize = 72;
+const USER_TOKEN_PURPOSE_EDGE_REGISTRATION: &str = "edge_registration";
+
+/// Claims carried by a `moi-user-token-v1` token minted by moi-core /
+/// moi-backend (`UserTokenSigner`). Field semantics mirror the Go struct.
+#[derive(Debug, Deserialize)]
+struct UserTokenClaims {
+    sub: String,
+    workspace_id: String,
+    #[serde(default)]
+    iss: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    iat: i64,
+    exp: i64,
+    #[serde(default)]
+    edge_agent_id: String,
+    #[serde(default)]
+    jti: String,
+    /// Empty means "runtime" (server-to-server).
+    #[serde(default)]
+    purpose: String,
+}
+
+/// Verify a `moi-user-token-v1.<claims>.<sig>` token locally with the shared
+/// HMAC key, mirroring moi-core's `UserTokenSigner.Verify` semantics.
+fn verify_user_token(key: &str, token: &str) -> Result<UserTokenClaims, AuthHttpError> {
+    if key.is_empty() {
+        return Err(edge_token_auth_error(
+            "Edge token verification key is not configured",
+        ));
+    }
+    let mut parts = token.split('.');
+    let (Some(prefix), Some(encoded_claims), Some(encoded_signature), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return Err(edge_token_auth_error("Edge token is malformed"));
+    };
+    if prefix != MOI_USER_TOKEN_PREFIX {
+        return Err(edge_token_auth_error("Edge token is malformed"));
+    }
+    if !verify_provider_request_signature(key.as_bytes(), encoded_claims, encoded_signature) {
+        return Err(edge_token_auth_error("Edge token signature is invalid"));
+    }
+    let claims_bytes = URL_SAFE_NO_PAD
+        .decode(encoded_claims)
+        .map_err(|_| edge_token_auth_error("Edge token claims are malformed"))?;
+    let claims: UserTokenClaims = serde_json::from_slice(&claims_bytes)
+        .map_err(|_| edge_token_auth_error("Edge token claims are malformed"))?;
+    // `>` (not `>=`): the token is accepted through the exp second, matching
+    // the Go verifiers (moi-backend edgetoken, moi-core astraauth).
+    if claims.exp <= 0 || Utc::now().timestamp() > claims.exp {
+        return Err(edge_token_auth_error("Edge token has expired"));
+    }
+    if claims.sub.is_empty() {
+        return Err(edge_token_auth_error("Edge token subject is missing"));
+    }
+    if claims.workspace_id.is_empty() {
+        return Err(edge_token_auth_error("Edge token workspace_id is missing"));
+    }
+    // moi-backend only mints edge-registration tokens for astra; fail closed
+    // on any other purpose claiming that issuer.
+    if claims.iss == "moi-backend" && claims.purpose != USER_TOKEN_PURPOSE_EDGE_REGISTRATION {
+        return Err(edge_token_auth_error(
+            "Edge token issuer moi-backend requires edge_registration purpose",
+        ));
+    }
+    if claims.purpose == USER_TOKEN_PURPOSE_EDGE_REGISTRATION
+        && (claims.edge_agent_id.is_empty() || claims.jti.is_empty())
+    {
+        return Err(edge_token_auth_error(
+            "Edge registration token requires edge_agent_id and jti",
+        ));
+    }
+    Ok(claims)
+}
+
+fn edge_token_auth_error(message: impl Into<String>) -> AuthHttpError {
+    error_response_coded(
+        StatusCode::UNAUTHORIZED,
+        message.into(),
+        "edge_token_auth_invalid",
+    )
+}
 
 #[derive(Debug, Deserialize)]
 struct ProviderRequestClaims {
@@ -599,6 +686,14 @@ pub struct DatabaseAuthService {
     external_client: std::sync::Arc<dyn ExternalProviderClient>,
     provider_request_auth: Vec<ProviderRequestAuthConfig>,
     provider_request_replay_cache: Arc<Mutex<HashMap<String, i64>>>,
+    edge_token_auth: Option<EdgeTokenAuthConfig>,
+    /// Short-TTL cache of jtis that passed the moi-core revocation check, so
+    /// per-request revocation on the HTTP surface stays cheap. Only positive
+    /// results are cached; denied/unavailable always fail closed uncached.
+    edge_revocation_ok_cache: Arc<Mutex<HashMap<String, std::time::Instant>>>,
+    /// Per-JTI shared checks. Weak entries avoid retaining attacker- or
+    /// issuer-controlled JTIs after the last waiter receives the result.
+    edge_revocation_inflight: Arc<Mutex<HashMap<String, std::sync::Weak<EdgeRevocationFlight>>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -664,6 +759,9 @@ impl DatabaseAuthService {
             external_client: HttpExternalProviderClient::shared(),
             provider_request_auth: Vec::new(),
             provider_request_replay_cache: Arc::new(Mutex::new(HashMap::new())),
+            edge_revocation_ok_cache: Arc::new(Mutex::new(HashMap::new())),
+            edge_revocation_inflight: Arc::new(Mutex::new(HashMap::new())),
+            edge_token_auth: None,
         }
     }
 
@@ -863,6 +961,113 @@ impl DatabaseAuthService {
     pub fn with_provider_request_auth(mut self, auth: Vec<ProviderRequestAuthConfig>) -> Self {
         self.provider_request_auth = auth;
         self
+    }
+
+    pub fn with_edge_token_auth(mut self, cfg: EdgeTokenAuthConfig) -> Self {
+        if !cfg.key.is_empty() {
+            if cfg.check_endpoint.is_empty() {
+                tracing::warn!(
+                    target: "astra_services::auth",
+                    "edge token revocation check endpoint not configured — edge-registration \
+                     tokens will be refused at verification (fail closed)"
+                );
+            }
+            self.edge_token_auth = Some(cfg);
+        }
+        self
+    }
+
+    /// Once-per-connection revocation check for an edge-registration token
+    /// against moi-core's check endpoint. Fail-closed: a revoked token or an
+    /// unavailable endpoint both deny the request.
+    /// Cached revocation check: a jti that recently passed is trusted for
+    /// EDGE_REVOCATION_OK_TTL, bounding staleness after an out-of-band revoke
+    /// to that window. Tokens without a jti are never cached.
+    async fn check_edge_token_revoked_cached(
+        &self,
+        check_endpoint: &str,
+        token: &str,
+        jti: &str,
+    ) -> Result<(), AuthHttpError> {
+        const EDGE_REVOCATION_OK_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+        if !jti.is_empty()
+            && let Ok(cache) = self.edge_revocation_ok_cache.lock()
+            && let Some(checked_at) = cache.get(jti)
+            && checked_at.elapsed() < EDGE_REVOCATION_OK_TTL
+        {
+            return Ok(());
+        }
+
+        if jti.is_empty() {
+            return self.check_edge_token_revoked(check_endpoint, token).await;
+        }
+
+        let flight = {
+            let mut inflight = self
+                .edge_revocation_inflight
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            inflight.retain(|_, flight| flight.strong_count() > 0);
+            match inflight.get(jti).and_then(std::sync::Weak::upgrade) {
+                Some(flight) => flight,
+                None => {
+                    let service = self.clone();
+                    let check_endpoint = check_endpoint.to_string();
+                    let token = token.to_string();
+                    let jti_owned = jti.to_string();
+                    let flight = Arc::new(
+                        async move {
+                            let result = service
+                                .check_edge_token_revoked(&check_endpoint, &token)
+                                .await;
+                            if result.is_ok()
+                                && let Ok(mut cache) = service.edge_revocation_ok_cache.lock()
+                            {
+                                let now = std::time::Instant::now();
+                                cache.retain(|_, at| at.elapsed() < EDGE_REVOCATION_OK_TTL);
+                                cache.insert(jti_owned, now);
+                            }
+                            result
+                        }
+                        .boxed()
+                        .shared(),
+                    );
+                    inflight.insert(jti.to_string(), Arc::downgrade(&flight));
+                    flight
+                }
+            }
+        };
+        flight.as_ref().clone().await
+    }
+
+    async fn check_edge_token_revoked(
+        &self,
+        check_endpoint: &str,
+        token: &str,
+    ) -> Result<(), AuthHttpError> {
+        match external::check_edge_token_revocation(check_endpoint, token).await {
+            Ok(()) => Ok(()),
+            Err(external::EdgeTokenRevocationCheckError::Denied(detail)) => {
+                warn!(
+                    target: "astra_services::auth",
+                    detail = %detail,
+                    "edge token revocation check: token revoked"
+                );
+                Err(edge_token_auth_error("Edge token is revoked"))
+            }
+            Err(external::EdgeTokenRevocationCheckError::Unavailable(detail)) => {
+                warn!(
+                    target: "astra_services::auth",
+                    detail = %detail,
+                    "edge token revocation check unavailable; failing closed"
+                );
+                Err(error_response_coded(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Edge token revocation check unavailable",
+                    "edge_token_revocation_unavailable",
+                ))
+            }
+        }
     }
 
     async fn get_pool(&self) -> Result<sqlx::Pool<sqlx::MySql>, sqlx::Error> {
@@ -1185,72 +1390,70 @@ impl DatabaseAuthService {
         })
     }
 
-    /// Resolve an [`AuthPrincipal`] from a moi-backend edge-registration token
-    /// (`moi-user-token-v1.*`) via the external auth provider.
+    /// Resolve an [`AuthPrincipal`] from a moi-issued edge-registration token
+    /// (`moi-user-token-v1.*`) by verifying it locally with the shared HMAC
+    /// key (`auth.edge_token_auth.key`).
     ///
-    /// The caller must supply the request that is actually being authorized.
-    /// This keeps route/method policy in the provider meaningful and prevents a
-    /// long-lived edge credential from being authorized against a synthetic
-    /// catch-all request.
+    /// A revocation check against moi-core's check endpoint is performed on
+    /// every surface (fail-closed), with a short positive cache (see
+    /// `check_edge_token_revoked_cached`).
     async fn principal_from_edge_token(
         &self,
         token: &str,
-        request: ProviderRequestDescriptor,
+        _request: ProviderRequestDescriptor,
     ) -> Result<AuthPrincipal, (StatusCode, Json<ErrorResponse>)> {
-        let provider = self
-            .ext_providers
-            .iter()
-            .find(|p| p.id == "moi")
-            .or_else(|| self.ext_providers.first())
-            .ok_or_else(|| {
-                error_response(
-                    StatusCode::UNAUTHORIZED,
-                    "No external provider configured for edge token auth",
-                )
-            })?
-            .clone();
-        let authorized = self
-            .external_client
-            .authorize_request(
-                &provider,
-                ExternalAuthorizeRequestData {
-                    provider_id: provider.id.clone(),
-                    token: format!("Bearer {token}"),
-                    request: ExternalRequestDescriptor {
-                        method: request.method,
-                        path: request.path,
-                        route: request.route,
-                        request_id: request.request_id,
-                        body_digest: request.body_digest,
-                    },
-                },
+        let cfg = self.edge_token_auth.as_ref().ok_or_else(|| {
+            edge_token_auth_error(
+                "Edge token verification is not configured (auth.edge_token_auth.key)",
             )
-            .await?;
+        })?;
+        let claims = verify_user_token(&cfg.key, token)?;
+        let is_edge_registration = claims.purpose == USER_TOKEN_PURPOSE_EDGE_REGISTRATION;
+        // Revocation is checked on EVERY surface (WS connect and HTTP), not
+        // just /edge/ws: a revoked 30-day token must not keep working over
+        // the chat/model HTTP endpoints. A short positive cache keeps the
+        // per-request cost bounded; deny/unavailable are never cached.
+        //
+        // Fail closed: config validation already requires check_endpoint
+        // whenever the HMAC key is set, but if an edge-registration token ever
+        // reaches here without a revocation endpoint we must deny — never
+        // accept a long-lived credential we cannot revoke.
+        if is_edge_registration {
+            if cfg.check_endpoint.is_empty() {
+                return Err(edge_token_auth_error(
+                    "Edge token revocation endpoint is not configured; refusing edge-registration token (fail closed)",
+                ));
+            }
+            self.check_edge_token_revoked_cached(&cfg.check_endpoint, token, &claims.jti)
+                .await?;
+        }
         tracing::debug!(
             target: "astra_services::auth",
-            provider_id = %authorized.provider_id,
-            external_subject = %authorized.external_subject,
-            "principal_from_edge_token: edge token authorized for request"
+            external_subject = %claims.sub,
+            workspace_id = %claims.workspace_id,
+            "principal_from_edge_token: edge token verified locally"
         );
-        let user_id = format!(
-            "external_authorized:{}:{}",
-            authorized.provider_id, authorized.external_subject
-        );
+        let request_authorization_id = if claims.jti.is_empty() {
+            format!("{MOI_USER_TOKEN_PREFIX}:{}:{}", claims.sub, claims.exp)
+        } else {
+            format!("{MOI_USER_TOKEN_PREFIX}:jti:{}", claims.jti)
+        };
+        let user_id = format!("external_authorized:moi:{}", claims.sub);
         Ok(AuthPrincipal {
             user: AuthUserRecord {
                 user_id,
-                username: authorized.external_subject.clone(),
+                username: claims.sub.clone(),
                 email: String::new(),
                 display_name: None,
             },
             session_id: None,
             origin: AuthPrincipalOrigin::ProviderAuthorizedRequest(
                 AuthProviderAuthorizedRequestContext {
-                    provider_id: authorized.provider_id,
-                    external_subject: authorized.external_subject,
-                    provider_scope_id: authorized.provider_scope_id,
-                    request_authorization_id: authorized.request_authorization_id,
-                    edge_agent_id: authorized.edge_agent_id,
+                    provider_id: "moi".to_string(),
+                    external_subject: claims.sub,
+                    provider_scope_id: claims.workspace_id,
+                    request_authorization_id,
+                    edge_agent_id: is_edge_registration.then(|| claims.edge_agent_id.clone()),
                 },
             ),
         })
@@ -1777,15 +1980,24 @@ impl AuthService for DatabaseAuthService {
         headers: &HeaderMap,
     ) -> Result<AuthPrincipal, (StatusCode, Json<ErrorResponse>)> {
         let token = bearer_token(headers)?;
-        // Long-lived edge-registration tokens must only be accepted by handlers
-        // that supply the real request descriptor. Otherwise the provider has
-        // no method/path information with which to enforce token purpose.
+        // Edge-registration tokens are verified locally (shared HMAC key) with
+        // a fail-closed revocation check — no request descriptor needed since
+        // the retired authorize_request callback was replaced by local
+        // verification. This is what lets edge CLIs call plain read surfaces
+        // such as GET /models (external catalog branch).
         if token.starts_with(MOI_USER_TOKEN_PREFIX) {
-            return Err(error_response_coded(
-                StatusCode::UNAUTHORIZED,
-                "Edge registration token requires request-aware authorization",
-                "edge_token_request_context_required",
-            ));
+            return self
+                .principal_from_edge_token(
+                    token,
+                    ProviderRequestDescriptor {
+                        method: String::new(),
+                        path: String::new(),
+                        route: None,
+                        request_id: None,
+                        body_digest: None,
+                    },
+                )
+                .await;
         }
         let claims = decode_jwt_claims(token, &self.jwt)?;
 
@@ -1908,82 +2120,62 @@ impl AuthService for DatabaseAuthService {
         if !token.starts_with(MOI_USER_TOKEN_PREFIX) {
             return Ok(EdgeTokenBinding::NotEdgeToken);
         }
-        // Resolve the MOI external provider. An edge-token-shaped credential
-        // cannot be downgraded to an unbound first-party token when its verifier
-        // is unavailable; that would turn configuration loss into authorization.
-        let provider = match self
-            .ext_providers
-            .iter()
-            .find(|p| p.id == "moi")
-            .or_else(|| self.ext_providers.first())
-        {
-            Some(provider) => provider.clone(),
-            None => {
-                tracing::error!(
-                    target: "astra_services::auth",
-                    "edge_registration_binding: no external provider configured; cannot verify edge binding"
-                );
-                return Err(error_response(
-                    StatusCode::UNAUTHORIZED,
-                    "No external provider configured for edge token auth",
-                ));
-            }
+        // An edge-token-shaped credential cannot be downgraded to an unbound
+        // first-party token when its verifier is unavailable; that would turn
+        // configuration loss into authorization (upstream #582 fail-closed).
+        let Some(cfg) = self.edge_token_auth.as_ref() else {
+            tracing::error!(
+                target: "astra_services::auth",
+                "edge_registration_binding: edge token verification not configured; cannot verify edge binding"
+            );
+            return Err(error_response(
+                StatusCode::UNAUTHORIZED,
+                "Edge token verification is not configured (auth.edge_token_auth.key)",
+            ));
         };
-        // authorize_request verifies the token (signature, expiry, jti
-        // revocation) and returns the bound edge_agent_id and provider_scope_id
-        // (workspace_id). A revoked or invalid edge token yields an Err here,
-        // which the caller treats as a denial.
-        tracing::debug!(
-            target: "astra_services::auth",
-            provider_id = %provider.id,
-            "edge_registration_binding: verifying moi edge token via provider authorize_request"
-        );
-        let authorized = match self
-            .external_client
-            .authorize_request(
-                &provider,
-                ExternalAuthorizeRequestData {
-                    provider_id: provider.id.clone(),
-                    token: format!("Bearer {token}"),
-                    request: ExternalRequestDescriptor {
-                        method: "GET".to_string(),
-                        path: "/edge/ws".to_string(),
-                        route: Some("/edge/ws".to_string()),
-                        request_id: None,
-                        body_digest: None,
-                    },
-                },
-            )
-            .await
-        {
-            Ok(authorized) => authorized,
+        // Local verification covers signature, expiry, and the
+        // edge-registration claim invariants (edge_agent_id + jti present).
+        let claims = match verify_user_token(&cfg.key, token) {
+            Ok(claims) => claims,
             Err((status, err)) => {
                 tracing::warn!(
                     target: "astra_services::auth",
-                    provider_id = %provider.id,
                     status = %status,
                     error = ?err,
-                    "edge_registration_binding: provider rejected edge token (revoked/invalid/expired)"
+                    "edge_registration_binding: edge token rejected (invalid/expired)"
                 );
                 return Err((status, err));
             }
         };
+        if claims.purpose != USER_TOKEN_PURPOSE_EDGE_REGISTRATION {
+            // A verified moi token without the edge_registration purpose is a
+            // runtime (server-to-server) token, not an edge-registration token.
+            return Ok(EdgeTokenBinding::MissingBinding);
+        }
+        // Once-per-connection jti revocation check against moi-core
+        // (fail-closed on denial or unavailability). Fail closed when no
+        // revocation endpoint is configured — consistent with
+        // principal_from_edge_token(); never accept a long-lived
+        // edge-registration credential we cannot revoke.
+        if cfg.check_endpoint.is_empty() {
+            return Err(error_response(
+                StatusCode::UNAUTHORIZED,
+                "Edge token revocation endpoint is not configured; refusing edge-registration token (fail closed)"
+                    .to_string(),
+            ));
+        }
+        self.check_edge_token_revoked(&cfg.check_endpoint, token)
+            .await?;
         tracing::debug!(
             target: "astra_services::auth",
-            provider_id = %provider.id,
-            edge_agent_id = ?authorized.edge_agent_id,
-            workspace_id = %authorized.provider_scope_id,
-            "edge_registration_binding: provider accepted edge token"
+            edge_agent_id = %claims.edge_agent_id,
+            workspace_id = %claims.workspace_id,
+            "edge_registration_binding: edge token verified locally"
         );
-        match authorized.edge_agent_id {
-            Some(edge_agent_id) => Ok(EdgeTokenBinding::Bound {
-                edge_agent_id,
-                workspace_id: authorized.provider_scope_id,
-            }),
-            // A recognized moi token that authorized without an edge_agent_id is
-            // a runtime (server-to-server) token, not an edge-registration token.
-            None => Ok(EdgeTokenBinding::MissingBinding),
-        }
+        Ok(EdgeTokenBinding::Bound {
+            edge_agent_id: claims.edge_agent_id,
+            workspace_id: claims.workspace_id,
+        })
     }
 
     async fn external_providers(
@@ -2154,11 +2346,7 @@ impl AuthService for StubAuthService {
 
 #[cfg(test)]
 mod tests {
-    use super::external::{
-        ExternalLogoutResponse, ExternalProviderAuthResponse, ExternalRefreshSessionResponse,
-    };
     use super::*;
-    use crate::auth::external::ExternalProviderSessionHandle;
     use astra_core::ProviderRequestAuthConfig;
     use chrono::Utc;
     use serde_json::json;
@@ -2167,99 +2355,84 @@ mod tests {
     const GOLDEN_PROVIDER_HMAC_KEY: &str = "WrE2irtwGEq1Ih2stZUtgFfLFNv2gVhOAwsBD999QLI";
     const GOLDEN_PROVIDER_TOKEN: &str = "moi-provider-v1.eyJzdWIiOiJ1c2VyXzEiLCJzY29wZSI6IndvcmtzcGFjZV8xIiwicHJvdmlkZXIiOiJtb2kiLCJpYXQiOjQxMDI0NDQ1MDAsImV4cCI6NDEwMjQ0NDgwMH0.wZS9mRKasIEmreqhzGheguYYPbq1URTYkJoSK3nfW3M";
 
-    #[allow(dead_code)]
-    struct AuthorizingProviderClient;
+    const TEST_EDGE_TOKEN_HMAC_KEY: &str = "test-edge-token-hmac-key";
 
-    #[async_trait]
-    impl ExternalProviderClient for AuthorizingProviderClient {
-        async fn authorize_request(
-            &self,
-            provider: &ExternalAuthProviderConfig,
-            request: ExternalAuthorizeRequestData,
-        ) -> Result<ExternalAuthorizedRequest, (StatusCode, Json<ErrorResponse>)> {
-            assert_eq!(provider.id, "moi");
-            assert_eq!(request.token, "Bearer moi-user-token-v1.payload.signature");
-            assert_eq!(request.request.method, "POST");
-            assert_eq!(request.request.path, "/chat/stream");
-            assert_eq!(request.request.route.as_deref(), Some("/chat/stream"));
-            assert_eq!(request.request.request_id.as_deref(), Some("request-1"));
-            assert_eq!(request.request.body_digest.as_deref(), Some("sha256-body"));
-            Ok(ExternalAuthorizedRequest {
-                provider_id: "moi".to_string(),
-                external_subject: "moi-user-1".to_string(),
-                provider_scope_id: "workspace-1".to_string(),
-                request_authorization_id: "authz-1".to_string(),
-                edge_agent_id: Some("edge-1".to_string()),
-            })
-        }
+    // spawn_revocation_ok_server starts a minimal HTTP endpoint that always
+    // reports "not revoked" ({"code":0,"data":{"ok":true}}). Edge-registration
+    // tokens now fail closed without a revocation endpoint, so acceptance tests
+    // must point check_endpoint at a live "not revoked" responder.
+    async fn spawn_revocation_ok_server() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind revocation mock");
+        let addr = listener.local_addr().expect("mock addr");
+        let app = axum::Router::new().route(
+            "/check",
+            axum::routing::post(|| async {
+                axum::Json(serde_json::json!({"code": 0, "data": {"ok": true}}))
+            }),
+        );
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        format!("http://{addr}/check")
+    }
 
-        async fn authenticate(
-            &self,
-            _provider: &ExternalAuthProviderConfig,
-            _request: ExternalLoginRequestData,
-        ) -> Result<ExternalProviderAuthResponse, (StatusCode, Json<ErrorResponse>)> {
-            unimplemented!("AuthorizingProviderClient stub: authenticate not used in these tests")
-        }
+    async fn spawn_counted_revocation_server(
+        response: serde_json::Value,
+    ) -> (String, Arc<std::sync::atomic::AtomicUsize>) {
+        use std::sync::atomic::Ordering;
 
-        async fn list_catalog(
-            &self,
-            _provider: &ExternalAuthProviderConfig,
-            _session: ExternalProviderSessionHandle,
-        ) -> Result<ExternalCatalogResponse, (StatusCode, Json<ErrorResponse>)> {
-            unimplemented!("AuthorizingProviderClient stub: list_catalog not used in these tests")
-        }
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let handler_calls = Arc::clone(&calls);
+        let response = Arc::new(response);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind counted revocation mock");
+        let addr = listener.local_addr().expect("counted mock addr");
+        let app = axum::Router::new().route(
+            "/check",
+            axum::routing::post(move || {
+                let handler_calls = Arc::clone(&handler_calls);
+                let response = Arc::clone(&response);
+                async move {
+                    handler_calls.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    axum::Json((*response).clone())
+                }
+            }),
+        );
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (format!("http://{addr}/check"), calls)
+    }
 
-        async fn issue_runtime_context(
-            &self,
-            _provider: &ExternalAuthProviderConfig,
-            _session: ExternalProviderSessionHandle,
-            _request: ExternalRuntimeContextRequestData,
-        ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)> {
-            unimplemented!(
-                "AuthorizingProviderClient stub: issue_runtime_context not used in these tests"
-            )
-        }
+    fn mint_user_token(key: &str, claims: &serde_json::Value) -> String {
+        let encoded_claims =
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(claims).expect("claims json"));
+        let signature = provider_request_signature(key.as_bytes(), &encoded_claims);
+        format!("{MOI_USER_TOKEN_PREFIX}.{encoded_claims}.{signature}")
+    }
 
-        async fn refresh_session(
-            &self,
-            _provider: &ExternalAuthProviderConfig,
-            _session: ExternalProviderSessionHandle,
-        ) -> Result<ExternalRefreshSessionResponse, (StatusCode, Json<ErrorResponse>)> {
-            unimplemented!(
-                "AuthorizingProviderClient stub: refresh_session not used in these tests"
-            )
-        }
+    fn edge_registration_claims(now: i64) -> serde_json::Value {
+        json!({
+            "sub": "moi-user-1",
+            "workspace_id": "workspace-1",
+            "iss": "moi-backend",
+            "iat": now,
+            "exp": now + 3600,
+            "edge_agent_id": "edge-1",
+            "jti": "jti-1",
+            "purpose": "edge_registration",
+        })
+    }
 
-        async fn logout(
-            &self,
-            _provider: &ExternalAuthProviderConfig,
-            _session: ExternalProviderSessionHandle,
-        ) -> Result<ExternalLogoutResponse, (StatusCode, Json<ErrorResponse>)> {
-            unimplemented!("AuthorizingProviderClient stub: logout not used in these tests")
-        }
-
-        async fn list_catalog_by_scope(
-            &self,
-            _provider: &ExternalAuthProviderConfig,
-            _provider_scope_id: String,
-            _external_subject: String,
-        ) -> Result<ExternalCatalogResponse, (StatusCode, Json<ErrorResponse>)> {
-            unimplemented!(
-                "AuthorizingProviderClient stub: list_catalog_by_scope not used in these tests"
-            )
-        }
-
-        async fn issue_runtime_context_by_scope(
-            &self,
-            _provider: &ExternalAuthProviderConfig,
-            _provider_scope_id: String,
-            _external_subject: String,
-            _request: ExternalRuntimeContextRequestData,
-        ) -> Result<ExternalRuntimeContextResponse, (StatusCode, Json<ErrorResponse>)> {
-            unimplemented!(
-                "AuthorizingProviderClient stub: issue_runtime_context_by_scope not used in these tests"
-            )
-        }
+    fn edge_registration_token() -> String {
+        mint_user_token(
+            TEST_EDGE_TOKEN_HMAC_KEY,
+            &edge_registration_claims(Utc::now().timestamp()),
+        )
     }
 
     fn hmac_provider_token(
@@ -2309,7 +2482,7 @@ mod tests {
     }
 
     fn edge_provider_service() -> DatabaseAuthService {
-        let mut service = DatabaseAuthService::new(
+        DatabaseAuthService::new(
             astra_core::MatrixOneSettings::mock(),
             JwtSettings {
                 secret_key: "test-secret-key-for-unit-tests".into(),
@@ -2318,20 +2491,35 @@ mod tests {
                 refresh_token_expire_days: 7,
             },
         )
-        .with_external_providers(vec![ExternalAuthProviderConfig {
-            id: "moi".to_string(),
-            display_name: "MOI".to_string(),
-            external_auth_endpoint: "http://127.0.0.1/unused".to_string(),
-        }]);
-        service.external_client = Arc::new(AuthorizingProviderClient);
-        service
+        .with_edge_token_auth(EdgeTokenAuthConfig {
+            key: TEST_EDGE_TOKEN_HMAC_KEY.to_string(),
+            check_endpoint: String::new(),
+        })
     }
 
-    fn edge_headers() -> HeaderMap {
+    // edge_provider_service_with_revocation configures a live revocation
+    // endpoint, required for accepting edge-registration tokens (fail closed).
+    fn edge_provider_service_with_revocation(check_endpoint: String) -> DatabaseAuthService {
+        DatabaseAuthService::new(
+            astra_core::MatrixOneSettings::mock(),
+            JwtSettings {
+                secret_key: "test-secret-key-for-unit-tests".into(),
+                algorithm: "HS256".into(),
+                access_token_expire_minutes: 60,
+                refresh_token_expire_days: 7,
+            },
+        )
+        .with_edge_token_auth(EdgeTokenAuthConfig {
+            key: TEST_EDGE_TOKEN_HMAC_KEY.to_string(),
+            check_endpoint,
+        })
+    }
+
+    fn edge_headers(token: &str) -> HeaderMap {
         let mut headers = HeaderMap::new();
         headers.insert(
             "authorization",
-            "Bearer moi-user-token-v1.payload.signature"
+            format!("Bearer {token}")
                 .parse()
                 .expect("authorization header"),
         );
@@ -2391,13 +2579,111 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn edge_token_authorization_forwards_the_actual_request_descriptor() {
-        let principal = edge_provider_service()
-            .current_principal_for_request(&edge_headers(), chat_stream_descriptor())
+    async fn edge_token_local_verification_resolves_principal() {
+        let token = edge_registration_token();
+        let check_endpoint = spawn_revocation_ok_server().await;
+        let principal = edge_provider_service_with_revocation(check_endpoint)
+            .current_principal_for_request(&edge_headers(&token), chat_stream_descriptor())
             .await
-            .expect("edge token should be authorized for the described request");
+            .expect("edge token should verify locally for the described request");
 
         assert_eq!(principal.user.user_id, "external_authorized:moi:moi-user-1");
+        assert_eq!(principal.user.username, "moi-user-1");
+        let AuthPrincipalOrigin::ProviderAuthorizedRequest(context) = principal.origin else {
+            panic!("expected provider-authorized principal");
+        };
+        assert_eq!(context.provider_id, "moi");
+        assert_eq!(context.external_subject, "moi-user-1");
+        assert_eq!(context.provider_scope_id, "workspace-1");
+        assert_eq!(context.edge_agent_id.as_deref(), Some("edge-1"));
+        assert_eq!(
+            context.request_authorization_id,
+            "moi-user-token-v1:jti:jti-1"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_revocation_cache_misses_are_singleflight_per_jti() {
+        use std::sync::atomic::Ordering;
+
+        let (check_endpoint, calls) =
+            spawn_counted_revocation_server(serde_json::json!({"code": 0, "data": {"ok": true}}))
+                .await;
+        let service = Arc::new(edge_provider_service_with_revocation(
+            check_endpoint.clone(),
+        ));
+        let mut requests = tokio::task::JoinSet::new();
+        for _ in 0..16 {
+            let service = Arc::clone(&service);
+            let check_endpoint = check_endpoint.clone();
+            requests.spawn(async move {
+                service
+                    .check_edge_token_revoked_cached(&check_endpoint, "same-token", "same-jti")
+                    .await
+            });
+        }
+        while let Some(result) = requests.join_next().await {
+            result
+                .expect("revocation check task")
+                .expect("revocation check");
+        }
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "concurrent misses for one jti must share one remote check"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_revocation_denials_share_the_same_inflight_result() {
+        use std::sync::atomic::Ordering;
+
+        let (check_endpoint, calls) =
+            spawn_counted_revocation_server(serde_json::json!({"code": 1, "data": {"ok": false}}))
+                .await;
+        let service = Arc::new(edge_provider_service_with_revocation(
+            check_endpoint.clone(),
+        ));
+        let mut requests = tokio::task::JoinSet::new();
+        for _ in 0..16 {
+            let service = Arc::clone(&service);
+            let check_endpoint = check_endpoint.clone();
+            requests.spawn(async move {
+                service
+                    .check_edge_token_revoked_cached(&check_endpoint, "same-token", "same-jti")
+                    .await
+            });
+        }
+        while let Some(result) = requests.join_next().await {
+            assert!(
+                result.expect("revocation check task").is_err(),
+                "all waiters must receive the shared denial"
+            );
+        }
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "concurrent denials for one jti must share one remote check"
+        );
+    }
+
+    #[tokio::test]
+    async fn edge_token_is_accepted_by_context_free_auth_via_local_verification() {
+        // current_principal verifies edge tokens locally (shared HMAC key) so
+        // edge CLIs can call plain read surfaces such as GET /models; the old
+        // request-descriptor requirement died with the authorize_request
+        // callback. Revocation is enforced inside principal_from_edge_token
+        // whenever a check endpoint is configured (none in this fixture).
+        let token = edge_registration_token();
+        let check_endpoint = spawn_revocation_ok_server().await;
+        let principal = edge_provider_service_with_revocation(check_endpoint)
+            .current_principal(&edge_headers(&token))
+            .await
+            .expect("edge token should verify locally without a request descriptor");
+
+        assert!(principal.is_edge_registration());
         let AuthPrincipalOrigin::ProviderAuthorizedRequest(context) = principal.origin else {
             panic!("expected provider-authorized principal");
         };
@@ -2406,21 +2692,168 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn edge_token_is_rejected_without_request_context() {
-        let err = edge_provider_service()
-            .current_principal(&edge_headers())
+    async fn edge_registration_binding_returns_bound_for_valid_token() {
+        let token = edge_registration_token();
+        // Fail-closed: binding now requires a revocation endpoint.
+        let check_endpoint = spawn_revocation_ok_server().await;
+        let binding = edge_provider_service_with_revocation(check_endpoint)
+            .edge_registration_binding(&token)
             .await
-            .expect_err("context-free auth must not accept an edge token");
-
-        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+            .expect("valid edge registration token should bind");
         assert_eq!(
-            err.1.error_code.as_deref(),
-            Some("edge_token_request_context_required")
+            binding,
+            EdgeTokenBinding::Bound {
+                edge_agent_id: "edge-1".to_string(),
+                workspace_id: "workspace-1".to_string(),
+            }
         );
     }
 
     #[tokio::test]
-    async fn edge_registration_binding_fails_closed_without_provider() {
+    async fn edge_registration_binding_runtime_purpose_is_missing_binding() {
+        let now = Utc::now().timestamp();
+        let token = mint_user_token(
+            TEST_EDGE_TOKEN_HMAC_KEY,
+            &json!({
+                "sub": "moi-user-1",
+                "workspace_id": "workspace-1",
+                "iss": "moi-catalog",
+                "iat": now,
+                "exp": now + 3600,
+                "purpose": "runtime",
+            }),
+        );
+        let binding = edge_provider_service()
+            .edge_registration_binding(&token)
+            .await
+            .expect("runtime token should verify but carry no binding");
+        assert_eq!(binding, EdgeTokenBinding::MissingBinding);
+    }
+
+    #[tokio::test]
+    async fn edge_registration_binding_rejects_wrong_key_signature() {
+        let token = mint_user_token(
+            "wrong-key",
+            &edge_registration_claims(Utc::now().timestamp()),
+        );
+        let err = edge_provider_service()
+            .edge_registration_binding(&token)
+            .await
+            .expect_err("wrong-key signature must be rejected");
+        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+        assert_eq!(err.1.error_code.as_deref(), Some("edge_token_auth_invalid"));
+    }
+
+    #[tokio::test]
+    async fn edge_registration_binding_rejects_expired_token() {
+        let now = Utc::now().timestamp();
+        let mut claims = edge_registration_claims(now - 7200);
+        claims["exp"] = json!(now - 3600);
+        let token = mint_user_token(TEST_EDGE_TOKEN_HMAC_KEY, &claims);
+        let err = edge_provider_service()
+            .edge_registration_binding(&token)
+            .await
+            .expect_err("expired token must be rejected");
+        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+        assert_eq!(err.1.error_code.as_deref(), Some("edge_token_auth_invalid"));
+    }
+
+    #[tokio::test]
+    async fn edge_registration_binding_accepts_token_at_exp_second() {
+        // Parity with the Go verifiers: the token is accepted through the exp
+        // second (`now > exp` rejects, `now == exp` does not).
+        let now = Utc::now().timestamp();
+        let mut claims = edge_registration_claims(now);
+        claims["exp"] = json!(now + 1);
+        let token = mint_user_token(TEST_EDGE_TOKEN_HMAC_KEY, &claims);
+        // Fail-closed: binding now requires a revocation endpoint.
+        let check_endpoint = spawn_revocation_ok_server().await;
+        edge_provider_service_with_revocation(check_endpoint)
+            .edge_registration_binding(&token)
+            .await
+            .expect("token at/before exp second must be accepted");
+    }
+
+    #[tokio::test]
+    async fn edge_registration_binding_fails_closed_without_revocation_endpoint() {
+        // A valid edge token whose HMAC key is configured but with no revocation
+        // endpoint must be refused (fail-closed) — consistent with
+        // principal_from_edge_token; never accept a long-lived credential we
+        // cannot revoke.
+        let token = edge_registration_token();
+        let err = edge_provider_service() // empty check_endpoint
+            .edge_registration_binding(&token)
+            .await
+            .expect_err("edge token without a revocation endpoint must be rejected");
+        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn edge_registration_binding_rejects_missing_jti() {
+        let now = Utc::now().timestamp();
+        let mut claims = edge_registration_claims(now);
+        claims.as_object_mut().expect("claims object").remove("jti");
+        let token = mint_user_token(TEST_EDGE_TOKEN_HMAC_KEY, &claims);
+        let err = edge_provider_service()
+            .edge_registration_binding(&token)
+            .await
+            .expect_err("edge_registration token without jti must be rejected");
+        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+        assert_eq!(err.1.error_code.as_deref(), Some("edge_token_auth_invalid"));
+    }
+
+    #[tokio::test]
+    async fn edge_registration_binding_rejects_moi_backend_runtime_purpose() {
+        let now = Utc::now().timestamp();
+        let token = mint_user_token(
+            TEST_EDGE_TOKEN_HMAC_KEY,
+            &json!({
+                "sub": "moi-user-1",
+                "workspace_id": "workspace-1",
+                "iss": "moi-backend",
+                "iat": now,
+                "exp": now + 3600,
+                "purpose": "runtime",
+            }),
+        );
+        let err = edge_provider_service()
+            .edge_registration_binding(&token)
+            .await
+            .expect_err("moi-backend issuer with runtime purpose must be rejected");
+        assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+        assert_eq!(err.1.error_code.as_deref(), Some("edge_token_auth_invalid"));
+    }
+
+    #[tokio::test]
+    async fn edge_token_runtime_purpose_principal_has_no_edge_binding() {
+        let now = Utc::now().timestamp();
+        let token = mint_user_token(
+            TEST_EDGE_TOKEN_HMAC_KEY,
+            &json!({
+                "sub": "moi-user-2",
+                "workspace_id": "workspace-2",
+                "iss": "moi-catalog",
+                "iat": now,
+                "exp": now + 3600,
+            }),
+        );
+        let principal = edge_provider_service()
+            .current_principal_for_request(&edge_headers(&token), chat_stream_descriptor())
+            .await
+            .expect("runtime token should resolve a principal");
+        let AuthPrincipalOrigin::ProviderAuthorizedRequest(context) = principal.origin else {
+            panic!("expected provider-authorized principal");
+        };
+        assert_eq!(context.provider_scope_id, "workspace-2");
+        assert_eq!(context.edge_agent_id, None);
+        assert_eq!(
+            context.request_authorization_id,
+            format!("moi-user-token-v1:moi-user-2:{}", now + 3600)
+        );
+    }
+
+    #[tokio::test]
+    async fn edge_registration_binding_fails_closed_without_edge_token_auth() {
         let service = DatabaseAuthService::new(
             astra_core::MatrixOneSettings::mock(),
             JwtSettings {

--- a/docs/design/moi-sandbox-integration.md
+++ b/docs/design/moi-sandbox-integration.md
@@ -67,6 +67,7 @@ payload.  Edge-registration tokens carry a `jti` for revocation.
 | F7 | Feature | `edge_agent` CapabilityDescriptor field | `services/src/runs.rs` |
 | F8 | Feature | Force EdgeWs transport to EdgeBound routing | `runtime/src/server/tool_route_selection.rs` |
 | F9 | Feature | Service-to-service edge status endpoint | `runtime/src/server/edge/edge_service_status_handler.rs` |
+| F10 | Feature | Local edge-token verification + connect-time revocation check (replaces the retired external-auth callback) | `services/src/auth/mod.rs`, `services/src/auth/external.rs`, `core/src/config.rs` |
 | B1 | Bug Fix | Connection pool generation guards against stale cleanup races | `astra-server-types/src/edge_connection_pool.rs` |
 | B2 | Bug Fix | DB registration failure rejects WebSocket connection | `runtime/src/server/edge/edge_ws_handler.rs` |
 | B3 | Bug Fix | Heartbeat scoped by edge_id to prevent stale connection refresh | `services/src/multi_agent/edge_registry.rs` |
@@ -84,6 +85,10 @@ payload.  Edge-registration tokens carry a `jti` for revocation.
 ## Detailed Descriptions
 
 ### F1 — MOI edge-registration token WebSocket auth
+
+> **Superseded in part by F10**: token verification is now local (no
+> authorize_request callback); the binding/three-state semantics below are
+> unchanged.
 
 **Files:** `services/src/auth/mod.rs`, `runtime/src/server/edge/edge_ws_handler.rs`
 
@@ -180,6 +185,17 @@ New `connect_via_proxy()` implements HTTP CONNECT tunneling:
 **`astra-thin-client/src/client.rs`:** `.no_proxy()` removed from both
 `streaming_http_client` and `ThinClient::new()`.  A source-level guard test
 asserts `.no_proxy()` is absent to prevent accidental re-introduction.
+
+**`astra-core/src/net.rs` + `astra-cli` (2026-07-23 follow-up):** the CLI's
+auxiliary clients (task service, todos, preferences, team store, durable
+bridge, memoria cloud tools) hard-coded `.no_proxy()` under the "internal =
+same host" assumption, which broke inside mandatory-egress-proxy sandboxes
+(requests to the remote Astra server timed out; symptom: `Skill sources
+unavailable`).  New shared policy `astra_core::net::client_builder_for_target
+(url)`: loopback targets stay `no_proxy`, remote targets keep reqwest's
+env-aware proxy behavior.  All nine call sites now route through it; the
+env-mutating proxy regression test and the cloud_sync tests are serialized
+(`serial_test`) because proxy env vars are process-global.
 
 #### Scope
 
@@ -427,6 +443,45 @@ is delayed at most one 2-second poll cycle — correctness is unaffected.
 ---
 
 ## Refactors Applied During Code Review
+
+### F10 — Local edge-token verification + connect-time revocation check
+
+**Files:** `services/src/auth/mod.rs`, `services/src/auth/external.rs`, `core/src/config.rs`
+
+moi-core #12865 retired the `POST /api/v1/astra/external-auth` callback (and the
+whole provider-session surface) in favor of provider HMAC. Astra's edge path
+followed:
+
+- `verify_user_token` verifies `moi-user-token-v1.*` tokens **locally** with the
+  shared HMAC key (`auth.edge_token_auth.key`, env
+  `${ASTRA_EDGE_TOKEN_HMAC_KEY}`), mirroring moi-core `UserTokenSigner.Verify`
+  fail-closed rules (iss=moi-backend ⇒ edge_registration; edge_registration ⇒
+  edge_agent_id + jti required).
+- `principal_from_edge_token` and `edge_registration_binding` no longer call
+  the provider over HTTP; claims map directly to the principal / binding.
+- **Revocation** (the one thing a self-contained token cannot carry) is checked
+  against moi-core `POST /api/v1/astra/edge-tokens/check`
+  (`auth.edge_token_auth.check_endpoint`) on **every surface that accepts an
+  edge token** — the edge WebSocket connect AND every HTTP request (chat, GET
+  /models, ...). Fail-closed on denial or unavailability.
+
+**Revocation surface (updated 2026-07-29).** Revocation is enforced
+per-request with a **30-second positive-only cache** keyed by jti
+(`check_edge_token_revoked_cached`): a jti that recently passed is trusted for
+up to 30s; denials and check-endpoint outages are never cached and always fail
+closed. Operational implications:
+
+- Worst-case revocation propagation on astra surfaces is **≤ 30 seconds**
+  (plus the moi-backend renewal grace window of ≤ 5 minutes for
+  rotated-away previous jtis — see the dual-valid rotation design).
+- Catalog load is bounded at ~1 check per active jti per 30s, not one per
+  request.
+
+The earlier design traded per-request revocation away entirely (exposure
+bounded only by token TTL); that stance was reversed after review — a revoked
+30-day token remaining valid on `/chat/stream` was judged unacceptable.
+
+---
 
 ### R1 — Phase 1.5 reads from resolved principal (no second provider call)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -85,6 +85,25 @@ by MOI deployment tooling. Astra uses the configured string's UTF-8 bytes
 directly as the provider request HMAC key; it does not base64url-decode the
 string before verifying request tokens.
 
+### Edge Token Auth
+
+MOI edge-registration tokens (`moi-user-token-v1.*`) presented by sandbox/runner
+edge agents are verified locally under `auth.edge_token_auth` in `server.toml`
+using a shared HMAC key (the MOI `jwt_secret`). Whenever `key` is configured,
+`check_endpoint` is **required** — config validation rejects a key without one so
+revocation can never be silently skipped. Astra then performs a jti revocation
+check against moi-core on **every surface that
+accepts an edge token** — the edge WebSocket connect and every HTTP request —
+with a 30-second positive-only cache per jti (denials and check-endpoint
+outages are never cached; both fail closed). Worst-case revocation propagation
+on astra surfaces is therefore ≤ 30 seconds.
+
+```toml
+[auth.edge_token_auth]
+key = "${ASTRA_EDGE_TOKEN_HMAC_KEY}"
+check_endpoint = "http://moi-catalog:8081/api/v1/astra/edge-tokens/check"
+```
+
 ### LLM
 
 LLM models are **not** configured via env vars. Use the admin CLI:


### PR DESCRIPTION
  ## What type of PR is this?

  - [x] feat (new feature)
  - [x] fix (bug fix)
  - [x] docs (documentation)
  - [ ] style (formatting, no code change)
  - [x] refactor (code change that neither fixes a bug nor adds a feature)
  - [ ] perf (performance improvement)
  - [x] test (adding or updating tests)
  - [ ] chore (maintenance, tooling)
  - [ ] build / ci (build or CI changes)

  ## Which issue(s) this PR fixes

  Fixes [# ](https://github.com/matrixorigin/astra/issues/556) https://github.com/matrixorigin/astra/issues/563

  ## What this PR does / why we need it

  This PR completes the Astra edge integration with MOI sandbox/runner environments.

  It introduces renewable edge-token management, moves edge-token authentication to local HMAC verification, adds fail-
  closed revocation checks, and fixes proxy handling for clients that may connect to either local or remote Astra services.

  ### Edge token lifecycle

  - Add a centralized `TokenManager` responsible for:
    - tracking the active edge token and its generation
    - rejecting stale renewal responses
    - preventing tokens from being replaced across MOI identities
    - atomically persisting renewed tokens
    - retrying failed persistence operations
  - Add a background edge-token renewal task.
  - Support configurable renewal URL, token file, and renewal threshold.
  - Handle transient failures, rejected tokens, malformed tokens, expired tokens, and persistence failures.
  - Disable HTTP redirects for renewal requests so token-bearing POST bodies cannot be forwarded to another origin.

  ### Edge authentication

  - Verify `moi-user-token-v1` edge tokens locally using the configured MOI HMAC key.
  - Map verified token claims directly to the Astra principal and edge-registration binding.
  - Require `edge_agent_id` and `jti` for edge-registration tokens.
  - Add fail-closed MOI revocation checks for every surface accepting an edge token.
  - Add a 30-second positive-only revocation cache keyed by `jti`.
  - Deduplicate concurrent revocation checks for the same token.
  - Do not cache revocation denials or endpoint failures.
  - Preserve external provider callbacks for catalog and runtime-context scope resolution.
  - Validate duplicate provider IDs and unresolved secret placeholders at startup.

  ### Proxy handling

  - Add `astra_core::net::client_builder_for_target`.
  - Bypass environment proxies for loopback targets.
  - Preserve environment-aware proxy behavior for remote targets.
  - Apply the policy to Astra CLI, edge, Memoria, task, preference, todo, team-store, and external-provider clients.
  - Fix remote Astra access from mandatory-egress-proxy sandbox environments.

  ### Additional fixes

  - Stop isolated skill discovery at the repository boundary.
  - Ensure isolated discovery without repository traversal searches only the current working directory.
  - Update MOI integration and configuration documentation.

  ## Configuration

  Server-side edge authentication:

  ```toml
  [auth.edge_token_auth]
  key = "${ASTRA_EDGE_TOKEN_HMAC_KEY}"
  check_endpoint = "http://moi-catalog:8081/api/v1/astra/edge-tokens/check"
 ```

  Edge renewal environment variables:

```
  ASTRA_TOKEN_RENEW_URL
  ASTRA_TOKEN_FILE
  ASTRA_TOKEN_RENEW_THRESHOLD_SECS
```
  check_endpoint is required whenever the edge-token HMAC key is configured, so revocation cannot be silently disabled.

  ## Architecture and complexity delta

  - Canonical owner changed or extended:
      - astra-edge::TokenManager is the canonical owner of edge-token state, replacement, and persistence.
      - astra-edge::token_renewal owns renewal scheduling and retry behavior.
      - astra-services::auth owns local edge-token verification and revocation enforcement.
      - astra-core::net owns target-aware HTTP proxy policy.

  - Existing implementations/callers searched:
      - Edge startup and WebSocket authentication
      - HTTP authentication middleware
      - External provider catalog/runtime-context callbacks
      - Astra CLI auxiliary HTTP clients
      - Memoria and cloud-sync clients
      - Skill project-root discovery

  - Superseded code, states, tables, shims, and self-only tests removed:
      - Removed the edge-token external authorization callback path.
      - Replaced scattered token mutation with the centralized token manager.
      - Replaced unconditional .no_proxy() usage in target-dependent clients.

  - Net code/state/table delta:
      - 21 files changed
      - 2,653 insertions
      - 311 deletions
      - No database schema changes

  - If parallel implementations remain, the external boundary and retirement condition:
      - Edge-token authentication is local.
      - External provider HTTP callbacks remain only for model catalog and runtime-context scope resolution.

  ## Production wiring and verification

  - Public product entrypoint exercised:
      - astra-edge startup and token renewal
      - Edge WebSocket authentication
      - HTTP requests authenticated with edge tokens
      - External provider catalog/runtime-context requests
      - Remote Astra access through environment proxies

  - Unhappy paths exercised:
      - malformed and expired tokens
      - identity mismatch during renewal
      - stale renewal responses
      - renewal timeout and transient transport failures
      - renewal rejection
      - token-file persistence failures
      - revoked tokens
      - revocation endpoint denial, outage, and malformed responses
      - concurrent revocation requests
      - unresolved configuration secrets
      - duplicate external provider IDs
      - local versus remote proxy selection
      - repository-boundary skill discovery

  - Database schema/query/transaction/migration verified against a real database, or N/A with reason:
      - N/A — this PR does not modify database schemas, migrations, or transactional behavior.

  ## Verification performed

  - [x] cargo test -p astra-edge — 43 passed
  - [x] cargo test -p astra-services auth::tests — 31 passed
  - [x] cargo test -p astra-services auth::external::tests — 6 passed
  - [x] cargo test -p astra-core server_config_ — 33 passed
  - [x] Previously failing astra-skills isolated-project tests pass
  - [x] git diff --check
  - [ ] Full workspace test suite rerun after the final changes