### PR TITLE
fix(runtime): preserve bridge turn boundaries through context optimization

### DIFF
--- a/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -500,15 +500,17 @@ pub(crate) async fn stream_chat_sse(
             }
         }
     }
-    let messages = load_turn_messages(p.pre_loaded_messages.take(), p.history, p.message).map_err(
-        |error| crate::TurnFailure {
+    let mut messages = load_turn_messages(p.pre_loaded_messages.take(), p.history, p.message)
+        .map_err(|error| crate::TurnFailure {
             error: error.to_string(),
             partial: crate::PartialTurnData {
                 session_id: p.session_id.map(str::to_string),
                 ..Default::default()
             },
-        },
-    )?;
+        })?;
+    if let Some(current) = messages.last_mut() {
+        astra_turn_types::mark_bridge_turn_message(current, &parent_turn_run_id);
+    }
     // Only the fresh user suffix starts this root execution transcript. The
     // preceding prompt history is inherited context, not a new conversation
     // item for this run.

--- a/crates/astra-cli/src/cli/session/session_cleanup.rs
+++ b/crates/astra-cli/src/cli/session/session_cleanup.rs
@@ -55,20 +55,21 @@ pub(crate) async fn finalize_session_exit(
     profile: Option<&str>,
     reason: SessionExit,
 ) {
+    // Finalization is allowed to release process-local session state. Capture
+    // the durable identity first so exit UX and EOF profile cleanup do not
+    // depend on mutation order inside the finalizer.
+    let session_id = state.session_id.clone();
+    let resume_hint = resume_hint_for_exit(reason, session_id.as_deref());
     finalize_session(state).await;
 
-    if should_show_resume_hint(reason)
-        && state.turn > 0
-        && let Some(ref sid) = state.session_id
-    {
-        let (label, command) = resume_hint_lines(sid);
+    if let Some((label, command)) = resume_hint {
         eprintln!();
         eprintln!("{}", format!("  {label}").dim());
         eprintln!("{}", format!("    {command}").cyan());
     }
 
     if should_clear_last_session_id(reason)
-        && let Some(ref session_id) = state.session_id
+        && let Some(ref session_id) = session_id
     {
         clear_profile_last_session_if_matches_or_warn(
             profile,
@@ -84,11 +85,27 @@ fn should_show_resume_hint(reason: SessionExit) -> bool {
     !matches!(reason, SessionExit::Error)
 }
 
-fn resume_hint_lines(session_id: &str) -> (String, String) {
-    (
+pub(crate) fn resume_hint_for_exit(
+    reason: SessionExit,
+    session_id: Option<&str>,
+) -> Option<(String, String)> {
+    if !should_show_resume_hint(reason) {
+        return None;
+    }
+    let session_id = session_id.filter(|id| !id.is_empty())?;
+    session_journal::validate_session_id(session_id).ok()?;
+    let session_argument = if session_id
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        session_id.to_string()
+    } else {
+        crate::edge_tools::shell_escape(session_id)
+    };
+    Some((
         "Resume this session with:".to_string(),
-        format!("/resume {session_id}"),
-    )
+        format!("astra --resume {session_argument}"),
+    ))
 }
 
 fn should_clear_last_session_id(reason: SessionExit) -> bool {
@@ -389,7 +406,7 @@ pub(crate) fn shutdown_session_facts(state: &SessionState) -> astra_runtime::Ses
 #[cfg(test)]
 mod tests {
     use super::{
-        SessionExit, finalize_session_exit, resume_hint_lines, settle_memory_maintenance,
+        SessionExit, finalize_session_exit, resume_hint_for_exit, settle_memory_maintenance,
         should_clear_last_session_id, should_show_resume_hint, shutdown_session_facts,
     };
     use crate::cli::cli_config::cli_utils::{
@@ -464,9 +481,32 @@ mod tests {
 
     #[test]
     fn resume_hint_prints_copyable_resume_command() {
-        let (label, command) = resume_hint_lines("1234-5678");
+        let (label, command) = resume_hint_for_exit(
+            SessionExit::Command,
+            Some("550e8400-e29b-41d4-a716-446655440000"),
+        )
+        .expect("completed interactive session is resumable");
         assert_eq!(label, "Resume this session with:");
-        assert_eq!(command, "/resume 1234-5678");
+        assert_eq!(
+            command,
+            "astra --resume 550e8400-e29b-41d4-a716-446655440000"
+        );
+        assert_eq!(resume_hint_for_exit(SessionExit::Command, None), None);
+        assert_eq!(
+            resume_hint_for_exit(SessionExit::Command, Some(" session-1 ")),
+            Some((
+                "Resume this session with:".to_string(),
+                "astra --resume ' session-1 '".to_string(),
+            ))
+        );
+        assert_eq!(
+            resume_hint_for_exit(SessionExit::Error, Some("session-1")),
+            None
+        );
+        assert_eq!(
+            resume_hint_for_exit(SessionExit::Command, Some("../../unsafe")),
+            None
+        );
     }
 
     #[test]

--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -106,6 +106,7 @@ mod shell;
 use astra_tools::env_tools;
 use astra_tools::schemas::all_tool_schemas as full_tool_schemas;
 pub use env_tools::apply_overlay as apply_env_overlay;
+pub(crate) use shell::shell_escape;
 #[path = "edge_tools/code_analysis.rs"]
 mod code_analysis;
 #[path = "edge_tools/config_tool.rs"]

--- a/crates/astra-cli/src/tui/ARCHITECTURE.md
+++ b/crates/astra-cli/src/tui/ARCHITECTURE.md
@@ -23,9 +23,10 @@
 │                                                                 │
 │  ✶ Thinking … (2.3s · ↓ 340 tok)                                │  ← StatusIndicator
 │                                                                 │     or the active
-│────────────────────────────────────────────────────────────────│     HistoryCell
-│  › Ask astra to do anything                                     │  ← Composer
-│  / commands · $ skills · Ctrl+O transcript     ~/dir · 7k↑ 85↓ │  ← Footer
+│  ───────────────                                      95k / 800k │  ← Context rail
+│  › Message Astra                                                 │  ← Composer
+│                                                                  │
+│  sonnet-4.6                                      ~/dir  ⎇ branch │  ← Status
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -61,17 +62,17 @@ read paths:
 | Name | Description | Location |
 |------|-------------|----------|
 | **Scrollback** | Terminal native scrollback above the viewport. Committed HistoryCells flushed here. | Top of screen, grows upward |
-| **Viewport** | Fixed-height region at screen bottom managed by ratatui. Active cell + separator + bottom pane. | Bottom N rows |
+| **Viewport** | Fixed-height region at screen bottom managed by ratatui. Active cell + bottom pane. | Bottom N rows |
 | **Active-cell area** | Live `HistoryCell` (streaming assistant, running tool, reasoning) or `StatusIndicator` fallback. | Top of viewport |
-| **Separator** | Thin `────` dim line between active cell and composer. | Between active cell and bottom pane |
-| **Bottom Pane** | Composer + Footer, or an overlay view (HelpView, TranscriptView, …). | Bottom of viewport |
+| **Bottom Pane** | Context rail + composer + status, or an overlay view (HelpView, TranscriptView, …). | Bottom of viewport |
 
 ### Bottom-pane components
 
 | Name | Description | When visible |
 |------|-------------|--------------|
-| **Composer** | Input line with `› ` prefix. Emacs keybindings, multi-line with Shift+Enter. | Always (unless an overlay is active) |
-| **Footer** | Shortcuts hint (left) + model · dir · tokens · cost (right) | When no popup/overlay is active |
+| **Context rail** | Request input occupancy encoded by line length and semantic colour, with one compact absolute readout. | Above the composer once usage is known |
+| **Composer** | Two-row-minimum editing surface with `› ` prefix. Emacs keybindings, expands for multi-line input. | Always (unless an overlay is active) |
+| **Status** | Model and attention states on the left; workspace identity on the right. Default policy and key tutorials stay hidden. | When no popup/overlay is active |
 | **Slash Popup** | Command list under composer, filters as user types `/…` | Composer text starts with `/` |
 | **Skill Popup** | Skill mention list, triggered by `$` | Composer text starts with `$` |
 | **Workspace / Overlay Panel** | A primary workspace (root/agent transcript or task board) replaces compact chat; forms and pickers remain bounded overlays. | When a view is pushed onto `view_stack` |

--- a/crates/astra-cli/src/tui/bottom_pane/chat_composer.rs
+++ b/crates/astra-cli/src/tui/bottom_pane/chat_composer.rs
@@ -54,8 +54,6 @@ pub(crate) struct ChatComposer {
 const PASTE_INLINE_MAX_CHARS: usize = 800;
 const PASTE_INLINE_MAX_LINES: usize = 2;
 const COMPOSER_PLACEHOLDER: &str = "Message Astra";
-const IDLE_COMPOSER_HELPER: &str = "Enter send · Shift+Enter newline · / commands · Alt+E editor";
-const ACTIVE_TURN_HELPER: &str = "Enter queues follow-up · Ctrl+C stops · / commands";
 
 impl ChatComposer {
     pub fn new() -> Self {
@@ -359,8 +357,13 @@ impl ChatComposer {
 
     pub fn desired_height(&self, width: u16) -> u16 {
         let inner_w = width.saturating_sub(self.prefix_display_width());
-        let helper_rows = u16::from(text_area_can_show_helper(2));
-        (self.textarea.desired_height(inner_w) + helper_rows).clamp(2, 4)
+        // The second row is intentional breathing room, not a permanent key
+        // legend. It keeps the composer feeling like an editing surface and
+        // lets multiline input grow without changing visual language.
+        self.textarea
+            .desired_height(inner_w)
+            .saturating_add(1)
+            .clamp(2, 4)
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> ComposerAction {
@@ -439,7 +442,7 @@ impl ChatComposer {
         }
     }
 
-    pub fn render(&self, area: Rect, buf: &mut Buffer, task_active: bool, queueing: bool) {
+    pub fn render(&self, area: Rect, buf: &mut Buffer, queueing: bool) {
         if area.height == 0 || area.width == 0 {
             return;
         }
@@ -464,7 +467,6 @@ impl ChatComposer {
         // The submit flash still wins outright when a send lands.
         let mut prefix_style = Style::default()
             .fg(theme.accent_dim())
-            .add_modifier(ratatui::style::Modifier::BOLD)
             .bg(panel.bg.unwrap_or(Color::Reset));
         if queueing && !self.is_flashing() {
             prefix_style = prefix_style.fg(theme.accent);
@@ -491,18 +493,11 @@ impl ChatComposer {
         );
         Widget::render(Line::from(prefix), prefix_area, buf);
 
-        let helper_h = u16::from(text_area_can_show_helper(content_area.height));
         let text_area = Rect::new(
             content_area.x + prefix_width.min(content_area.width),
             content_area.y,
             content_area.width.saturating_sub(prefix_width),
-            content_area.height.saturating_sub(helper_h).max(1),
-        );
-        let helper_area = Rect::new(
-            text_area.x,
-            text_area.y + text_area.height.min(content_area.height.saturating_sub(1)),
-            text_area.width,
-            helper_h,
+            content_area.height.max(1),
         );
 
         if self.textarea.is_empty() {
@@ -520,22 +515,6 @@ impl ChatComposer {
         } else {
             self.textarea.render(text_area, buf);
         }
-
-        if helper_area.height > 0 {
-            let helper_text = if task_active {
-                ACTIVE_TURN_HELPER
-            } else {
-                IDLE_COMPOSER_HELPER
-            };
-            let helper = Span::styled(
-                truncate_end(helper_text, helper_area.width as usize),
-                Style::default()
-                    .fg(theme.dim)
-                    .bg(panel.bg.unwrap_or(Color::Reset))
-                    .add_modifier(ratatui::style::Modifier::DIM),
-            );
-            Widget::render(Line::from(helper), helper_area, buf);
-        }
     }
 
     pub fn cursor_position(&self, area: Rect) -> Option<(u16, u16)> {
@@ -544,19 +523,14 @@ impl ChatComposer {
         let content_h = area.height.saturating_sub(top_inset);
         let content_area = Rect::new(area.x, content_y, area.width, content_h.max(1));
         let prefix_width = self.prefix_display_width();
-        let helper_h = u16::from(text_area_can_show_helper(content_area.height));
         let text_area = Rect::new(
             content_area.x + prefix_width.min(content_area.width),
             content_area.y,
             content_area.width.saturating_sub(prefix_width),
-            content_area.height.saturating_sub(helper_h).max(1),
+            content_area.height.max(1),
         );
         self.textarea.cursor_position(text_area)
     }
-}
-
-fn text_area_can_show_helper(content_h: u16) -> bool {
-    content_h >= 2
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -774,8 +748,11 @@ mod paste_tests {
     }
 
     #[test]
-    fn active_turn_helper_surfaces_queue_semantics() {
-        assert!(ACTIVE_TURN_HELPER.contains("Enter queues"));
-        assert!(ACTIVE_TURN_HELPER.contains("Ctrl+C"));
+    fn composer_keeps_breathing_room_and_grows_for_multiline_input() {
+        let mut composer = ChatComposer::new_ephemeral();
+        assert_eq!(composer.desired_height(80), 2);
+
+        composer.set_text("first\nsecond\nthird");
+        assert_eq!(composer.desired_height(80), 4);
     }
 }

--- a/crates/astra-cli/src/tui/bottom_pane/footer.rs
+++ b/crates/astra-cli/src/tui/bottom_pane/footer.rs
@@ -4,18 +4,14 @@
 //! pure [`StatusContext`]; this struct remains as the mutable container
 //! the event loop writes into, to avoid churn across call sites.
 
-use std::time::Duration;
-
 use ratatui::{buffer::Buffer, layout::Rect};
 
 use crate::cli::permission_manager::{PermissionMode, PermissionModeMirror};
-use crate::tui::status_line::{BackgroundTaskCounts, StatusContext, StatusLine};
+use crate::tui::status_line::{BackgroundTaskCounts, ContextBar, StatusContext, StatusLine};
 use astra_turn_types::{ContextWindowUsage, ContextWindowUsageSource};
 
 pub(crate) struct Footer {
     pub model: Option<String>,
-    pub session_id: Option<String>,
-    pub token_usage: Option<String>,
     pub cwd: Option<String>,
     pub is_turn_active: bool,
     pub permission_mode: Option<PermissionMode>,
@@ -31,8 +27,6 @@ pub(crate) struct Footer {
     /// exact system-prompt count through a typed SSE signal.
     context_window_non_system_tokens: Option<(u64, u64)>,
     last_system_prompt_tokens: Option<u32>,
-    pub current_objective: Option<String>,
-    pub turn_elapsed: Option<Duration>,
     pub pending_approvals: usize,
     pub task_counts: Option<(usize, usize)>,
     pub task_board_expanded: bool,
@@ -53,8 +47,6 @@ impl Footer {
     pub fn new() -> Self {
         Self {
             model: None,
-            session_id: None,
-            token_usage: None,
             cwd: current_cwd_display(),
             is_turn_active: false,
             permission_mode: None,
@@ -66,8 +58,6 @@ impl Footer {
             context_window_is_previous: false,
             context_window_non_system_tokens: None,
             last_system_prompt_tokens: None,
-            current_objective: None,
-            turn_elapsed: None,
             pending_approvals: 0,
             task_counts: None,
             task_board_expanded: false,
@@ -105,15 +95,7 @@ impl Footer {
         StatusContext {
             model: self.model.clone(),
             cwd: self.cwd.clone(),
-            context_window: self.context_window,
-            raw_context_window_tokens: self.raw_context_window_tokens,
-            context_window_is_previous: self.context_window_is_previous,
-            current_objective: self.current_objective.clone(),
-            turn_elapsed: self.turn_elapsed,
             permission_mode: self.live_mode(),
-            turn_active: self.is_turn_active,
-            session_id: self.session_id.clone(),
-            cost_usd: None,
             // Prefer the cached field refreshed by `refresh_env()`,
             // but fall back to a direct probe if the footer has not
             // been initialized yet (useful for early renders/tests).
@@ -221,6 +203,13 @@ impl Footer {
         }
         StatusLine::from_context(&self.to_context()).render(area, buf);
     }
+
+    /// Render request capacity as a quiet rail immediately above the input.
+    /// The detailed raw/usable policy remains available in the context panel;
+    /// this surface shows only the actionable input budget.
+    pub fn render_context_bar(&self, area: Rect, buf: &mut Buffer) {
+        ContextBar::new(self.context_window, self.context_window_is_previous).render(area, buf);
+    }
 }
 
 /// Home-shortened cwd for the status line (`~/foo/bar`). Falls back
@@ -254,17 +243,6 @@ fn detect_git_branch() -> Option<String> {
 mod tests {
     use super::Footer;
     use astra_turn_types::{ContextWindowUsage, ContextWindowUsageSource};
-    use std::time::Duration;
-
-    #[test]
-    fn footer_passes_objective_and_elapsed_to_status_line() {
-        let mut footer = Footer::new();
-        footer.current_objective = Some("Running bash".to_string());
-        footer.turn_elapsed = Some(Duration::from_secs(16));
-        let ctx = footer.to_context();
-        assert_eq!(ctx.current_objective.as_deref(), Some("Running bash"));
-        assert_eq!(ctx.turn_elapsed, Some(Duration::from_secs(16)));
-    }
 
     #[test]
     fn context_window_replaces_estimate_with_provider_measurement() {
@@ -272,33 +250,31 @@ mod tests {
         footer.begin_context_window_estimate(ContextWindowUsage::estimated(5_000, 160_000));
         footer.set_context_system_prompt_tokens(9_000);
         assert_eq!(
-            footer.to_context().context_window,
+            footer.context_window,
             Some(ContextWindowUsage::estimated(14_000, 160_000))
         );
 
         footer.set_context_window_measured(17_250);
         assert_eq!(
-            footer.to_context().context_window,
+            footer.context_window,
             Some(ContextWindowUsage::provider_reported(17_250, 160_000))
         );
 
         footer.clear_context_window_for_new_request();
-        let previous = footer.to_context();
         assert_eq!(
-            previous.context_window,
+            footer.context_window,
             Some(ContextWindowUsage::provider_reported(17_250, 160_000))
         );
-        assert!(previous.context_window_is_previous);
+        assert!(footer.context_window_is_previous);
 
         footer.begin_context_window_estimate(ContextWindowUsage::estimated(8_000, 160_000));
-        let next_context = footer.to_context();
-        let next = next_context.context_window.expect("new estimate");
+        let next = footer.context_window.expect("new estimate");
         assert_eq!(
             next.used_tokens, 17_000,
             "prior system count is a bridge only"
         );
         assert_eq!(next.source, ContextWindowUsageSource::Estimated);
-        assert!(!next_context.context_window_is_previous);
+        assert!(!footer.context_window_is_previous);
     }
 
     #[test]
@@ -313,10 +289,9 @@ mod tests {
             output_tokens: 4_000,
         });
 
-        let context = footer.to_context();
-        assert_eq!(context.raw_context_window_tokens, Some(1_000_000));
+        assert_eq!(footer.raw_context_window_tokens, Some(1_000_000));
         assert_eq!(
-            context.context_window,
+            footer.context_window,
             Some(ContextWindowUsage::estimated(700_000, 910_000))
         );
         assert_eq!(
@@ -334,20 +309,18 @@ mod tests {
         assert_eq!(footer.raw_context_window_tokens, Some(1_000_000));
 
         footer.set_context_window_policy(200_000, 180_000);
-        let previous = footer.to_context();
         assert_eq!(
-            previous.context_window,
+            footer.context_window,
             Some(ContextWindowUsage::estimated(700_000, 910_000)),
             "the next request's policy must not relabel stale evidence from the previous request"
         );
-        assert_eq!(previous.raw_context_window_tokens, Some(1_000_000));
+        assert_eq!(footer.raw_context_window_tokens, Some(1_000_000));
 
         footer.begin_context_window_estimate(ContextWindowUsage::estimated(12_000, 123_456));
-        let next = footer.to_context();
         assert_eq!(
-            next.context_window,
+            footer.context_window,
             Some(ContextWindowUsage::estimated(12_000, 180_000))
         );
-        assert_eq!(next.raw_context_window_tokens, Some(200_000));
+        assert_eq!(footer.raw_context_window_tokens, Some(200_000));
     }
 }

--- a/crates/astra-cli/src/tui/bottom_pane/mod.rs
+++ b/crates/astra-cli/src/tui/bottom_pane/mod.rs
@@ -1402,7 +1402,10 @@ impl BottomPane {
         let approval_h = self.focused_approval_height(width);
         let queue_h = self.user_intent_height();
         let popup_h = self.popup_height();
-        content_h + approval_h + queue_h + popup_h + 1
+        // One quiet row above the composer is reserved for the context rail.
+        // Keeping it stable avoids shifting the input when the first usage
+        // measurement arrives; before that it simply acts as breathing room.
+        content_h + approval_h + queue_h + popup_h + 2
     }
 
     /// Top-level key routing. Dispatches to named phase handlers so
@@ -1806,18 +1809,6 @@ impl BottomPane {
             self.pop_active_view();
             changed = true;
         }
-        if self.task_status.is_active() {
-            // The live status indicator already owns the "Thinking /
-            // Running / Waiting" narrative above the composer. Duplicating
-            // that same label + timer in the footer makes the bottom stack
-            // feel cramped, so the footer stays focused on mode + context
-            // while a turn is active.
-            self.footer.current_objective = None;
-            self.footer.turn_elapsed = None;
-        } else {
-            self.footer.current_objective = self.task_status.objective_label();
-            self.footer.turn_elapsed = self.task_status.elapsed();
-        }
         // Flush paste burst buffer when idle timeout expires.
         if self.composer.flush_paste_burst() {
             self.sync_popups();
@@ -1895,6 +1886,7 @@ impl BottomPane {
                 Constraint::Length(approval_h),
                 Constraint::Length(intent_queue_h),
                 Constraint::Length(next_turn_queue_h),
+                Constraint::Length(1),
                 Constraint::Length(content_h),
                 Constraint::Length(popup_h),
                 Constraint::Length(1),
@@ -1904,25 +1896,23 @@ impl BottomPane {
             self.render_focused_approval(chunks[0], buf);
             self.render_pending_user_intents(chunks[1], buf);
             self.render_queued_next_turn_submissions(chunks[2], buf);
-            self.composer.render(
-                chunks[3],
-                buf,
-                self.task_status.is_active(),
-                self.has_pending_composer_queue(),
-            );
+            self.footer.render_context_bar(chunks[3], buf);
+            self.composer
+                .render(chunks[4], buf, self.has_pending_composer_queue());
             if let Some(ref menu) = self.slash_menu {
-                slash_popup_render::render_composer(menu, chunks[4], buf);
+                slash_popup_render::render_composer(menu, chunks[5], buf);
             } else if let Some(ref menu) = self.mention_menu {
-                mention_popup_render::render(menu, chunks[4], buf);
+                mention_popup_render::render(menu, chunks[5], buf);
             } else if let Some(ref popup) = self.skill_popup {
-                popup.render(chunks[4], buf);
+                popup.render(chunks[5], buf);
             }
-            self.footer.render(chunks[5], buf);
+            self.footer.render(chunks[6], buf);
         } else {
             let chunks = Layout::vertical([
                 Constraint::Length(approval_h),
                 Constraint::Length(intent_queue_h),
                 Constraint::Length(next_turn_queue_h),
+                Constraint::Length(1),
                 Constraint::Length(content_h),
                 Constraint::Length(1),
             ])
@@ -1931,13 +1921,10 @@ impl BottomPane {
             self.render_focused_approval(chunks[0], buf);
             self.render_pending_user_intents(chunks[1], buf);
             self.render_queued_next_turn_submissions(chunks[2], buf);
-            self.composer.render(
-                chunks[3],
-                buf,
-                self.task_status.is_active(),
-                self.has_pending_composer_queue(),
-            );
-            self.footer.render(chunks[4], buf);
+            self.footer.render_context_bar(chunks[3], buf);
+            self.composer
+                .render(chunks[4], buf, self.has_pending_composer_queue());
+            self.footer.render(chunks[5], buf);
         }
     }
 
@@ -2143,12 +2130,13 @@ impl BottomPane {
             Constraint::Length(approval_h),
             Constraint::Length(intent_queue_h),
             Constraint::Length(next_turn_queue_h),
+            Constraint::Length(1),
             Constraint::Length(content_h),
             Constraint::Min(0),
         ])
         .split(area);
 
-        self.composer.cursor_position(chunks[3])
+        self.composer.cursor_position(chunks[4])
     }
 }
 

--- a/crates/astra-cli/src/tui/bottom_pane/mod.rs
+++ b/crates/astra-cli/src/tui/bottom_pane/mod.rs
@@ -171,6 +171,7 @@ fn pending_user_intent_title(intent: &PendingUserIntent, task_status: &TaskStatu
             TaskStatus::Cancelling => {
                 "Stopping current run · guidance returns to composer".to_string()
             }
+            TaskStatus::Exiting => "Stopping · saving session before exit".to_string(),
             TaskStatus::Idle | TaskStatus::Dispatching | TaskStatus::TurnRunning { .. } => {
                 "Queued for current run · applies at next model boundary".to_string()
             }
@@ -475,9 +476,13 @@ impl BottomPane {
         // events already queued before Ctrl+C may still arrive, but they do
         // not revoke the user's stop intent. Only terminal settlement may
         // return the pane to Idle.
-        if matches!(self.task_status, TaskStatus::Cancelling)
-            && !matches!(status, TaskStatus::Cancelling | TaskStatus::Idle)
-        {
+        if matches!(
+            self.task_status,
+            TaskStatus::Cancelling | TaskStatus::Exiting
+        ) && !matches!(
+            status,
+            TaskStatus::Cancelling | TaskStatus::Exiting | TaskStatus::Idle
+        ) {
             return;
         }
         let was_active = self.task_status.is_active();

--- a/crates/astra-cli/src/tui/bottom_pane/queue_preview_tests.rs
+++ b/crates/astra-cli/src/tui/bottom_pane/queue_preview_tests.rs
@@ -49,10 +49,13 @@ fn seed_footer(pane: &mut BottomPane) {
     pane.footer.model = Some("sonnet-4.6".into());
     pane.footer.cwd = Some("~/github/astra".into());
     pane.footer.git_branch = Some("enqueue_new_after_next_call".into());
+    pane.footer.context_window = Some(astra_turn_types::ContextWindowUsage::provider_reported(
+        95_000, 800_000,
+    ));
 }
 
 #[test]
-fn active_turn_placeholder_explains_queue_vs_interrupt() {
+fn active_turn_keeps_the_composer_focused_on_input() {
     let mut pane = BottomPane::new();
     pane.set_task_status(TaskStatus::TurnRunning {
         started_at: Instant::now(),
@@ -65,8 +68,8 @@ fn active_turn_placeholder_explains_queue_vs_interrupt() {
         "active composer should keep the same primary prompt as idle; got {rendered:?}"
     );
     assert!(
-        rendered.contains("Enter queues follow-up") || rendered.contains("Ctrl+C stops"),
-        "active composer should keep an in-panel helper hint; got {rendered:?}"
+        !rendered.contains("Enter queues") && !rendered.contains("Ctrl+C stops"),
+        "active state already has a dedicated indicator; the composer must not repeat a key tutorial; got {rendered:?}"
     );
     assert!(
         rendered.contains("sonnet-4.6")
@@ -77,7 +80,7 @@ fn active_turn_placeholder_explains_queue_vs_interrupt() {
 }
 
 #[test]
-fn idle_composer_uses_clean_prompt_and_editor_hint() {
+fn idle_composer_uses_a_clean_prompt_without_permanent_key_legend() {
     let pane = BottomPane::new();
 
     let rendered = render_text(&pane, Rect::new(0, 0, 80, 5));
@@ -86,8 +89,8 @@ fn idle_composer_uses_clean_prompt_and_editor_hint() {
         "idle composer should render a short prompt; got {rendered:?}"
     );
     assert!(
-        rendered.contains("Alt+E editor") || rendered.contains("Shift+Enter newline"),
-        "idle composer should keep an in-panel helper hint; got {rendered:?}"
+        !rendered.contains("Alt+E editor") && !rendered.contains("Shift+Enter newline"),
+        "idle composer should leave shortcuts in help and command discovery; got {rendered:?}"
     );
 }
 
@@ -115,7 +118,7 @@ fn next_turn_queue_confirms_visibility_and_preserves_fifo() {
 }
 
 #[test]
-fn narrow_active_composer_degrades_helper_without_losing_stop_hint() {
+fn narrow_active_composer_does_not_reintroduce_key_chrome() {
     let mut pane = BottomPane::new();
     pane.set_task_status(TaskStatus::TurnRunning {
         started_at: Instant::now(),
@@ -127,19 +130,13 @@ fn narrow_active_composer_degrades_helper_without_losing_stop_hint() {
         "narrow composer should keep the primary prompt; got {rendered:?}"
     );
     assert!(
-        rendered.contains("Ctrl+C stops") || rendered.contains("Enter queues"),
-        "narrow composer should keep a compressed helper hint; got {rendered:?}"
-    );
-    assert!(
-        rendered
-            .lines()
-            .any(|line| line.contains("~/") || line.contains("sonnet-4.6")),
-        "narrow footer should stay visible under the composer; got {rendered:?}"
+        !rendered.contains("Ctrl+C stops") && !rendered.contains("Enter queues"),
+        "narrow layouts must reduce chrome rather than invent another shorthand; got {rendered:?}"
     );
 }
 
 #[test]
-fn helper_row_stays_visible_after_typing_begins() {
+fn typing_does_not_allocate_a_second_tutorial_row() {
     let mut pane = BottomPane::new();
     pane.set_task_status(TaskStatus::TurnRunning {
         started_at: Instant::now(),
@@ -152,8 +149,8 @@ fn helper_row_stays_visible_after_typing_begins() {
         "typed text should remain visible inside the composer; got {rendered:?}"
     );
     assert!(
-        rendered.contains("Enter queues follow-up") || rendered.contains("Ctrl+C stops"),
-        "the helper row should stay visible after typing begins; got {rendered:?}"
+        !rendered.contains("Enter queues follow-up") && !rendered.contains("Ctrl+C stops"),
+        "typed content should remain the sole composer focus; got {rendered:?}"
     );
 }
 

--- a/crates/astra-cli/src/tui/bottom_pane/snapshots/astra__tui__bottom_pane__queue_preview_tests__bottom_surface_active_42.snap
+++ b/crates/astra-cli/src/tui/bottom_pane/snapshots/astra__tui__bottom_pane__queue_preview_tests__bottom_surface_active_42.snap
@@ -2,6 +2,7 @@
 source: crates/astra-cli/src/tui/bottom_pane/queue_preview_tests.rs
 expression: "snapshot_text(&pane, Rect::new(0, 0, 42, 5))"
 ---
+  ─────────────────────────── 95k / 800k
 › Message Astra
-  Enter queues follow-up · Ctrl+C stops ·…
-  sonnet-4.6 · Ask · ~/github/astra
+
+  sonnet-4.6              ~/github/astra

--- a/crates/astra-cli/src/tui/bottom_pane/snapshots/astra__tui__bottom_pane__queue_preview_tests__bottom_surface_active_80.snap
+++ b/crates/astra-cli/src/tui/bottom_pane/snapshots/astra__tui__bottom_pane__queue_preview_tests__bottom_surface_active_80.snap
@@ -2,6 +2,7 @@
 source: crates/astra-cli/src/tui/bottom_pane/queue_preview_tests.rs
 expression: "snapshot_text(&pane, Rect::new(0, 0, 80, 5))"
 ---
+  ───────────────────────────────────────────────────────────────── 95k / 800k
 › Message Astra
-  Enter queues follow-up · Ctrl+C stops · / commands
-  sonnet-4.6 · Ask · ~/github/astra · ⎇ enqueue…ext_call
+
+  sonnet-4.6                                ~/github/astra  ⎇ enqueue…ext_call

--- a/crates/astra-cli/src/tui/bottom_pane/snapshots/astra__tui__bottom_pane__queue_preview_tests__bottom_surface_idle_80.snap
+++ b/crates/astra-cli/src/tui/bottom_pane/snapshots/astra__tui__bottom_pane__queue_preview_tests__bottom_surface_idle_80.snap
@@ -2,6 +2,7 @@
 source: crates/astra-cli/src/tui/bottom_pane/queue_preview_tests.rs
 expression: "snapshot_text(&pane, Rect::new(0, 0, 80, 5))"
 ---
+  ───────────────────────────────────────────────────────────────── 95k / 800k
 › Message Astra
-  Enter send · Shift+Enter newline · / commands · Alt+E editor
-  sonnet-4.6 · Ask · ~/github/astra · ⎇ enqueue…ext_call
+
+  sonnet-4.6                                ~/github/astra  ⎇ enqueue…ext_call

--- a/crates/astra-cli/src/tui/chat_widget/snapshots/astra__tui__chat_widget__turn_driver__canonical_turn_80.snap
+++ b/crates/astra-cli/src/tui/chat_widget/snapshots/astra__tui__chat_widget__turn_driver__canonical_turn_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/chat_widget/turn_driver.rs
-assertion_line: 166
 expression: "render_history(&w, 80)"
 ---
 

--- a/crates/astra-cli/src/tui/diff_render.rs
+++ b/crates/astra-cli/src/tui/diff_render.rs
@@ -1,4 +1,5 @@
-//! Renders diff output with line numbers, gutter signs, and colors.
+//! Renders diff output with aligned old/new line numbers, gutter signs, and
+//! full-row semantic surfaces.
 //!
 //! Inspired by Codex's diff_render.rs (MIT) but simplified for astra's
 //! use case: tool output strings with +/- prefix lines rather than
@@ -44,6 +45,8 @@ fn header_style() -> Style {
     Style::default().add_modifier(Modifier::BOLD)
 }
 
+const HEADER_INDENT: &str = "            ";
+
 /// Render a diff string (with +/- prefix lines) into styled ratatui Lines.
 ///
 /// Handles formats:
@@ -63,7 +66,10 @@ pub fn render_diff_lines(diff_text: &str, max_lines: usize) -> Vec<Line<'static>
         if raw.starts_with("@@") {
             // Hunk header
             let hunk_style = theme::current().diff_hunk_style();
-            lines.push(Line::from(Span::styled(format!("    {raw}"), hunk_style)));
+            lines.push(Line::from(Span::styled(
+                format!("{HEADER_INDENT}{raw}"),
+                hunk_style,
+            )));
             // Try to parse line numbers from @@ -N,M +N,M @@
             if let Some(nums) = parse_hunk_header(raw) {
                 line_num_del = nums.0;
@@ -76,13 +82,13 @@ pub fn render_diff_lines(diff_text: &str, max_lines: usize) -> Vec<Line<'static>
             current_lang = diff_header_language(raw);
             // Style file headers with path: directory dim, filename bright.
             let (prefix, path) = if let Some(path) = raw.strip_prefix("--- a/") {
-                ("    --- a/", path)
+                ("            --- a/", path)
             } else if let Some(path) = raw.strip_prefix("+++ b/") {
-                ("    +++ b/", path)
+                ("            +++ b/", path)
             } else {
                 // No recognised prefix — render as plain bold.
                 lines.push(Line::from(Span::styled(
-                    format!("    {raw}"),
+                    format!("{HEADER_INDENT}{raw}"),
                     header_style(),
                 )));
                 continue;
@@ -100,10 +106,10 @@ pub fn render_diff_lines(diff_text: &str, max_lines: usize) -> Vec<Line<'static>
 
         if raw.starts_with('+') {
             line_num_add += 1;
-            let num = format!("{:>4} ", line_num_add);
             let content = &raw[1..];
             lines.push(render_content_line(
-                &num,
+                None,
+                Some(line_num_add),
                 "+ ",
                 content,
                 add_style(),
@@ -111,10 +117,10 @@ pub fn render_diff_lines(diff_text: &str, max_lines: usize) -> Vec<Line<'static>
             ));
         } else if raw.starts_with('-') {
             line_num_del += 1;
-            let num = format!("{:>4} ", line_num_del);
             let content = &raw[1..];
             lines.push(render_content_line(
-                &num,
+                Some(line_num_del),
+                None,
                 "- ",
                 content,
                 del_style(),
@@ -123,10 +129,10 @@ pub fn render_diff_lines(diff_text: &str, max_lines: usize) -> Vec<Line<'static>
         } else if raw.starts_with(' ') {
             line_num_add += 1;
             line_num_del += 1;
-            let num = format!("{:>4} ", line_num_add);
             let content = &raw[1..];
             lines.push(render_content_line(
-                &num,
+                Some(line_num_del),
+                Some(line_num_add),
                 "  ",
                 content,
                 ctx_style(),
@@ -171,19 +177,29 @@ pub fn render_diff_lines(diff_text: &str, max_lines: usize) -> Vec<Line<'static>
 }
 
 fn render_content_line(
-    number: &str,
+    old_number: Option<u32>,
+    new_number: Option<u32>,
     prefix: &str,
     content: &str,
     style: Style,
     lang: Option<&str>,
 ) -> Line<'static> {
     let gutter = gutter_style().bg(style.bg.unwrap_or(Color::Reset));
+    let old_number = old_number.map_or_else(String::new, |number| number.to_string());
+    let new_number = new_number.map_or_else(String::new, |number| number.to_string());
     let mut spans = vec![
-        Span::styled(number.to_string(), gutter),
+        Span::styled(format!("{old_number:>4} {new_number:>4} │ "), gutter),
         Span::styled(prefix.to_string(), style),
     ];
     spans.extend(highlighted_diff_content(content, lang, style).spans);
-    Line::from(spans)
+    let mut line = Line::from(spans);
+    // Spans colour the occupied cells; the line owns the physical row. Buffer
+    // and scrollback renderers use this metadata to extend the semantic add/
+    // delete surface through the terminal edge without padding with spaces.
+    if let Some(background) = style.bg {
+        line.style = Style::default().bg(background);
+    }
+    line
 }
 
 fn highlighted_diff_content(content: &str, lang: Option<&str>, style: Style) -> Line<'static> {
@@ -231,6 +247,9 @@ fn diff_header_language(header: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{add_style, diff_header_language, render_diff_lines};
+    use crate::tui::render::line_utils::FullRowParagraph;
+    use crate::tui::testing::render::draw_widget;
+    use ratatui::widgets::Wrap;
 
     #[test]
     fn diff_headers_set_language_for_highlighted_content() {
@@ -259,5 +278,35 @@ mod tests {
             added.spans.iter().all(|span| span.style.bg == expected_bg),
             "every span in an added line should carry the diff background: {added:?}"
         );
+        assert_eq!(added.style.bg, expected_bg);
+    }
+
+    #[test]
+    fn old_and_new_line_numbers_form_a_stable_two_column_grid() {
+        let lines = render_diff_lines("@@ -41,2 +99,2 @@\n-old\n+new\n same\n", 20);
+        let text = |index: usize| {
+            lines[index]
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        };
+        assert!(text(1).starts_with("  41      │ - "), "{:?}", text(1));
+        assert!(text(2).starts_with("       99 │ + "), "{:?}", text(2));
+        assert!(text(3).starts_with("  42  100 │   "), "{:?}", text(3));
+    }
+
+    #[test]
+    fn added_and_deleted_surfaces_fill_the_complete_physical_row() {
+        let lines = render_diff_lines("@@ -1 +1 @@\n-old\n+new\n", 20);
+        let area_width = 52;
+        let buffer = draw_widget(
+            FullRowParagraph::new(lines).wrap(Wrap { trim: false }),
+            area_width,
+            3,
+        );
+        let theme = crate::tui::theme::current();
+        assert!((0..area_width).all(|x| buffer[(x, 1)].bg == theme.diff_del_bg));
+        assert!((0..area_width).all(|x| buffer[(x, 2)].bg == theme.diff_add_bg));
     }
 }

--- a/crates/astra-cli/src/tui/draw.rs
+++ b/crates/astra-cli/src/tui/draw.rs
@@ -2,7 +2,7 @@
 //!
 //! The TUI's draw cycle is: compute which source owns the active-cell
 //! region (active cell / task board / status line / next-hint / empty),
-//! then paint `active | separator | bottom pane` into the ratatui
+//! then paint `active | bottom pane` into the ratatui
 //! frame. This file owns that pipeline so the outer event loop in
 //! [`super::event_loop`] doesn't carry render details.
 //!
@@ -746,7 +746,7 @@ pub(crate) fn sync_task_footer(
 // ───────────────────────────────────────────────────────────────────────
 
 /// Paint one frame. Layout top-to-bottom:
-/// `task_board (optional) | active | separator | bottom_pane`.
+/// `task_board (optional) | active | bottom_pane`.
 /// The task board is its OWN slot — it does NOT race the active
 /// cell for priority, so a streaming tool/assistant cell can't
 /// hide it mid-frame.
@@ -842,13 +842,6 @@ pub(crate) fn do_draw(
         RenderableItem::Owned(Box::new(framed) as Box<dyn Renderable>)
     });
 
-    // Breathing room between scrollback and the bottom surface.
-    // Earlier versions used a full-width rule here, but the extra line
-    // made the composer feel boxed off rather than integrated with the
-    // rest of the screen.
-    let sep_line = separator_line(width);
-    let sep_renderable = RenderableItem::Owned(Box::new(sep_line));
-
     let bp_renderable = BottomPaneRenderable(bottom_pane);
     let bp_item = RenderableItem::Owned(Box::new(bp_renderable) as Box<dyn Renderable>);
 
@@ -856,7 +849,6 @@ pub(crate) fn do_draw(
     // Layout (top → bottom):
     //   active cell + scrollback   (weight=1, soaks remaining space)
     //   multi-agent strip          (weight=0, only if any sub-agents are live)
-    //   separator                  (weight=0)  ← visual break above board
     //   task board                 (weight=0, pinned just above composer)
     //   blank spacer               (weight=0)  ← only when board renders
     //   bottom pane / composer     (weight=0)
@@ -876,7 +868,6 @@ pub(crate) fn do_draw(
     if let Some(item) = multi_agent_renderable {
         flex.push(0, item);
     }
-    flex.push(0, sep_renderable);
     let board_rendered = task_board_lines
         .as_ref()
         .is_some_and(|lines| !lines.is_empty());
@@ -908,11 +899,6 @@ pub(crate) fn do_draw(
         })
         .map_err(|e| format!("draw: {e}"))?;
     Ok(())
-}
-
-fn separator_line(width: u16) -> Line<'static> {
-    let dim = Style::default().fg(crate::tui::theme::current().dim);
-    Line::from(Span::styled("─".repeat(width as usize), dim))
 }
 
 struct BottomPaneRenderable<'a>(&'a mut BottomPane);
@@ -2083,6 +2069,40 @@ mod multi_agent_strip_tests {
             settled_buffer[(0, 0)].fg,
             crate::tui::theme::current().gutter_frozen
         );
+    }
+
+    #[test]
+    fn live_and_frozen_tool_titles_render_in_the_same_terminal_column() {
+        use crate::tui::history_cell::{HistoryCell, tool::ToolCell};
+        use crate::tui::render::{line_utils::FullRowParagraph, renderable::Renderable};
+        use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
+
+        let area = Rect::new(0, 0, 40, 2);
+        let mut tool = ToolCell::new_running("bash", "$ cargo test");
+
+        let mut live_buffer = Buffer::empty(area);
+        LiveFramedCell {
+            lines: tool.display_lines(area.width.saturating_sub(2)),
+            live: true,
+        }
+        .render(area, &mut live_buffer);
+
+        tool.complete("success", 42, "$ cargo test".into(), None, None);
+        let mut frozen_buffer = Buffer::empty(area);
+        Widget::render(
+            FullRowParagraph::new(tool.display_lines(area.width)),
+            area,
+            &mut frozen_buffer,
+        );
+
+        let title_column = |buffer: &Buffer| {
+            (area.x..area.right())
+                .find(|&x| buffer[(x, area.y)].symbol() == "R")
+                .expect("tool title must contain its lifecycle verb")
+        };
+        assert_eq!(live_buffer[(0, 0)].symbol(), "█");
+        assert_eq!(frozen_buffer[(0, 0)].symbol(), "●");
+        assert_eq!(title_column(&live_buffer), title_column(&frozen_buffer));
     }
 
     #[test]

--- a/crates/astra-cli/src/tui/draw.rs
+++ b/crates/astra-cli/src/tui/draw.rs
@@ -2106,6 +2106,41 @@ mod multi_agent_strip_tests {
     }
 
     #[test]
+    fn live_and_frozen_thought_titles_render_in_the_same_terminal_column() {
+        use crate::tui::history_cell::{HistoryCell, reasoning::ReasoningCell};
+        use crate::tui::render::{line_utils::FullRowParagraph, renderable::Renderable};
+        use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
+
+        let area = Rect::new(0, 0, 60, 2);
+        let mut thought = ReasoningCell::new_streaming();
+        thought.push_delta("inspect the state");
+
+        let mut live_buffer = Buffer::empty(area);
+        LiveFramedCell {
+            lines: thought.display_lines(area.width.saturating_sub(2)),
+            live: true,
+        }
+        .render(area, &mut live_buffer);
+
+        thought.finalize();
+        let mut frozen_buffer = Buffer::empty(area);
+        Widget::render(
+            FullRowParagraph::new(thought.display_lines(area.width)),
+            area,
+            &mut frozen_buffer,
+        );
+
+        let title_column = |buffer: &Buffer| {
+            (area.x..area.right())
+                .find(|&x| buffer[(x, area.y)].symbol() == "T")
+                .expect("thought title must be rendered")
+        };
+        assert_eq!(live_buffer[(0, 0)].symbol(), "█");
+        assert_eq!(frozen_buffer[(0, 0)].symbol(), "●");
+        assert_eq!(title_column(&live_buffer), title_column(&frozen_buffer));
+    }
+
+    #[test]
     fn active_edit_diff_paints_the_entire_available_row_surface() {
         use crate::tui::history_cell::{
             HistoryCell,

--- a/crates/astra-cli/src/tui/event_loop.rs
+++ b/crates/astra-cli/src/tui/event_loop.rs
@@ -12565,9 +12565,14 @@ mod tests {
         let mut buf = ratatui::buffer::Buffer::empty(area);
         bottom_pane.render(area, &mut buf);
         let pane_text = crate::tui::testing::render::buffer_to_string(&buf);
+        assert!(bottom_pane.footer.is_turn_active);
         assert!(
-            pane_text.contains("Enter queues") && pane_text.contains("Ctrl+C stops"),
-            "active-turn composer feedback missing: {pane_text:?}"
+            pane_text.contains("Message Astra"),
+            "dispatch feedback must not displace the composer: {pane_text:?}"
+        );
+        assert!(
+            !pane_text.contains("Enter queues") && !pane_text.contains("Ctrl+C stops"),
+            "the status indicator owns dispatch feedback; the composer must stay free of duplicate key chrome: {pane_text:?}"
         );
 
         finish_submission_feedback(&mut bottom_pane, &mut indicator);
@@ -12576,6 +12581,7 @@ mod tests {
             status_indicator::IndicatorState::Idle
         ));
         assert!(indicator.render_at(at).is_none());
+        assert!(!bottom_pane.footer.is_turn_active);
 
         let mut settled = ratatui::buffer::Buffer::empty(area);
         bottom_pane.render(area, &mut settled);
@@ -12592,6 +12598,7 @@ mod tests {
             indicator.state(),
             status_indicator::IndicatorState::Idle
         ));
+        assert!(!bottom_pane.footer.is_turn_active);
         let mut after_late_progress = ratatui::buffer::Buffer::empty(area);
         bottom_pane.render(area, &mut after_late_progress);
         let after_late_progress =

--- a/crates/astra-cli/src/tui/event_loop.rs
+++ b/crates/astra-cli/src/tui/event_loop.rs
@@ -23,6 +23,7 @@ use crate::lock_recovery::LockRecovery;
 use astra_services::session_journal::ToolCallRecord;
 use astra_services::session_journal::{JournalEvent, JournalEventType};
 use astra_turn_core::context_assembly_trace::ContextAssemblyTrace;
+use crossterm::style::Stylize;
 use tokio::sync::broadcast;
 use tokio_stream::StreamExt;
 
@@ -5852,6 +5853,7 @@ pub(crate) async fn run_tui_session(
                                     let mut turn_tool_count: u32 = 0;
                                     let mut turn_ttft: Option<std::time::Instant> = None;
                                     let mut output_settled_at: Option<std::time::Instant> = None;
+                                    let mut exit_after_turn_settlement = false;
                                     let mut explain_items: Vec<serde_json::Value> = Vec::new();
                                     // Phase 3b.3c: prime the bash detach slot for this
                                     // turn. The bash runner takes the handle on entry;
@@ -6182,12 +6184,32 @@ pub(crate) async fn run_tui_session(
                                                                     BottomPaneAction::SubmitInput(queued_text) => {
                                                                         match slash_dispatch::immediate_control(&queued_text) {
                                                                             Some(slash_dispatch::ImmediateControl::Exit) => {
-                                                                                // `/exit` is a workbench lifecycle command in every
-                                                                                // turn phase. Cancel the in-flight local boundary and
-                                                                                // leave through the regular shutdown path; never queue
-                                                                                // it as model guidance or a follow-up user message.
-                                                                                tui_cancel_token.cancel();
-                                                                                break 'main Ok(());
+                                                                                // Exit is a lifecycle intent, not permission to drop a
+                                                                                // visible-but-not-yet-durable turn. If generation is
+                                                                                // still active, request its normal cancellation; in both
+                                                                                // cases keep polling the turn future until settlement has
+                                                                                // rebound/persisted the session, then leave the main loop.
+                                                                                if !exit_after_turn_settlement {
+                                                                                    exit_after_turn_settlement = true;
+                                                                                    if output_settled_at.is_none() {
+                                                                                        request_active_run_cancel(
+                                                                                            &mut chat_widget,
+                                                                                            &mut bottom_pane,
+                                                                                            &mut status_indicator,
+                                                                                            &mut cancel_control_tasks,
+                                                                                            task_service_for_cancel.as_ref(),
+                                                                                            &preinstalled_run_control,
+                                                                                            &tui_cancel_token,
+                                                                                        );
+                                                                                        interrupt_pending = true;
+                                                                                        bottom_pane.interrupt_pending = true;
+                                                                                    }
+                                                                                    let now = std::time::Instant::now();
+                                                                                    bottom_pane.set_task_status(TaskStatus::Exiting);
+                                                                                    status_indicator.begin_exit(now);
+                                                                                    frame_requester.schedule_frame();
+                                                                                }
+                                                                                continue;
                                                                             }
                                                                             Some(slash_dispatch::ImmediateControl::StopCurrentRun) => {
                                                                                 if output_settled_at.is_some() {
@@ -7282,7 +7304,9 @@ pub(crate) async fn run_tui_session(
                                     let unapplied_user_intents =
                                         bottom_pane.take_unapplied_user_intents();
                                     let should_start_followups =
-                                        turn_result.is_ok() && !state.last_turn_interrupted;
+                                        turn_result.is_ok()
+                                            && !state.last_turn_interrupted
+                                            && !exit_after_turn_settlement;
                                     if interrupt_pending {
                                         interrupt_pending = false;
                                         bottom_pane.interrupt_pending = false;
@@ -7433,6 +7457,10 @@ pub(crate) async fn run_tui_session(
                                     // possibly TurnSummary + SystemError) to
                                     // scrollback in one shot.
                                     flush_chat_widget(&mut guard, &mut chat_widget, w);
+
+                                    if exit_after_turn_settlement {
+                                        break 'main turn_result;
+                                    }
 
                                     let new_tok = std::sync::Arc::new(
                                         session_shutdown_token.child_token(),
@@ -8539,6 +8567,34 @@ pub(crate) async fn run_tui_session(
             }
         }
     };
+    // A graceful exit can spend time settling journals, background workers,
+    // and session memory. Render that accepted lifecycle state before any of
+    // those waits so the terminal never appears unresponsive.
+    if result.is_ok() {
+        let now = std::time::Instant::now();
+        bottom_pane.set_task_status(TaskStatus::Exiting);
+        status_indicator.begin_exit(now);
+        let width = guard.terminal.size().map(|size| size.width).unwrap_or(80);
+        let frame = active_viewport(
+            &chat_widget,
+            &status_indicator,
+            Some(&*task_board),
+            board_expanded,
+            board_user_pin,
+            width,
+            guard.terminal.size().map(|size| size.height).unwrap_or(24),
+        );
+        board_expanded = frame.resolved_board_expanded;
+        let _ = do_draw(
+            &mut guard,
+            frame.active,
+            frame.multi_agent,
+            &mut bottom_pane,
+            Some((&*task_board, board_expanded)),
+            frame.task_board,
+        );
+    }
+
     let shutdown_signal = if session_shutdown_token.is_cancelled() {
         match (&mut shutdown_monitor).await {
             Ok(signal) => Some(signal),
@@ -8553,6 +8609,13 @@ pub(crate) async fn run_tui_session(
         None
     };
     let signal_driven_shutdown = shutdown_signal.is_some();
+    let exit_reason = match (result.is_err(), shutdown_signal) {
+        (true, _) => crate::cli::session::session_cleanup::SessionExit::Error,
+        (false, Some(signal)) => {
+            crate::cli::session::session_cleanup::SessionExit::Shutdown(signal)
+        }
+        (false, None) => crate::cli::session::session_cleanup::SessionExit::Command,
+    };
     if let Some(signal) = shutdown_signal {
         tracing::info!(
             signal = signal.label(),
@@ -8639,6 +8702,13 @@ pub(crate) async fn run_tui_session(
     );
     let width = guard.terminal.size().map(|size| size.width).unwrap_or(80);
     flush_chat_widget(&mut guard, &mut chat_widget, width);
+    // Capture before finalization: process-local cleanup may release the live
+    // identity, while the copyable command must name the durable session that
+    // was just committed.
+    let resume_hint = crate::cli::session::session_cleanup::resume_hint_for_exit(
+        exit_reason,
+        state.session_id.as_deref(),
+    );
     let finalization_budget = if signal_driven_shutdown {
         Duration::from_secs(2)
     } else {
@@ -8666,6 +8736,10 @@ pub(crate) async fn run_tui_session(
     // turn/agent work has stopped so no consumer outlives its provider.
     drop(pipeline_modules);
     drop(guard);
+    if let Some((label, command)) = resume_hint {
+        println!("{}", label.dim());
+        println!("  {}", command.cyan());
+    }
     result
 }
 

--- a/crates/astra-cli/src/tui/event_loop.rs
+++ b/crates/astra-cli/src/tui/event_loop.rs
@@ -4406,10 +4406,6 @@ fn refresh_footer_from_state(
     state: &crate::cli::session::session_state::SessionState,
 ) {
     bottom_pane.footer.model = state.model.clone();
-    bottom_pane.footer.session_id = state
-        .session_id
-        .as_ref()
-        .map(|sid| sid[..8.min(sid.len())].to_string());
     bottom_pane.footer.permission_mode = Some(state.perm_manager.mode());
     if let Some(trace) = latest_context_trace(state)
         && let Some(usage) = context_window_from_trace(&trace)
@@ -4683,9 +4679,6 @@ pub(crate) async fn run_tui_session(
 
     if let Some(ref model) = state.model {
         bottom_pane.footer.model = Some(model.clone());
-    }
-    if let Some(ref sid) = state.session_id {
-        bottom_pane.footer.session_id = Some(sid[..8.min(sid.len())].to_string());
     }
     bottom_pane.footer.permission_mode = Some(state.perm_manager.mode());
     // Lock-free observer of `perm_manager.mode()` so the inner-tick
@@ -7366,8 +7359,6 @@ pub(crate) async fn run_tui_session(
 
                                     // Update footer
                                     if let Some(ref m) = state.model { bottom_pane.footer.model = Some(m.clone()); }
-                                    if let Some(ref s) = state.session_id { bottom_pane.footer.session_id = Some(s[..8.min(s.len())].to_string()); }
-                                    bottom_pane.footer.token_usage = Some(format!("{}↑ {}↓", state.total_prompt_tokens, state.total_completion_tokens));
                                     bottom_pane.footer.permission_mode = Some(state.perm_manager.mode());
                                     // The live stream has already updated the footer from the
                                     // current request's assembly and provider usage. A trace is
@@ -7845,10 +7836,6 @@ pub(crate) async fn run_tui_session(
                                                 &mut board_user_pin,
                                             );
                                         }
-                                        bottom_pane.footer.session_id = state
-                                            .session_id
-                                            .as_ref()
-                                            .map(|s| s[..8.min(s.len())].to_string());
                                     } else if let bottom_pane::view::ViewResult::Session {
                                         session_id: parent_id,
                                         intent: bottom_pane::view::SessionSelectionIntent::Fork,
@@ -7890,10 +7877,6 @@ pub(crate) async fn run_tui_session(
                                                         outcome.events_copied,
                                                         task_board_note,
                                                     )),
-                                                );
-                                                bottom_pane.footer.session_id = Some(
-                                                    outcome.new_session_id[..8.min(outcome.new_session_id.len())]
-                                                        .to_string(),
                                                 );
                                             }
                                             Err(error) => chat_widget.commit_system(
@@ -8833,7 +8816,6 @@ mod tests {
     use crate::background_task_error::BackgroundTaskError;
     use crate::cli::turn::local_run_control::LocalRunControl;
     use crate::tui::background_tasks::BgTaskEvent;
-    use crate::tui::status_line::{StatusContext, StatusLine};
     use astra_runtime::turn::run_control::{
         RunControlStatus, RunStatusProvider, UserIntentProvider,
     };
@@ -10132,16 +10114,6 @@ mod tests {
             Some(astra_turn_types::ContextWindowUsage::provider_reported(
                 20_687, 800_000
             ))
-        );
-
-        let plain = StatusLine::from_context(&StatusContext {
-            context_window: usage,
-            ..StatusContext::default()
-        })
-        .plain();
-        assert!(
-            plain.contains("Ctx 3%") && plain.contains("21k/800k"),
-            "footer should present one request's context occupancy: {plain:?}"
         );
     }
 

--- a/crates/astra-cli/src/tui/history_cell/assistant.rs
+++ b/crates/astra-cli/src/tui/history_cell/assistant.rs
@@ -318,7 +318,10 @@ impl AssistantCell {
         let inner_width = (width as usize).saturating_sub(2).max(20);
         let (rendered, total) = self.markdown_layout_window(source, inner_width, start, maximum);
         let theme = crate::tui::theme::current();
-        let gutter_style = Style::default().fg(theme.gutter_frozen);
+        // A settled assistant response is a completed unit, so its guide uses
+        // the exact success colour of terminal `●` markers. Live responses
+        // use the distinct focus gutter supplied by `LiveFramedCell`.
+        let gutter_style = Style::default().fg(theme.success);
         let lines = rendered
             .into_iter()
             .map(|line| {
@@ -551,7 +554,7 @@ impl AssistantCell {
         }
 
         let theme = crate::tui::theme::current();
-        let gutter_style = Style::default().fg(theme.gutter_frozen);
+        let gutter_style = Style::default().fg(theme.success);
         rendered
             .into_iter()
             .map(|line| {
@@ -621,7 +624,7 @@ impl HistoryCell for AssistantCell {
 /// Collapsed one-line header shown in place of a `<think>` block
 /// once the closing tag has arrived.
 ///
-/// Example: `• Thought · 12 lines · 50 tokens`
+/// Example: `● Thought · 12 lines · 50 tokens`
 fn thought_header_lines(line_count: usize, token_count: u64) -> Vec<Line<'static>> {
     let theme = crate::tui::theme::current();
     let dim = Style::default().fg(theme.dim);
@@ -637,7 +640,7 @@ fn thought_header_lines(line_count: usize, token_count: u64) -> Vec<Line<'static
         format!("{token_count} tokens")
     };
     vec![Line::from(vec![
-        Span::styled("• ", dim),
+        Span::styled("● ", dim),
         thought_gradient("Thought", theme),
         Span::styled(" · ", stat),
         Span::styled(label, stat),
@@ -696,9 +699,10 @@ fn render_live_thinking(think_partial: &str, width: u16) -> Vec<Line<'static>> {
         format!("{token_count} tokens")
     };
 
-    // Header line: bold Thought with accent blend, then dim stats.
+    // The outer live gutter owns the activity marker. Keeping the inner
+    // header marker-free makes its title align with `● Thought` after the
+    // thinking segment freezes.
     let mut out = vec![Line::from(vec![
-        Span::styled("• ", dim),
         thought_gradient("Thought", theme),
         Span::styled(" · ", stat),
         Span::styled(line_label, stat),
@@ -854,6 +858,18 @@ mod tests {
         assert!(c.is_live());
         c.finalize();
         assert!(!c.is_live());
+    }
+
+    #[test]
+    fn settled_assistant_guide_matches_terminal_success_marker() {
+        let c = AssistantCell::from_markdown("done");
+        let lines = c.display_lines(40);
+        let guide = lines
+            .first()
+            .and_then(|line| line.spans.first())
+            .expect("settled assistant has a guide");
+        assert_eq!(guide.content.as_ref(), "█ ");
+        assert_eq!(guide.style.fg, Some(crate::tui::theme::current().success));
     }
 
     #[test]
@@ -1034,6 +1050,13 @@ mod tests {
             out.contains("Thought") && out.contains("2 lines") && out.contains("token"),
             "collapsed header missing: {out}"
         );
+        assert!(
+            out.lines()
+                .next()
+                .unwrap_or_default()
+                .starts_with("● Thought"),
+            "closed thinking needs a terminal marker: {out}"
+        );
         assert!(out.contains("I am Astra"), "body missing: {out}");
     }
 
@@ -1107,6 +1130,17 @@ mod tests {
         c.push_delta("<think>\nstep one\nstep two in progres");
         let out = render(&c, 80, 5);
         assert!(out.contains("Thought"), "live indicator missing: {out}");
+        assert!(
+            out.lines()
+                .next()
+                .unwrap_or_default()
+                .starts_with("Thought"),
+            "outer live gutter owns the marker: {out}"
+        );
+        assert!(
+            !out.contains("● Thought"),
+            "live marker must not double up: {out}"
+        );
         assert!(out.contains("2 lines"), "line count missing: {out}");
         assert!(out.contains("token"), "token count missing: {out}");
         assert!(
@@ -1157,6 +1191,10 @@ mod tests {
         assert!(
             out.contains("Thought") && out.contains("3 lines") && out.contains("token"),
             "collapsed header with line count: {out}"
+        );
+        assert!(
+            out.contains("● Thought"),
+            "closed thinking marker missing: {out}"
         );
         assert!(out.contains("answer"), "body still visible: {out}");
     }

--- a/crates/astra-cli/src/tui/history_cell/reasoning.rs
+++ b/crates/astra-cli/src/tui/history_cell/reasoning.rs
@@ -3,7 +3,7 @@
 //!
 //! While streaming: a fixed-height scrolling preview window so the
 //! composer stays visible. After completion: collapses to a one-line
-//! header (`Thought · Xs · N lines · N tokens`) — not a framed window or
+//! header (`● Thought · Xs · N lines · N tokens`) — not a framed window or
 //! expanding pill. A reasoning cell is just another cell in the
 //! scrollback; toggle visibility lives in ChatWidget, not here.
 //!
@@ -144,12 +144,15 @@ impl ReasoningCell {
             .duration_label()
             .map(|d| format!(" · {d} · {line_label} · {tok_label}"))
             .unwrap_or_else(|| format!(" · {line_label} · {tok_label}"));
-        // The normal conversation projection has no tree affordance: a
-        // leading bullet made a collapsed Thought sit two columns to the
-        // right of adjacent assistant content. The transcript navigator keeps
-        // an arrow only when the item is actually interactive.
+        // The live viewport already has a two-column `█ ` gutter. Once this
+        // cell freezes into ordinary scrollback, `● ` takes over those two
+        // columns so the title stays fixed in the same terminal column. The
+        // transcript navigator replaces that marker with its interactive
+        // disclosure arrow.
         let marker = if transcript && self.has_transcript_details(width) {
             if expanded { "▼ " } else { "▶ " }
+        } else if !self.live {
+            "● "
         } else {
             ""
         };
@@ -372,16 +375,27 @@ mod tests {
     }
 
     #[test]
-    fn normal_header_has_no_decorative_bullet() {
+    fn live_header_has_no_inner_marker_and_frozen_header_has_terminal_marker() {
         let mut c = ReasoningCell::new_streaming();
         c.push_delta("analysis");
-        let out = render(&c, 60, 3);
-        let header = out.lines().next().unwrap_or_default();
+        let live = render(&c, 60, 3);
+        let header = live.lines().next().unwrap_or_default();
         assert!(
             header.starts_with("Thought"),
-            "misaligned header: {header:?}"
+            "live gutter owns the marker: {header:?}"
         );
-        assert!(!header.contains("• Thought"));
+        assert!(!header.contains("● Thought"));
+
+        c.finalize();
+        let frozen = render(&c, 60, 3);
+        assert!(
+            frozen
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .starts_with("● Thought"),
+            "frozen row needs its terminal marker: {frozen:?}"
+        );
     }
 
     #[test]
@@ -460,7 +474,7 @@ mod tests {
     #[test]
     fn finalised_cell_hides_body_and_shows_line_and_token_count() {
         // Once thinking is done, scrollback shows only the compact
-        // header `Thought · Xs · N lines · N tokens` — not the 20-40 row
+        // header `● Thought · Xs · N lines · N tokens` — not the 20-40 row
         // dim wall. The count cues the user that there's
         // substance behind the header without dumping it on-screen.
         // (The full text stays in the JSONL transcript for later.)

--- a/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_think_closed_60.snap
+++ b/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_think_closed_60.snap
@@ -2,5 +2,5 @@
 source: crates/astra-cli/src/tui/history_cell/assistant.rs
 expression: "render(&c, 60, 3)"
 ---
-• Thought · 2 lines · 14 tokens
+● Thought · 2 lines · 14 tokens
 █ Hello — happy to help.

--- a/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_think_streaming_80.snap
+++ b/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__assistant__tests__assistant_think_streaming_80.snap
@@ -2,6 +2,6 @@
 source: crates/astra-cli/src/tui/history_cell/assistant.rs
 expression: "render(&c, 80, 4)"
 ---
-• Thought · 2 lines · 21 tokens
+Thought · 2 lines · 21 tokens
     First, let me think about the structure.
     Actually, the user wants a concise answer.

--- a/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__reasoning__tests__reasoning_finalised_60.snap
+++ b/crates/astra-cli/src/tui/history_cell/snapshots/astra__tui__history_cell__reasoning__tests__reasoning_finalised_60.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/history_cell/reasoning.rs
-assertion_line: 558
 expression: "render(&c, 60, 4)"
 ---
-Thought · 3s · 2 lines · 10 tokens
+● Thought · 3s · 2 lines · 10 tokens

--- a/crates/astra-cli/src/tui/history_cell/tool.rs
+++ b/crates/astra-cli/src/tui/history_cell/tool.rs
@@ -1,12 +1,12 @@
-//! Tool-invocation history cell — the live `● Running Bash (42ms)` and
+//! Tool-invocation history cell — the live `Running Bash (42ms)` and
 //! terminal `● Ran Bash · 42ms` blocks.
 //!
 //! Three visual states:
-//! - **Running** — accent bullet, shimmer title, elapsed from
-//!   construction `Instant`, optional Braille spinner+progress bar
-//!   if the tool has been running more than 3 s. Not persisted
+//! - **Running** — shimmer title, elapsed from construction `Instant`, and an
+//!   optional compact activity row for real stream counters/backgrounding.
+//!   The outer live gutter already owns the running marker. Not persisted
 //!   until the final `complete()` call.
-//! - **Success** — green bullet, `Ran <name> · Xms` title, optional
+//! - **Success** — green `●`, `Ran <name> · Xms` title, optional
 //!   description (`│ <cmd>`) + output summary (`└ <first 5 lines>`).
 //! - **Failed** — red bullet, `Failed <name> · Xms`, otherwise identical to success.
 //! - **Rejected** — warning bullet, `Did not run <name> · Xms`; the
@@ -67,9 +67,8 @@ pub(crate) struct ToolCell {
     pub output: Option<String>,
     pub ts: Option<String>,
     /// Cumulative lines observed in the tool's stdout stream (bash
-    /// only today — other tools don't emit `ToolOutput` events so
-    /// these stay at 0 and the cell renders an indeterminate
-    /// breathing animation instead of a line counter).
+    /// only today — other tools don't emit `ToolOutput` events, so
+    /// these stay at 0 and no synthetic percentage is shown).
     pub progress_lines: u64,
     pub progress_bytes: u64,
     /// Whether the live bash row should advertise Ctrl+B promotion.
@@ -206,13 +205,10 @@ impl ToolCell {
     fn bullet(&self) -> Span<'static> {
         let theme = crate::tui::theme::current();
         match self.status {
-            // A solid state dot is easier to scan than a tiny middle dot.
-            // Running keeps the focus accent; success/failure use their
-            // narrow semantic roles and never recolor the surrounding prose.
-            ToolStatus::Running => {
-                let theme = crate::tui::theme::current();
-                Span::styled("● ", Style::default().fg(theme.accent).bold())
-            }
+            // Live cells already have a two-column `█ ` gutter. Keeping this
+            // span empty aligns the live title with the frozen title after
+            // the latter gains its `● ` terminal marker.
+            ToolStatus::Running => Span::raw(""),
             ToolStatus::Success => Span::styled("● ", Style::default().fg(theme.success).bold()),
             ToolStatus::Uncertain => Span::styled("● ", Style::default().fg(theme.warn).bold()),
             ToolStatus::Failed => Span::styled("● ", Style::default().fg(theme.error).bold()),
@@ -330,19 +326,10 @@ impl ToolCell {
         })
     }
 
-    /// Sub-line rendered under the header for tools that are still
-    /// running past the 3 s grace window.
-    ///
-    /// Two shapes:
-    /// - **Signal mode** (any `progress_lines` / `progress_bytes`
-    ///   arrived) — a Braille spinner + `"streaming · N lines · K KB"`
-    ///   counter. Honest, monotonic, no fake percentages.
-    /// - **Indeterminate mode** (no progress signal ever arrived —
-    ///   non-streaming tools like `read_file`, `git(action=log)`, skill
-    ///   dispatch) — a breathing bar with a small block sliding back
-    ///   and forth. Purely time-based; makes "still working" visible
-    ///   without pretending to track progress.
-    fn progress_line(&self, width: usize, elapsed_ms: u64) -> Line<'static> {
+    /// Compact sub-line for tools that have real stream counters or expose a
+    /// backgrounding action. Indeterminate progress needs no second animation:
+    /// the shimmer title and outer live gutter already communicate activity.
+    fn progress_line(&self, elapsed_ms: u64) -> Option<Line<'static>> {
         const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
         let frame_idx = ((elapsed_ms / 80) % FRAMES.len() as u64) as usize;
         let theme = crate::tui::theme::current();
@@ -355,7 +342,7 @@ impl ToolCell {
         // Signal mode: show real counters when the tool actually
         // streamed something.
         let background_hint = if self.name == "bash" && self.ctrl_b_background_hint {
-            " · Ctrl+B to background"
+            " · Ctrl+B background"
         } else {
             ""
         };
@@ -371,43 +358,21 @@ impl ToolCell {
                 format_bytes(self.progress_bytes),
                 background_hint,
             );
-            return Line::from(vec![
+            return Some(Line::from(vec![
                 Span::styled("    ", dim),
                 spinner,
                 Span::styled(body, dim),
-            ]);
+            ]));
         }
 
-        // Indeterminate mode: breathing block slides across a
-        // fixed-width track. Position is `t = elapsed_ms / 1400`,
-        // normalised to [0, 1] via a triangle wave so the block
-        // bounces off the ends rather than wrapping.
-        let bar_max = width.saturating_sub(12).clamp(10, 28);
-        let block_len = (bar_max / 4).max(2);
-        let travel = bar_max.saturating_sub(block_len);
-        let pos = if travel == 0 {
-            0
-        } else {
-            let t = (elapsed_ms as f32 / 1400.0).fract();
-            let tri = if t < 0.5 { t * 2.0 } else { (1.0 - t) * 2.0 };
-            (tri * travel as f32).round() as usize
-        };
-        let mut bar = String::with_capacity(bar_max);
-        for i in 0..bar_max {
-            if i >= pos && i < pos + block_len {
-                bar.push('▓');
-            } else {
-                bar.push('░');
-            }
+        if background_hint.is_empty() {
+            return None;
         }
-
-        Line::from(vec![
+        Some(Line::from(vec![
             Span::styled("    ", dim),
             spinner,
-            Span::raw(" "),
-            Span::styled(bar, Style::default().fg(theme.accent)),
-            Span::styled(background_hint.to_string(), dim),
-        ])
+            Span::styled("  Ctrl+B background", dim),
+        ]))
     }
 }
 
@@ -602,11 +567,13 @@ impl ToolCell {
         let has_preview_block = edited_diff.is_some() || preview_text.is_some();
         let description_has_children = missing_failure_details || has_preview_block;
 
-        // Spinner + progress bar for long-running tools.
+        // One compact activity row for real counters or a background action.
         if self.status == ToolStatus::Running {
             let elapsed = self.started_at.elapsed().as_millis() as u64;
-            if elapsed >= 3_000 {
-                lines.push(self.progress_line(w, elapsed));
+            if elapsed >= 3_000
+                && let Some(progress) = self.progress_line(elapsed)
+            {
+                lines.push(progress);
             }
         }
 
@@ -1165,6 +1132,21 @@ mod tests {
         buffer_to_string(&draw_widget(p, width, height))
     }
 
+    fn assert_diff_row(rendered: &str, line_number: usize, marker: char, content: &str) {
+        let body = format!("│ {marker} {content}");
+        let row = rendered
+            .lines()
+            .find(|row| row.contains(&body))
+            .unwrap_or_else(|| panic!("missing diff row `{body}` in:\n{rendered}"));
+        let gutter = row.split_once('│').expect("diff row has a gutter").0;
+        assert!(
+            gutter
+                .split_whitespace()
+                .any(|field| field == line_number.to_string()),
+            "diff row has no line number {line_number}: {row}"
+        );
+    }
+
     fn ok_tool(name: &str, desc: &str, dur: u64) -> ToolCell {
         let mut t = ToolCell::new_running(name, desc);
         t.status = ToolStatus::Success;
@@ -1301,6 +1283,22 @@ mod tests {
         let out = render(&t, 80, 3);
         assert!(out.contains("Running Agent Fanout"), "{out}");
         assert!(!out.contains("Ran Agent Fanout"), "{out}");
+        assert!(
+            !out.contains("● Running") && !out.contains("• Running"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn live_and_frozen_tool_titles_share_the_same_text_column() {
+        let mut tool = ToolCell::new_running("bash", "$ cargo test");
+        let live = tool.display_lines(80);
+        assert_eq!(live[0].spans[0].content.as_ref(), "");
+
+        tool.complete("success", 42, "$ cargo test".into(), None, None);
+        let frozen = tool.display_lines(80);
+        assert_eq!(frozen[0].spans[0].content.as_ref(), "● ");
+        assert_eq!(frozen[0].spans[0].content.width(), 2);
     }
 
     #[test]
@@ -1633,8 +1631,8 @@ mod tests {
 
         let out = render(&t, 100, 8);
         assert!(out.contains("hello.py"));
-        assert!(out.contains("   1 + #!/usr/bin/env python3"), "{out}");
-        assert!(out.contains("   2 + print(\"hello\")"), "{out}");
+        assert_diff_row(&out, 1, '+', "#!/usr/bin/env python3");
+        assert_diff_row(&out, 2, '+', "print(\"hello\")");
         assert!(!out.contains("[38;5;10m"));
         assert!(!out.contains("[2m"));
     }
@@ -1658,9 +1656,9 @@ mod tests {
         );
 
         let out = render(&t, 100, 12);
-        assert!(out.contains("   1 - print(\"old\")"), "{out}");
-        assert!(out.contains("   1 + print(\"new1\")"), "{out}");
-        assert!(out.contains("   5 + print(\"new5\")"), "{out}");
+        assert_diff_row(&out, 1, '-', "print(\"old\")");
+        assert_diff_row(&out, 1, '+', "print(\"new1\")");
+        assert_diff_row(&out, 5, '+', "print(\"new5\")");
         assert!(out.contains("… +1 more changed lines"), "{out}");
         assert!(out.contains("(Ctrl+O to view transcript)"), "{out}");
     }
@@ -1743,8 +1741,8 @@ mod tests {
         let out = render(&t, 100, 10);
         assert!(out.contains("● Edited src/main.rs · +2 -1"), "{out}");
         assert!(!out.contains("Ran Write file"), "{out}");
-        assert!(out.contains("   1 - fn old_name() {}"), "{out}");
-        assert!(out.contains("   2 + fn helper() {}"), "{out}");
+        assert_diff_row(&out, 1, '-', "fn old_name() {}");
+        assert_diff_row(&out, 2, '+', "fn helper() {}");
     }
 
     #[test]
@@ -1942,9 +1940,21 @@ mod tests {
             })
             .expect("expected first added diff row");
         let continuation = &lines[first_idx + 1];
-        assert_eq!(continuation.spans[0].content.as_ref(), "    ");
-        assert_eq!(continuation.spans[1].content.as_ref(), "     ");
-        assert_eq!(continuation.spans[2].content.as_ref(), "  ");
+        let first = &lines[first_idx];
+        for index in 0..3 {
+            assert!(
+                continuation.spans[index]
+                    .content
+                    .chars()
+                    .all(char::is_whitespace),
+                "continuation structural columns must be blank: {continuation:?}"
+            );
+            assert_eq!(
+                UnicodeWidthStr::width(continuation.spans[index].content.as_ref()),
+                UnicodeWidthStr::width(first.spans[index].content.as_ref()),
+                "continuation must preserve the source row's column grid"
+            );
+        }
         let bg = continuation.spans[1].style.bg;
         assert!(bg.is_some(), "expected wrapped diff background");
         assert_eq!(continuation.spans[0].style.bg, bg);
@@ -1974,7 +1984,8 @@ mod tests {
         t.set_ctrl_b_background_hint(true);
         t.started_at = Instant::now() - std::time::Duration::from_secs(4);
         let out = render(&t, 100, 4);
-        assert!(out.contains("Ctrl+B to background"), "{out}");
+        assert!(out.contains("Ctrl+B background"), "{out}");
+        assert!(!out.contains('░') && !out.contains('▓'), "{out}");
     }
 
     #[test]
@@ -1983,6 +1994,17 @@ mod tests {
         t.started_at = Instant::now() - std::time::Duration::from_secs(4);
         let out = render(&t, 100, 4);
         assert!(!out.contains("Ctrl+B"), "{out}");
+        assert!(!out.contains('░') && !out.contains('▓'), "{out}");
+    }
+
+    #[test]
+    fn real_stream_progress_keeps_compact_monotonic_counters() {
+        let mut t = ToolCell::new_running("bash", "$ cargo test");
+        t.started_at = Instant::now() - std::time::Duration::from_secs(4);
+        t.set_progress(12, 2_048);
+        let out = render(&t, 100, 4);
+        assert!(out.contains("streaming · 12 lines · 2.0 KB"), "{out}");
+        assert!(!out.contains('░') && !out.contains('▓'), "{out}");
     }
 
     #[test]

--- a/crates/astra-cli/src/tui/status_indicator.rs
+++ b/crates/astra-cli/src/tui/status_indicator.rs
@@ -43,6 +43,9 @@ pub(crate) enum IndicatorState {
     /// A user stop request is visible locally while the run and any child
     /// control-plane updates converge on a terminal state.
     Cancelling { started_at: Instant },
+    /// The process is preserving the current turn and finalizing its session
+    /// before returning control to the shell.
+    Exiting { started_at: Instant },
     /// Turn is running, model is thinking / producing tokens.
     Thinking { started_at: Instant },
     /// Tool is executing mid-turn.
@@ -59,6 +62,7 @@ impl IndicatorState {
             IndicatorState::Idle => None,
             IndicatorState::Dispatching { started_at }
             | IndicatorState::Cancelling { started_at }
+            | IndicatorState::Exiting { started_at }
             | IndicatorState::Thinking { started_at }
             | IndicatorState::Tool { started_at, .. }
             | IndicatorState::WaitingModel { started_at }
@@ -123,12 +127,15 @@ impl StatusIndicator {
         // Stream events queued before Ctrl+C can arrive during shutdown. They
         // are progress evidence, not authority to revoke the user's cancel
         // intent, so keep Stopping monotonic until terminal settlement.
-        if matches!(self.state, IndicatorState::Cancelling { .. })
-            && !matches!(
-                state,
-                IndicatorState::Cancelling { .. } | IndicatorState::Idle
-            )
-        {
+        if matches!(
+            self.state,
+            IndicatorState::Cancelling { .. } | IndicatorState::Exiting { .. }
+        ) && !matches!(
+            state,
+            IndicatorState::Cancelling { .. }
+                | IndicatorState::Exiting { .. }
+                | IndicatorState::Idle
+        ) {
             return;
         }
         // The stream counter resets across state changes only when
@@ -150,7 +157,10 @@ impl StatusIndicator {
             self.stream_chars = 0;
             self.turn_started_at = None;
             self.turn_label = None;
-        } else if matches!(state, IndicatorState::Cancelling { .. }) {
+        } else if matches!(
+            state,
+            IndicatorState::Cancelling { .. } | IndicatorState::Exiting { .. }
+        ) {
             self.turn_label = Some("Stopping");
         }
         self.state = state;
@@ -179,6 +189,14 @@ impl StatusIndicator {
         self.turn_label = Some("Sending");
         self.stream_chars = 0;
         self.state = IndicatorState::Dispatching { started_at: at };
+    }
+
+    /// Project an accepted process-exit request immediately. Unlike
+    /// cancellation, this is also valid while idle, when no turn start exists.
+    pub fn begin_exit(&mut self, at: Instant) {
+        self.turn_started_at = Some(at);
+        self.turn_label = Some("Stopping");
+        self.state = IndicatorState::Exiting { started_at: at };
     }
 
     pub fn mark_dispatched(&mut self) {
@@ -255,6 +273,7 @@ fn render_for_with_bash_hint(
     let state_label: String = match state {
         IndicatorState::Dispatching { .. } => "Sending".into(),
         IndicatorState::Cancelling { .. } => "Stopping".into(),
+        IndicatorState::Exiting { .. } => "Stopping".into(),
         IndicatorState::Thinking { .. } => "Thinking".into(),
         IndicatorState::Tool { name, .. } => label_for_tool(name),
         IndicatorState::WaitingModel { .. } => "Starting".into(),
@@ -312,7 +331,7 @@ fn label_for_tool(name: &str) -> String {
 fn indicator_state_color(state: &IndicatorState, theme: &crate::tui::theme::Theme) -> Color {
     match state {
         IndicatorState::AwaitingApproval { .. } => theme.warn,
-        IndicatorState::Cancelling { .. } => theme.warn,
+        IndicatorState::Cancelling { .. } | IndicatorState::Exiting { .. } => theme.warn,
         IndicatorState::Dispatching { .. }
         | IndicatorState::Thinking { .. }
         | IndicatorState::Tool { .. }
@@ -353,7 +372,10 @@ fn suffix(
             crate::tui::background_shortcut::ctrl_b_background_shortcut()
         ));
     }
-    if !matches!(state, IndicatorState::Cancelling { .. }) {
+    if !matches!(
+        state,
+        IndicatorState::Cancelling { .. } | IndicatorState::Exiting { .. }
+    ) {
         parts.push("Ctrl+C to stop".into());
     }
     parts.join(" · ")
@@ -494,6 +516,22 @@ mod tests {
     fn idle_renders_none() {
         let s = StatusIndicator::new();
         assert!(s.render().is_none());
+    }
+
+    #[test]
+    fn exit_is_visible_without_an_active_turn() {
+        let mut indicator = StatusIndicator::new();
+        let started_at = Instant::now();
+
+        indicator.begin_exit(started_at);
+
+        let rendered = text_of(
+            &indicator
+                .render_at(started_at + Duration::from_secs(1))
+                .expect("accepted exit remains visible during finalization"),
+        );
+        assert!(rendered.contains("Stopping"), "{rendered}");
+        assert!(!rendered.contains("Ctrl+C to stop"), "{rendered}");
     }
 
     #[test]

--- a/crates/astra-cli/src/tui/status_line/context_bar.rs
+++ b/crates/astra-cli/src/tui/status_line/context_bar.rs
@@ -1,0 +1,241 @@
+//! Context-window capacity rail rendered directly above the composer.
+//!
+//! The rail is deliberately a separate visual channel from the status line:
+//! capacity is continuous data, so position and colour communicate it more
+//! efficiently than another textual chip in an already crowded footer.
+
+use astra_turn_types::{ContextWindowUsage, ContextWindowUsageSource};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+};
+use unicode_width::UnicodeWidthStr;
+
+const SIDE_PADDING: u16 = 2;
+const LABEL_GAP: u16 = 1;
+const WARN_PERCENT: u64 = 75;
+const ERROR_PERCENT: u64 = 90;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ContextBar {
+    usage: Option<ContextWindowUsage>,
+    is_previous: bool,
+}
+
+impl ContextBar {
+    pub(crate) fn new(usage: Option<ContextWindowUsage>, is_previous: bool) -> Self {
+        Self { usage, is_previous }
+    }
+
+    pub(crate) fn render(self, area: Rect, buf: &mut Buffer) {
+        let Some(usage) = self.usage.filter(|usage| usage.limit_tokens > 0) else {
+            return;
+        };
+        if area.height == 0 || area.width <= SIDE_PADDING.saturating_mul(2) {
+            return;
+        }
+
+        let theme = crate::tui::theme::current();
+        let inner_x = area.x.saturating_add(SIDE_PADDING);
+        let inner_width = area.width.saturating_sub(SIDE_PADDING.saturating_mul(2));
+        let label = context_label(usage);
+        let label_width = u16::try_from(label.width()).unwrap_or(u16::MAX);
+
+        // On genuinely narrow terminals, capacity is still useful as text.
+        // Giving the label the row is clearer than squeezing in a decorative
+        // one- or two-cell rail that cannot communicate a meaningful ratio.
+        if label_width.saturating_add(LABEL_GAP) >= inner_width {
+            let compact = compact_label(usage, usize::from(inner_width));
+            let compact_width = u16::try_from(compact.width()).unwrap_or(inner_width);
+            let x = inner_x.saturating_add(inner_width.saturating_sub(compact_width));
+            buf.set_string(x, area.y, compact, label_style(usage, self.is_previous));
+            return;
+        }
+
+        let rail_width = inner_width.saturating_sub(label_width + LABEL_GAP);
+        let filled = filled_cells(usage.used_tokens, usage.limit_tokens, rail_width);
+        let fill_style = evidence_style(
+            Style::default().fg(capacity_color(usage)),
+            usage,
+            self.is_previous,
+        );
+        let empty_style = Style::default().fg(theme.dim).add_modifier(Modifier::DIM);
+        if filled > 0 {
+            buf.set_string(inner_x, area.y, "─".repeat(usize::from(filled)), fill_style);
+        }
+        if rail_width > filled {
+            buf.set_string(
+                inner_x.saturating_add(filled),
+                area.y,
+                "─".repeat(usize::from(rail_width - filled)),
+                empty_style,
+            );
+        }
+        buf.set_string(
+            inner_x.saturating_add(rail_width + LABEL_GAP),
+            area.y,
+            label,
+            label_style(usage, self.is_previous),
+        );
+    }
+}
+
+fn filled_cells(used: u64, limit: u64, width: u16) -> u16 {
+    if used == 0 || limit == 0 || width == 0 {
+        return 0;
+    }
+    let used = u128::from(used.min(limit));
+    let limit = u128::from(limit);
+    let width = u128::from(width);
+    // Round to the nearest cell. A non-zero value gets one visible cell so a
+    // large window does not make early usage look exactly empty.
+    let rounded = ((used * width) + (limit / 2)) / limit;
+    u16::try_from(rounded.max(1).min(width)).unwrap_or(u16::MAX)
+}
+
+fn capacity_color(usage: ContextWindowUsage) -> Color {
+    let theme = crate::tui::theme::current();
+    let used = u128::from(usage.used_tokens);
+    let limit = u128::from(usage.limit_tokens.max(1));
+    if used.saturating_mul(100) >= limit.saturating_mul(u128::from(ERROR_PERCENT)) {
+        theme.error
+    } else if used.saturating_mul(100) >= limit.saturating_mul(u128::from(WARN_PERCENT)) {
+        theme.warn
+    } else {
+        // A calm teal rail reads as ambient capacity, not primary action.
+        // Bright accent remains reserved for focus and navigation.
+        theme.quote
+    }
+}
+
+fn label_style(usage: ContextWindowUsage, is_previous: bool) -> Style {
+    let theme = crate::tui::theme::current();
+    let style = if capacity_color(usage) == theme.quote {
+        Style::default().fg(theme.dim)
+    } else {
+        Style::default().fg(capacity_color(usage))
+    };
+    evidence_style(style, usage, is_previous)
+}
+
+fn context_label(usage: ContextWindowUsage) -> String {
+    format!(
+        "{} / {}",
+        format_tokens_compact(usage.used_tokens),
+        format_tokens_compact(usage.limit_tokens)
+    )
+}
+
+fn evidence_style(mut style: Style, usage: ContextWindowUsage, is_previous: bool) -> Style {
+    if is_previous || matches!(usage.source, ContextWindowUsageSource::Estimated) {
+        style = style.add_modifier(Modifier::DIM);
+    }
+    style
+}
+
+fn compact_label(usage: ContextWindowUsage, max_width: usize) -> String {
+    let label = context_label(usage);
+    if label.width() <= max_width {
+        return label;
+    }
+    let compact = label.replace(" / ", "/");
+    if compact.width() <= max_width {
+        return compact;
+    }
+    if max_width == 0 {
+        return String::new();
+    }
+    if max_width == 1 {
+        return "…".to_string();
+    }
+    let mut out = compact.chars().take(max_width - 1).collect::<String>();
+    out.push('…');
+    out
+}
+
+/// "25000" → "25k"; preserves exact counts below 1k.
+fn format_tokens_compact(tokens: u64) -> String {
+    if tokens < 1_000 {
+        tokens.to_string()
+    } else if tokens < 1_000_000 {
+        let rounded_k = (tokens + 500) / 1_000;
+        if rounded_k >= 1_000 {
+            "1.0M".to_string()
+        } else {
+            format!("{rounded_k}k")
+        }
+    } else {
+        format!("{:.1}M", tokens as f64 / 1_000_000.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(usage: ContextWindowUsage, width: u16) -> Buffer {
+        let area = Rect::new(0, 0, width, 1);
+        let mut buf = Buffer::empty(area);
+        ContextBar::new(Some(usage), false).render(area, &mut buf);
+        buf
+    }
+
+    fn text(buf: &Buffer) -> String {
+        (0..buf.area.width)
+            .map(|x| buf[(x, 0)].symbol())
+            .collect::<String>()
+    }
+
+    #[test]
+    fn rail_uses_the_actionable_input_limit_without_internal_breakdown() {
+        let buf = render(ContextWindowUsage::provider_reported(95_000, 800_000), 64);
+        let rendered = text(&buf);
+        assert!(rendered.contains("95k / 800k"), "{rendered:?}");
+        assert!(!rendered.contains("Ctx"), "{rendered:?}");
+        assert!(!rendered.contains("usable"), "{rendered:?}");
+    }
+
+    #[test]
+    fn fill_is_proportional_and_clamped_to_the_rail() {
+        assert_eq!(filled_cells(25, 100, 40), 10);
+        assert_eq!(filled_cells(0, 100, 40), 0);
+        assert_eq!(filled_cells(150, 100, 40), 40);
+    }
+
+    #[test]
+    fn capacity_thresholds_use_semantic_theme_colours() {
+        let theme = crate::tui::theme::current();
+        assert_eq!(
+            capacity_color(ContextWindowUsage::provider_reported(74, 100)),
+            theme.quote
+        );
+        assert_eq!(
+            capacity_color(ContextWindowUsage::provider_reported(75, 100)),
+            theme.warn
+        );
+        assert_eq!(
+            capacity_color(ContextWindowUsage::provider_reported(90, 100)),
+            theme.error
+        );
+    }
+
+    #[test]
+    fn estimated_usage_avoids_cryptic_punctuation_in_the_compact_readout() {
+        let buf = render(ContextWindowUsage::estimated(95_000, 800_000), 64);
+        let rendered = text(&buf);
+        assert!(rendered.contains("95k / 800k"));
+        assert!(!rendered.contains('~'));
+    }
+
+    #[test]
+    fn narrow_width_keeps_a_compact_readout_and_never_overflows() {
+        let buf = render(ContextWindowUsage::provider_reported(95_000, 800_000), 14);
+        let rendered = text(&buf);
+        assert_eq!(rendered.width(), 14);
+        assert!(
+            rendered.contains("95k / 800k") || rendered.contains("95k/800k"),
+            "{rendered:?}"
+        );
+    }
+}

--- a/crates/astra-cli/src/tui/status_line/line.rs
+++ b/crates/astra-cli/src/tui/status_line/line.rs
@@ -1,7 +1,5 @@
 //! Pure status-line composition.
 
-use std::time::Duration;
-
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
@@ -17,20 +15,7 @@ pub(crate) use crate::cli::permission_manager::PermissionMode;
 pub(crate) struct StatusContext {
     pub model: Option<String>,
     pub cwd: Option<String>,
-    /// One request's usable context-window occupancy.
-    pub context_window: Option<astra_turn_types::ContextWindowUsage>,
-    pub raw_context_window_tokens: Option<u64>,
-    /// The displayed occupancy belongs to the preceding completed request
-    /// while the next request is still being assembled. Keeping it visible
-    /// avoids a false "unknown/zero" gap, while this bit prevents presenting
-    /// stale evidence as the current request.
-    pub context_window_is_previous: bool,
-    pub current_objective: Option<String>,
-    pub turn_elapsed: Option<Duration>,
     pub permission_mode: PermissionMode,
-    pub turn_active: bool,
-    pub session_id: Option<String>,
-    pub cost_usd: Option<f64>,
     pub git_branch: Option<String>,
     /// Number of approvals currently awaiting a user decision.
     pub pending_approvals: usize,
@@ -291,14 +276,10 @@ fn background_task_count_parts(counts: BackgroundTaskCounts) -> Vec<String> {
     parts
 }
 
-/// Threshold below which the budget chip is dim, above which it warns.
-const BUDGET_WARN_PERCENT: f32 = 75.0;
-const BUDGET_ERROR_PERCENT: f32 = 90.0;
 /// Max cwd segment width before the middle is elided.
 const MODEL_MAX_WIDTH: usize = 24;
 const BRANCH_MAX_WIDTH: usize = 16;
 const CWD_MAX_WIDTH: usize = 26;
-const PRIMARY_LEFT_FLOOR_WIDTH: usize = 14;
 
 fn permission_mode_label(mode: PermissionMode) -> &'static str {
     mode.chip_text()
@@ -322,12 +303,10 @@ impl StatusLine {
         // Permission mode changes whether tools run automatically or ask first.
         // Keep it visible so `/mode` feedback matches the persistent status line.
         match ctx.permission_mode {
-            PermissionMode::Prompt => {
-                out.left.push(Segment::styled(
-                    permission_mode_label(ctx.permission_mode),
-                    muted.add_modifier(Modifier::BOLD),
-                ));
-            }
+            // Prompt is the safe default. Repeating it forever adds no new
+            // information; modes that materially change execution remain
+            // visible and colour-coded.
+            PermissionMode::Prompt => {}
             PermissionMode::Auto => {
                 out.left.push(Segment::styled(
                     permission_mode_label(ctx.permission_mode),
@@ -338,7 +317,7 @@ impl StatusLine {
                 out.left.push(Segment::styled(
                     permission_mode_label(ctx.permission_mode),
                     Style::default()
-                        .fg(theme.accent)
+                        .fg(theme.error)
                         .add_modifier(Modifier::BOLD),
                 ));
             }
@@ -426,48 +405,12 @@ impl StatusLine {
             out.left.push(Segment::styled(parts.join(" · "), style));
         }
 
-        // ── Right: cwd · budget · branch · cost ────────────────────
+        // ── Right: quiet workspace identity ───────────────────────
         if let Some(cwd) = ctx.cwd.as_deref() {
             out.right.push(Segment::styled(
                 truncate_cwd(cwd, CWD_MAX_WIDTH),
                 Style::default().fg(theme.path_file),
             ));
-        }
-
-        if let Some(usage) = ctx.context_window {
-            if usage.limit_tokens > 0 {
-                let pct = (usage.used_tokens as f32 / usage.limit_tokens as f32) * 100.0;
-                let style = if pct >= BUDGET_ERROR_PERCENT {
-                    Style::default().fg(theme.error)
-                } else if pct >= BUDGET_WARN_PERCENT {
-                    Style::default().fg(theme.warn)
-                } else {
-                    muted
-                };
-                let approximation = matches!(
-                    usage.source,
-                    astra_turn_types::ContextWindowUsageSource::Estimated
-                )
-                .then_some("~")
-                .unwrap_or("");
-                let scope = if ctx.context_window_is_previous {
-                    "last "
-                } else {
-                    ""
-                };
-                out.right.push(Segment::styled(
-                    format!(
-                        "Ctx {scope}{approximation}{pct:.0}% · {}/{}{}",
-                        format_tokens_compact(usage.used_tokens),
-                        format_tokens_compact(usage.limit_tokens),
-                        ctx.raw_context_window_tokens
-                            .filter(|raw| *raw != usage.limit_tokens)
-                            .map(|raw| format!(" usable · {} raw", format_tokens_compact(raw)))
-                            .unwrap_or_default(),
-                    ),
-                    style,
-                ));
-            }
         }
 
         if let Some(branch) = ctx.git_branch.as_deref() {
@@ -477,23 +420,17 @@ impl StatusLine {
             ));
         }
 
-        if should_render_cost(ctx) {
-            let cost = ctx.cost_usd.expect("cost checked above");
-            out.right
-                .push(Segment::styled(format!("${cost:.2}"), muted));
-        }
-
         out
     }
 
-    /// Render to a simple string for testing: left joined by ' · ',
-    /// two-space gap, right joined by ' · '.
+    /// Render to a simple string for testing. Colour carries grouping in the
+    /// actual TUI; two spaces preserve that rhythm in plain text.
     pub fn plain(&self) -> String {
         ordered_render_segments(&self.left, &self.right)
             .into_iter()
             .map(|seg| seg.text)
             .collect::<Vec<_>>()
-            .join(" · ")
+            .join("  ")
     }
 
     /// Draw into `area` of `buf`. Left side sticks to the left edge; right
@@ -506,100 +443,58 @@ impl StatusLine {
         }
         let surface = crate::tui::style::footer_surface_style();
         let bg = surface.bg.unwrap_or(Color::Reset);
-        let sep = Span::styled(
-            " · ",
-            Style::default().fg(crate::tui::theme::current().dim).bg(bg),
-        );
-
+        const MARGIN: usize = 2;
+        const INNER_GAP: &str = "  ";
+        let available = usize::from(area.width).saturating_sub(MARGIN * 2);
+        if available == 0 {
+            return;
+        }
+        let mut left_segments = self.left.clone();
         let mut right_segments = self.right.clone();
-        while right_segments.len() > 1
-            && status_line_total_width(&self.left, &right_segments) > usize::from(area.width)
-        {
-            // Context capacity is operational state. Drop optional decoration
-            // by meaning, not by its incidental position in the vector.
-            let remove_index = right_segments
-                .iter()
-                .rposition(|segment| segment.text.starts_with('$'))
-                .or_else(|| {
-                    right_segments
-                        .iter()
-                        .rposition(|segment| segment.text.starts_with("⎇ "))
-                })
-                .or_else(|| {
-                    right_segments
-                        .iter()
-                        .position(|segment| !segment.text.starts_with("Ctx "))
-                });
-            let Some(remove_index) = remove_index else {
-                break;
-            };
-            right_segments.remove(remove_index);
+        fit_clusters(&mut left_segments, &mut right_segments, available);
+
+        let left_spans = join_segments(&left_segments, INNER_GAP, bg);
+        let right_spans = join_segments(&right_segments, INNER_GAP, bg);
+        let left_width = spans_width(&left_spans);
+        let right_width = spans_width(&right_spans);
+
+        if !left_spans.is_empty() {
+            Widget::render(
+                Line::from(left_spans),
+                Rect::new(
+                    area.x.saturating_add(MARGIN as u16),
+                    area.y,
+                    u16::try_from(left_width.min(available)).unwrap_or(area.width),
+                    1,
+                ),
+                buf,
+            );
         }
-        tighten_primary_right_segment(&self.left, &mut right_segments, area.width);
-        let mut ordered = ordered_render_segments(&self.left, &right_segments);
-        loop {
-            let spans = join_segments(&ordered, &sep, 2 /* leading indent */, bg);
-            let used: usize = spans.iter().map(|s| s.content.width()).sum();
-            let total = used + 2; // trailing margin
-            if total <= area.width as usize || ordered.len() <= 1 {
-                let padding = (area.width as usize).saturating_sub(used + 2);
-                let mut all = spans;
-                all.push(Span::styled(" ".repeat(padding), Style::default().bg(bg)));
-                Widget::render(Line::from(all), area, buf);
-                break;
-            }
-            if compact_last_context_segment(&mut ordered, area.width) {
-                continue;
-            }
-            if ordered
-                .last()
-                .is_some_and(|segment| segment.text.starts_with("Ctx "))
-                && ordered.len() > 2
-            {
-                // Keep the primary left identity and capacity signal; shed a
-                // secondary left chip before discarding context altogether.
-                ordered.remove(ordered.len() - 2);
-                continue;
-            }
-            ordered.pop();
+        if !right_spans.is_empty() {
+            let right_x = area
+                .x
+                .saturating_add(area.width)
+                .saturating_sub(MARGIN as u16)
+                .saturating_sub(u16::try_from(right_width).unwrap_or(area.width));
+            Widget::render(
+                Line::from(right_spans),
+                Rect::new(
+                    right_x,
+                    area.y,
+                    u16::try_from(right_width.min(available)).unwrap_or(area.width),
+                    1,
+                ),
+                buf,
+            );
         }
     }
 }
 
-fn should_render_cost(ctx: &StatusContext) -> bool {
-    ctx.cost_usd.is_some() && !is_dense_footer_context(ctx)
-}
-
-fn is_dense_footer_context(ctx: &StatusContext) -> bool {
-    let mut signals = 0usize;
-    if ctx.context_window.is_some() {
-        signals += 1;
-    }
-    if ctx.git_branch.is_some() {
-        signals += 1;
-    }
-    if ctx.cost_usd.is_some() {
-        signals += 1;
-    }
-    signals >= 2
-}
-
-fn join_segments(
-    segments: &[Segment],
-    sep: &Span<'_>,
-    leading_spaces: usize,
-    bg: Color,
-) -> Vec<Span<'static>> {
-    let mut spans: Vec<Span<'static>> = Vec::with_capacity(segments.len() * 2 + 1);
-    if leading_spaces > 0 {
-        spans.push(Span::styled(
-            " ".repeat(leading_spaces),
-            Style::default().bg(bg),
-        ));
-    }
+fn join_segments(segments: &[Segment], separator: &str, bg: Color) -> Vec<Span<'static>> {
+    let mut spans: Vec<Span<'static>> = Vec::with_capacity(segments.len() * 2);
     for (i, seg) in segments.iter().enumerate() {
         if i > 0 {
-            spans.push(Span::styled(sep.content.to_string(), sep.style));
+            spans.push(Span::styled(separator.to_string(), Style::default().bg(bg)));
         }
         spans.push(Span::styled(seg.text.clone(), seg.style.bg(bg)));
     }
@@ -613,71 +508,48 @@ fn ordered_render_segments(left: &[Segment], right: &[Segment]) -> Vec<Segment> 
     ordered
 }
 
-fn status_line_total_width(left: &[Segment], right: &[Segment]) -> usize {
-    let segments = left.len() + right.len();
-    if segments == 0 {
-        return 0;
-    }
-    let segment_width: usize = left
-        .iter()
-        .chain(right.iter())
-        .map(|seg| seg.text.width())
-        .sum();
-    let separator_width = segments.saturating_sub(1) * " · ".width();
-    2 + segment_width + separator_width + 2
+fn spans_width(spans: &[Span<'_>]) -> usize {
+    spans.iter().map(|span| span.content.width()).sum()
 }
 
-fn tighten_ordered_cwd_segment(ordered: &mut [Segment], total_width: u16) {
-    if ordered.len() < 2 {
-        return;
-    }
-
-    let sep_w = " · ".width();
-    let lead_indent = 2usize;
-    let trailing_margin = 2usize;
-    let model_width = ordered[0].text.width();
-    let other_width: usize = ordered
+fn cluster_width(segments: &[Segment]) -> usize {
+    segments
         .iter()
-        .skip(2)
-        .map(|seg| seg.text.width() + sep_w)
-        .sum();
-    let separator_count = ordered.len().saturating_sub(1);
-    let separator_width = separator_count * sep_w;
-    let available = usize::from(total_width)
-        .saturating_sub(lead_indent + trailing_margin + model_width + other_width + separator_width)
-        .max(8);
-
-    if ordered[1].text.width() > available {
-        ordered[1].text = truncate_cwd(&ordered[1].text, available);
-    }
+        .map(|segment| segment.text.width())
+        .sum::<usize>()
+        + segments.len().saturating_sub(1) * 2
 }
 
-fn tighten_primary_right_segment(left: &[Segment], right: &mut [Segment], total_width: u16) {
-    if left.is_empty() || right.is_empty() || right[0].text.starts_with("Ctx ") {
-        return;
+fn fit_clusters(left: &mut Vec<Segment>, right: &mut Vec<Segment>, available: usize) {
+    const CLUSTER_GAP: usize = 3;
+    let total = |left: &[Segment], right: &[Segment]| {
+        cluster_width(left)
+            + cluster_width(right)
+            + usize::from(!left.is_empty() && !right.is_empty()) * CLUSTER_GAP
+    };
+
+    // Branch is decoration; cwd is the primary workspace anchor.
+    while right.len() > 1 && total(left, right) > available {
+        right.pop();
     }
-
-    let sep_w = " · ".width();
-    let lead_indent = 2usize;
-    let trailing_margin = 2usize;
-    let preferred_left = left[0]
-        .text
-        .width()
-        .min(MODEL_MAX_WIDTH.max(PRIMARY_LEFT_FLOOR_WIDTH));
-    let other_right_width: usize = right
-        .iter()
-        .skip(1)
-        .map(|seg| seg.text.width() + sep_w)
-        .sum();
-    let available_for_primary_right = usize::from(total_width)
-        .saturating_sub(lead_indent + trailing_margin + preferred_left + other_right_width);
-
-    if right[0].text.width() <= available_for_primary_right {
-        return;
+    // Secondary left chips yield before model identity on very narrow screens.
+    while left.len() > 1 && total(left, right) > available {
+        left.pop();
     }
-
-    let max_width = available_for_primary_right.max(8);
-    right[0].text = truncate_cwd(&right[0].text, max_width);
+    if total(left, right) > available && !right.is_empty() {
+        if left.is_empty() {
+            right[0].text = truncate_end(&right[0].text, available.max(1));
+            right.truncate(1);
+        } else {
+            right.clear();
+        }
+    }
+    if total(left, right) > available
+        && let Some(primary) = left.first_mut()
+    {
+        primary.text = truncate_end(&primary.text, available.max(1));
+        left.truncate(1);
+    }
 }
 
 /// Shorten `cwd` to at most `max_width` characters by replacing the
@@ -788,120 +660,4 @@ fn truncate_end(text: &str, max_width: usize) -> String {
     }
     let head: String = text.chars().take(max_width - 1).collect();
     format!("{head}…")
-}
-
-fn compact_last_context_segment(ordered: &mut [Segment], total_width: u16) -> bool {
-    let Some(last_text) = ordered.last().map(|seg| seg.text.as_str()) else {
-        return false;
-    };
-    if !last_text.starts_with("Ctx ") {
-        return false;
-    }
-
-    let sep_w = " · ".width();
-    let lead_indent = 2usize;
-    let trailing_margin = 2usize;
-    let fixed_width: usize = ordered
-        .iter()
-        .take(ordered.len().saturating_sub(1))
-        .map(|seg| seg.text.width())
-        .sum::<usize>()
-        + ordered.len().saturating_sub(1) * sep_w
-        + lead_indent
-        + trailing_margin;
-    let available = usize::from(total_width).saturating_sub(fixed_width);
-    if last_text.width() <= available {
-        return false;
-    }
-
-    let compact = compact_context_text(last_text, available);
-    if compact == last_text {
-        return false;
-    }
-    if let Some(last) = ordered.last_mut() {
-        last.text = compact;
-    }
-    true
-}
-
-fn compact_context_text(text: &str, max_width: usize) -> String {
-    if text.width() <= max_width {
-        return text.to_string();
-    }
-    if max_width <= 1 {
-        return "…".to_string();
-    }
-
-    let Some((prefix, tokens)) = text.rsplit_once(" · ") else {
-        return truncate_end(text, max_width);
-    };
-    let limit = tokens
-        .rsplit_once('/')
-        .map(|(_, limit)| limit)
-        .unwrap_or(tokens);
-    let limit_only = format!("…/{limit}");
-    if limit_only.width() > max_width {
-        return truncate_end(&limit_only, max_width);
-    }
-
-    let with_prefix = format!("{prefix} · {limit_only}");
-    if with_prefix.width() <= max_width {
-        with_prefix
-    } else {
-        limit_only
-    }
-}
-
-fn truncate_left_segments_to_fit(
-    segments: &[Segment],
-    right_width: usize,
-    total_width: u16,
-) -> Vec<Segment> {
-    if segments.is_empty() {
-        return Vec::new();
-    }
-
-    let sep_w = " · ".width();
-    let lead_indent = 2usize;
-    let trailing_margin = 2usize;
-    let mut kept = segments.to_vec();
-
-    loop {
-        let other_width: usize = kept
-            .iter()
-            .skip(1)
-            .map(|seg| seg.text.width() + sep_w)
-            .sum();
-        let available = usize::from(total_width)
-            .saturating_sub(right_width + lead_indent + trailing_margin + other_width);
-
-        if kept[0].text.width() <= available {
-            return kept;
-        }
-
-        if kept.len() > 1 {
-            kept.pop();
-            continue;
-        }
-
-        let floor = 10usize;
-        kept[0].text = truncate_end(&kept[0].text, available.max(floor));
-        return kept;
-    }
-}
-
-/// "25000" → "25k"; preserves exact count under 1k.
-fn format_tokens_compact(n: u64) -> String {
-    if n < 1_000 {
-        n.to_string()
-    } else if n < 1_000_000 {
-        let rounded_k = (n + 500) / 1_000;
-        if rounded_k >= 1_000 {
-            "1.0M".to_string()
-        } else {
-            format!("{rounded_k}k")
-        }
-    } else {
-        format!("{:.1}M", n as f64 / 1_000_000.0)
-    }
 }

--- a/crates/astra-cli/src/tui/status_line/mod.rs
+++ b/crates/astra-cli/src/tui/status_line/mod.rs
@@ -3,8 +3,10 @@
 //! [`StatusContext`] value, which means every visual variation has a
 //! snapshot and nothing depends on the event loop state.
 
+pub(crate) mod context_bar;
 pub(crate) mod line;
 
+pub(crate) use context_bar::ContextBar;
 pub(crate) use line::{BackgroundTaskCounts, StatusContext, StatusLine};
 
 #[cfg(test)]

--- a/crates/astra-cli/src/tui/status_line/snapshot_tests.rs
+++ b/crates/astra-cli/src/tui/status_line/snapshot_tests.rs
@@ -40,15 +40,6 @@ fn snapshot_idle_minimal() {
 }
 
 #[test]
-fn snapshot_turn_active() {
-    let ctx = StatusContext {
-        turn_active: true,
-        ..base_ctx()
-    };
-    crate::tui::testing::assert_tui_snapshot!("status_turn_active_80", render_ctx(&ctx, 80));
-}
-
-#[test]
 fn snapshot_auto_mode() {
     let ctx = StatusContext {
         permission_mode: PermissionMode::Auto,
@@ -67,21 +58,6 @@ fn snapshot_deny_mode() {
 }
 
 #[test]
-fn snapshot_high_token_usage_with_cost() {
-    let ctx = StatusContext {
-        context_window: Some(astra_turn_types::ContextWindowUsage::provider_reported(
-            92_000, 100_000,
-        )),
-        cost_usd: Some(3.47),
-        ..base_ctx()
-    };
-    crate::tui::testing::assert_tui_snapshot!(
-        "status_high_tokens_with_cost_80",
-        render_ctx(&ctx, 80)
-    );
-}
-
-#[test]
 fn snapshot_git_branch_included() {
     let ctx = StatusContext {
         git_branch: Some("enhance_tui".into()),
@@ -95,12 +71,7 @@ fn snapshot_full_context_80() {
     let ctx = StatusContext {
         model: Some("sonnet-4.6".into()),
         cwd: Some("~/projects/astra".into()),
-        context_window: Some(astra_turn_types::ContextWindowUsage::provider_reported(
-            40_000, 200_000,
-        )),
         permission_mode: PermissionMode::Auto,
-        turn_active: false,
-        cost_usd: Some(0.42),
         git_branch: Some("enhance_tui".into()),
         ..StatusContext::default()
     };
@@ -112,9 +83,6 @@ fn snapshot_narrow_drops_right_segments() {
     let ctx = StatusContext {
         model: Some("sonnet-4.6".into()),
         cwd: Some("~/projects/astra".into()),
-        context_window: Some(astra_turn_types::ContextWindowUsage::provider_reported(
-            40_000, 200_000,
-        )),
         git_branch: Some("enhance_tui".into()),
         ..StatusContext::default()
     };

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_auto_mode_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_auto_mode_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 57
 expression: "render_ctx(&ctx, 80)"
 ---
-  sonnet-4.6 · Auto · ~/projects/astra
+  sonnet-4.6  Auto                                            ~/projects/astra

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_deny_mode_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_deny_mode_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 66
 expression: "render_ctx(&ctx, 80)"
 ---
-  sonnet-4.6 · Deny · ~/projects/astra
+  sonnet-4.6  Deny                                            ~/projects/astra

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_full_context_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_full_context_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 107
 expression: "render_ctx(&ctx, 80)"
 ---
-  sonnet-4.6 · Auto · ~/projects/astra · Ctx 20% · 40k/200k · ⎇ enhance_tui
+  sonnet-4.6  Auto                             ~/projects/astra  ⎇ enhance_tui

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_high_tokens_with_cost_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_high_tokens_with_cost_80.snap
@@ -1,6 +1,0 @@
----
-source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 78
-expression: "render_ctx(&ctx, 80)"
----
-  sonnet-4.6 · Ask · ~/projects/astra · Ctx 92% · 92k/100k

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_idle_minimal_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_idle_minimal_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 36
 expression: "render_ctx(&base_ctx(), 80)"
 ---
-  sonnet-4.6 · Ask · ~/projects/astra
+  sonnet-4.6                                                  ~/projects/astra

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_long_cwd_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_long_cwd_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 143
 expression: "render_ctx(&ctx, 80)"
 ---
-  Ask · ~/…/that/exceeds/limit
+                                                        ~/…/that/exceeds/limit

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_long_model_and_cwd_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_long_model_and_cwd_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 153
 expression: "render_ctx(&ctx, 80)"
 ---
-  claude-sonnet-4.6-super… · Ask · ~/…/that/exceeds/limit
+  claude-sonnet-4.6-super…                              ~/…/that/exceeds/limit

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_narrow_drops_40.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_narrow_drops_40.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 121
 expression: "render_ctx(&ctx, 40)"
 ---
-  sonnet-4.6 · Ask · Ctx 20% · …/200k
+  sonnet-4.6          ~/projects/astra

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_pending_and_auto_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_pending_and_auto_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 134
 expression: "render_ctx(&ctx, 80)"
 ---
-  sonnet-4.6 · Auto · ⏸ 1 pending · ~/projects/astra
+  sonnet-4.6  Auto  ⏸ 1 pending                               ~/projects/astra

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_pending_approvals_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_pending_approvals_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 124
 expression: "render_ctx(&ctx, 80)"
 ---
-  sonnet-4.6 · Ask · ⏸ 3 pending · ~/projects/astra
+  sonnet-4.6  ⏸ 3 pending                                     ~/projects/astra

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_task_chip_all_done_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_task_chip_all_done_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 186
 expression: "render_ctx(&ctx, 80)"
 ---
-  sonnet-4.6 · Ask · ▶ 4 done · ~/projects/astra
+  sonnet-4.6  ▶ 4 done                                        ~/projects/astra

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_task_chip_collapsed_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_task_chip_collapsed_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 163
 expression: "render_ctx(&ctx, 80)"
 ---
-  sonnet-4.6 · Ask · ▶ 2/5 · ~/projects/astra
+  sonnet-4.6  ▶ 2/5                                           ~/projects/astra

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_task_chip_empty_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_task_chip_empty_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 196
 expression: "render_ctx(&ctx, 80)"
 ---
-  sonnet-4.6 · Ask · ~/projects/astra
+  sonnet-4.6                                                  ~/projects/astra

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_task_chip_expanded_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_task_chip_expanded_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 176
 expression: "render_ctx(&ctx, 80)"
 ---
-  sonnet-4.6 · Ask · ▼ 2/5 · ~/projects/astra
+  sonnet-4.6  ▼ 2/5                                           ~/projects/astra

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_turn_active_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_turn_active_80.snap
@@ -1,6 +1,0 @@
----
-source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 48
-expression: "render_ctx(&ctx, 80)"
----
-  sonnet-4.6 · Ask · ~/projects/astra

--- a/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_with_git_branch_80.snap
+++ b/crates/astra-cli/src/tui/status_line/snapshots/astra__tui__status_line__snapshot_tests__status_with_git_branch_80.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astra-cli/src/tui/status_line/snapshot_tests.rs
-assertion_line: 88
 expression: "render_ctx(&ctx, 80)"
 ---
-  sonnet-4.6 · Ask · ~/projects/astra · ⎇ enhance_tui
+  sonnet-4.6                                   ~/projects/astra  ⎇ enhance_tui

--- a/crates/astra-cli/src/tui/status_line/tests.rs
+++ b/crates/astra-cli/src/tui/status_line/tests.rs
@@ -2,8 +2,6 @@
 
 #![cfg(test)]
 
-use std::time::Duration;
-
 use super::{BackgroundTaskCounts, StatusContext, StatusLine};
 use crate::tui::status_line::line::PermissionMode;
 use crate::tui::theme::current as current_theme;
@@ -15,12 +13,12 @@ fn ctx() -> StatusContext {
 // ─── Left-side state ──────────────────────────────────────────────
 
 #[test]
-fn idle_shows_mode_chip_without_tutorial_legend() {
+fn idle_hides_default_mode_and_tutorial_legend() {
     let s = StatusLine::from_context(&ctx());
     let plain = s.plain();
     assert!(
-        plain.contains("Ask"),
-        "default prompt mode should be visible; got {plain:?}"
+        !plain.contains("Ask"),
+        "the safe default should not consume permanent footer space; got {plain:?}"
     );
     assert!(
         !plain.contains("/commands"),
@@ -33,57 +31,6 @@ fn idle_shows_mode_chip_without_tutorial_legend() {
     assert!(
         !plain.contains("$shell"),
         "footer should not duplicate shell legend; got {plain:?}"
-    );
-}
-
-#[test]
-fn active_turn_without_objective_renders_no_interrupt_prompt() {
-    let c = StatusContext {
-        turn_active: true,
-        ..ctx()
-    };
-    let plain = StatusLine::from_context(&c).plain();
-    assert_eq!(
-        plain.matches("Ctrl+C interrupt").count(),
-        0,
-        "interrupt hint must not render in status line; got {plain:?}"
-    );
-}
-
-#[test]
-fn active_turn_keeps_footer_calm_even_with_objective_and_elapsed() {
-    let c = StatusContext {
-        turn_active: true,
-        current_objective: Some("Running bash".into()),
-        turn_elapsed: Some(Duration::from_secs(16)),
-        model: Some("sonnet-4.6".into()),
-        ..ctx()
-    };
-    let plain = StatusLine::from_context(&c).plain();
-    assert!(
-        !plain.contains("Running bash") && !plain.contains("16s"),
-        "footer should not duplicate live objective/elapsed; got {plain:?}"
-    );
-    assert!(
-        !plain.contains("Ctrl+C interrupt"),
-        "interrupt hint should NOT appear in status line; got {plain:?}"
-    );
-    assert!(
-        plain.contains("sonnet-4.6"),
-        "model should remain visible after footer de-noising; got {plain:?}"
-    );
-}
-
-#[test]
-fn idle_turn_does_not_render_elapsed_chip() {
-    let c = StatusContext {
-        turn_elapsed: Some(Duration::from_secs(16)),
-        ..ctx()
-    };
-    let plain = StatusLine::from_context(&c).plain();
-    assert!(
-        !plain.contains("16s"),
-        "elapsed chip must stay hidden when turn is idle; got {plain:?}"
     );
 }
 
@@ -113,7 +60,7 @@ fn very_narrow_width_degrades_idle_hint_to_tiny_form() {
     );
     assert!(
         rendered.contains("sonnet-4.6"),
-        "model should remain visible with the default mode chip; got {rendered:?}"
+        "model should remain visible in narrow layouts; got {rendered:?}"
     );
 }
 
@@ -144,7 +91,7 @@ fn model_stays_first_when_auto_mode_is_visible() {
     };
     let plain = StatusLine::from_context(&c).plain();
     assert!(
-        plain.starts_with("sonnet-4.6 · Auto"),
+        plain.starts_with("sonnet-4.6  Auto"),
         "model should anchor the left cluster before mode chips; got {plain:?}"
     );
 }
@@ -158,7 +105,7 @@ fn thinking_suffix_is_compacted_before_model_identity_is_lost() {
     };
     let plain = StatusLine::from_context(&c).plain();
     assert!(
-        plain.starts_with("deepseek-reasoner(high) · Auto"),
+        plain.starts_with("deepseek-reasoner(high)  Auto"),
         "thinking suffix should compact cleanly without ugly middle truncation; got {plain:?}"
     );
 }
@@ -166,20 +113,25 @@ fn thinking_suffix_is_compacted_before_model_identity_is_lost() {
 // ─── Permission mode chip ─────────────────────────────────────────
 
 #[test]
-fn ask_mode_renders_default_chip() {
+fn ask_mode_is_the_unlabelled_safe_default() {
     let s = StatusLine::from_context(&ctx());
-    assert!(s.plain().contains("Ask"));
+    assert!(!s.plain().contains("Ask"));
+    assert!(s.left.is_empty());
+}
+
+#[test]
+fn bypass_mode_uses_the_semantic_error_colour() {
+    let c = StatusContext {
+        permission_mode: PermissionMode::Bypass,
+        ..ctx()
+    };
+    let s = StatusLine::from_context(&c);
     let chip = s
         .left
         .iter()
-        .find(|seg| seg.text == "Ask")
-        .expect("ask chip segment");
-    assert_eq!(chip.style.fg, Some(current_theme().dim));
-    assert!(
-        chip.style
-            .add_modifier
-            .contains(ratatui::style::Modifier::BOLD)
-    );
+        .find(|seg| seg.text == "Bypass")
+        .expect("bypass chip");
+    assert_eq!(chip.style.fg, Some(current_theme().error));
 }
 
 #[test]
@@ -264,7 +216,7 @@ fn deny_mode_uses_the_semantic_error_colour() {
     );
 }
 
-// ─── Right-side segments: model · dir · tokens · cost · branch ────
+// ─── Stable identity and responsive layout ────────────────────────
 
 #[test]
 fn model_shows_on_right_when_set() {
@@ -332,16 +284,13 @@ fn narrow_footer_drops_mode_before_model_identity() {
 }
 
 #[test]
-fn dense_footer_preserves_mode_before_budget_and_branch() {
+fn dense_footer_preserves_model_and_mode_before_branch() {
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
 
     let c = StatusContext {
         model: Some("deepseek-v4-pro-official(thinking:high)".into()),
         cwd: Some("~/github/astra".into()),
-        context_window: Some(astra_turn_types::ContextWindowUsage::provider_reported(
-            138_000, 200_000,
-        )),
         git_branch: Some("enqueue_new_after_next_call".into()),
         permission_mode: PermissionMode::Auto,
         ..ctx()
@@ -356,151 +305,12 @@ fn dense_footer_preserves_mode_before_budget_and_branch() {
 
     assert!(
         rendered.contains("Auto"),
-        "permission mode is higher priority than budget/branch; got {rendered:?}"
+        "permission mode is higher priority than branch decoration; got {rendered:?}"
     );
     assert!(
         rendered.contains("deepseek"),
         "model identity should remain visible; got {rendered:?}"
     );
-}
-
-#[test]
-fn token_budget_renders_as_percent_and_absolute() {
-    let c = StatusContext {
-        turn_active: true,
-        context_window: Some(astra_turn_types::ContextWindowUsage::provider_reported(
-            25_000, 100_000,
-        )),
-        ..ctx()
-    };
-    let plain = StatusLine::from_context(&c).plain();
-    assert!(plain.contains("25%"), "percent expected; got {plain:?}");
-    // Absolute count reference for quick math.
-    assert!(
-        plain.contains("25k") || plain.contains("25000") || plain.contains("25,000"),
-        "absolute used count expected; got {plain:?}"
-    );
-    // The "... left" chip was removed — it duplicated the percentage
-    // and wasted status-line width during active turns.
-    assert!(
-        !plain.contains("left"),
-        "unexpected 'left' chip; got {plain:?}"
-    );
-}
-
-#[test]
-fn previous_request_context_is_visible_and_explicitly_scoped() {
-    let c = StatusContext {
-        context_window: Some(astra_turn_types::ContextWindowUsage::provider_reported(
-            25_000, 100_000,
-        )),
-        context_window_is_previous: true,
-        turn_active: true,
-        ..ctx()
-    };
-
-    let plain = StatusLine::from_context(&c).plain();
-    assert!(plain.contains("Ctx last 25%"), "{plain:?}");
-}
-
-#[test]
-fn idle_turn_hides_remaining_budget_suffix() {
-    let c = StatusContext {
-        context_window: Some(astra_turn_types::ContextWindowUsage::provider_reported(
-            25_000, 100_000,
-        )),
-        ..ctx()
-    };
-    let plain = StatusLine::from_context(&c).plain();
-    assert!(
-        plain.contains("25%"),
-        "usage summary should remain visible; got {plain:?}"
-    );
-    assert!(
-        !plain.contains("left"),
-        "remaining budget suffix should be active-turn only; got {plain:?}"
-    );
-}
-
-#[test]
-fn high_token_usage_uses_warning_color() {
-    let c = StatusContext {
-        context_window: Some(astra_turn_types::ContextWindowUsage::provider_reported(
-            90_000, 100_000,
-        )),
-        ..ctx()
-    };
-    let s = StatusLine::from_context(&c);
-    let budget_seg = s
-        .right
-        .iter()
-        .find(|seg| seg.text.contains('%'))
-        .expect("budget segment");
-    assert!(
-        matches!(budget_seg.style.fg, Some(color) if color == current_theme().warn || color == current_theme().error),
-        "high-usage budget should highlight; style={:?}",
-        budget_seg.style.fg
-    );
-}
-
-#[test]
-fn narrow_footer_keeps_context_and_drops_cwd_first() {
-    use ratatui::buffer::Buffer;
-    use ratatui::layout::Rect;
-
-    let c = StatusContext {
-        model: Some("astra-model".into()),
-        cwd: Some("~/very/long/project/path".into()),
-        context_window: Some(astra_turn_types::ContextWindowUsage::provider_reported(
-            25_000, 100_000,
-        )),
-        ..ctx()
-    };
-    let status = StatusLine::from_context(&c);
-    let area = Rect::new(0, 0, 44, 1);
-    let mut buf = Buffer::empty(area);
-    status.render(area, &mut buf);
-    let rendered: String = (0..area.width)
-        .map(|x| buf[(x, 0)].symbol().to_string())
-        .collect();
-    assert!(rendered.contains("Ctx 25%"), "{rendered:?}");
-    assert!(!rendered.contains("very/long"), "{rendered:?}");
-}
-
-#[test]
-fn medium_footer_does_not_keep_cwd_at_contexts_expense() {
-    use ratatui::buffer::Buffer;
-    use ratatui::layout::Rect;
-
-    let c = StatusContext {
-        model: Some("astra-model".into()),
-        cwd: Some("~/very/long/project/path".into()),
-        context_window: Some(astra_turn_types::ContextWindowUsage::provider_reported(
-            25_000, 100_000,
-        )),
-        git_branch: Some("feature/long-lived-context-work".into()),
-        ..ctx()
-    };
-    let status = StatusLine::from_context(&c);
-    let area = Rect::new(0, 0, 55, 1);
-    let mut buf = Buffer::empty(area);
-    status.render(area, &mut buf);
-    let rendered: String = (0..area.width)
-        .map(|x| buf[(x, 0)].symbol().to_string())
-        .collect();
-
-    assert!(rendered.contains("Ctx 25%"), "{rendered:?}");
-    assert!(!rendered.contains("project/path"), "{rendered:?}");
-}
-
-#[test]
-fn cost_formats_with_two_decimals_and_dollar_sign() {
-    let c = StatusContext {
-        cost_usd: Some(1.2345),
-        ..ctx()
-    };
-    let plain = StatusLine::from_context(&c).plain();
-    assert!(plain.contains("$1.23"), "cost formatting; got {plain:?}");
 }
 
 #[test]
@@ -514,7 +324,7 @@ fn git_branch_renders_on_right() {
 }
 
 #[test]
-fn right_segments_joined_with_middle_dot() {
+fn status_segments_use_whitespace_instead_of_punctuation_chrome() {
     let c = StatusContext {
         model: Some("M".into()),
         cwd: Some("D".into()),
@@ -528,22 +338,22 @@ fn right_segments_joined_with_middle_dot() {
     );
     let plain = s.plain();
     assert!(
-        plain.contains(" · "),
-        "status segments should be joined with ' · '; got {plain:?}"
+        !plain.contains(" · ") && plain.contains("  "),
+        "colour and whitespace should group status segments; got {plain:?}"
     );
 }
 
 // ─── Composition hygiene ──────────────────────────────────────────
 
 #[test]
-fn empty_context_produces_some_left_content() {
+fn empty_context_produces_no_permanent_chrome() {
     let s = StatusLine::from_context(&ctx());
     assert_eq!(
         s.left
             .iter()
             .map(|seg| seg.text.as_str())
             .collect::<Vec<_>>(),
-        vec!["Ask"]
+        Vec::<&str>::new()
     );
 }
 

--- a/crates/astra-cli/src/tui/style.rs
+++ b/crates/astra-cli/src/tui/style.rs
@@ -36,9 +36,8 @@ pub(crate) fn queue_panel_style() -> Style {
 }
 
 pub(crate) fn footer_surface_style() -> Style {
-    if let Some(bg) = default_bg() {
-        return Style::default().bg(footer_surface_bg(bg));
-    }
+    // The footer is chrome, not a card. Its semantic colours and alignment
+    // provide hierarchy without drawing another horizontal band.
     Style::default()
 }
 
@@ -101,15 +100,6 @@ fn queue_panel_rgb(terminal_bg: (u8, u8, u8)) -> (u8, u8, u8) {
         ((84, 111, 145), 0.10)
     };
     blend(top, terminal_bg, alpha)
-}
-
-fn footer_surface_bg(terminal_bg: (u8, u8, u8)) -> Color {
-    let (top, alpha) = if is_light(terminal_bg) {
-        ((0, 0, 0), 0.015)
-    } else {
-        ((255, 255, 255), 0.04)
-    };
-    best_color(blend(top, terminal_bg, alpha))
 }
 
 fn proposed_plan_bg(terminal_bg: (u8, u8, u8)) -> Color {

--- a/crates/astra-cli/src/tui/task_status.rs
+++ b/crates/astra-cli/src/tui/task_status.rs
@@ -5,9 +5,19 @@ pub(crate) enum TaskStatus {
     Idle,
     Dispatching,
     Cancelling,
-    TurnRunning { started_at: Instant },
-    ToolExecuting { name: String, started_at: Instant },
-    WaitingApproval { tool: String },
+    /// The workbench accepted an exit request and is converging durable
+    /// session state before restoring the terminal.
+    Exiting,
+    TurnRunning {
+        started_at: Instant,
+    },
+    ToolExecuting {
+        name: String,
+        started_at: Instant,
+    },
+    WaitingApproval {
+        tool: String,
+    },
     WaitingModel,
 }
 
@@ -29,6 +39,7 @@ impl TaskStatus {
             TaskStatus::Idle => "",
             TaskStatus::Dispatching => "Sending",
             TaskStatus::Cancelling => "Stopping",
+            TaskStatus::Exiting => "Stopping",
             TaskStatus::TurnRunning { .. } => "Thinking",
             TaskStatus::ToolExecuting { .. } => "Running tool",
             TaskStatus::WaitingApproval { .. } => "Awaiting approval",
@@ -41,6 +52,7 @@ impl TaskStatus {
             TaskStatus::Idle => None,
             TaskStatus::Dispatching => Some("Sending".to_string()),
             TaskStatus::Cancelling => Some("Stopping".to_string()),
+            TaskStatus::Exiting => Some("Stopping".to_string()),
             TaskStatus::TurnRunning { .. } => Some("Thinking".to_string()),
             TaskStatus::ToolExecuting { name, .. } => Some(format!("Running {name}")),
             TaskStatus::WaitingApproval { tool } => {
@@ -87,6 +99,14 @@ mod tests {
     #[test]
     fn cancelling_replaces_the_running_objective() {
         let status = TaskStatus::Cancelling;
+        assert!(status.is_active());
+        assert_eq!(status.display_label(), "Stopping");
+        assert_eq!(status.objective_label().as_deref(), Some("Stopping"));
+    }
+
+    #[test]
+    fn exiting_is_an_active_stopping_boundary() {
+        let status = TaskStatus::Exiting;
         assert!(status.is_active());
         assert_eq!(status.display_label(), "Stopping");
         assert_eq!(status.objective_label().as_deref(), Some("Stopping"));

--- a/crates/astra-cli/src/tui/theme.rs
+++ b/crates/astra-cli/src/tui/theme.rs
@@ -124,12 +124,9 @@ impl Theme {
             // rows legible without turning the TUI into a stack of cards.
             selected_bg: Color::Rgb(31, 42, 55),
             selected_fg: Color::Rgb(231, 238, 248),
-            // Active work uses a vivid emerald gutter: it is a compact,
-            // high-salience execution marker rather than another panel.
-            // Settled output switches to a cool slate, not a dimmer green:
-            // colour must communicate terminal state at a glance, even in a
-            // peripheral transcript scan.
-            gutter: Color::Rgb(43, 220, 142),
+            // Live work gets a high-chroma violet signal distinct from both
+            // blue interactive focus and green completed output.
+            gutter: Color::Rgb(205, 132, 255),
             gutter_frozen: Color::Rgb(91, 115, 136),
             success: Color::Rgb(54, 226, 157),
             warn: Color::Rgb(244, 192, 102),
@@ -173,7 +170,7 @@ impl Theme {
             accent: Color::Rgb(39, 98, 149),
             selected_bg: Color::Rgb(226, 235, 243),
             selected_fg: Color::Rgb(23, 34, 45),
-            gutter: Color::Rgb(48, 117, 153),
+            gutter: Color::Rgb(126, 55, 190),
             gutter_frozen: Color::Rgb(89, 119, 139),
             success: Color::Rgb(33, 120, 101),
             warn: Color::Rgb(139, 100, 38),
@@ -206,15 +203,14 @@ impl Theme {
     /// an indexed colour the terminal can actually display.
     pub fn dark_256() -> Self {
         let mut theme = Self::quantize_256(Self::dark());
-        // The xterm cube has no genuinely low-saturation dark red/green
-        // surfaces: indices 22/52 turn a wide diff into solid green/red bars.
-        // Keep the *row* grouping on a quiet graphite surface and carry
-        // direction with the foreground plus the explicit +/- marker. This is
-        // an intentional capability fallback, not a second visual language.
+        // Preserve the product-level add/delete surfaces when truecolour is
+        // unavailable. 22/52 are the darkest useful green/red cells in the
+        // xterm cube; using one neutral graphite for both directions made a
+        // common xterm-256 session look as if diff backgrounds were missing.
         theme.diff_add_fg = Color::Indexed(115);
-        theme.diff_add_bg = Color::Indexed(234);
+        theme.diff_add_bg = Color::Indexed(22);
         theme.diff_del_fg = Color::Indexed(217);
-        theme.diff_del_bg = Color::Indexed(234);
+        theme.diff_del_bg = Color::Indexed(52);
         theme
     }
 
@@ -265,7 +261,7 @@ impl Theme {
         theme.accent = Color::LightBlue;
         theme.selected_bg = Color::DarkGray;
         theme.selected_fg = Color::White;
-        theme.gutter = Color::LightGreen;
+        theme.gutter = Color::LightMagenta;
         theme.gutter_frozen = Color::DarkGray;
         theme.success = Color::LightGreen;
         theme.warn = Color::Yellow;
@@ -280,14 +276,12 @@ impl Theme {
         theme.md_link = Color::Cyan;
         theme.md_blockquote = Color::LightGreen;
         theme.md_list_marker = Color::LightBlue;
-        // A genuine 16-colour palette cannot express a restrained tinted
-        // surface. Painting a complete row with `Green`/`Red` is much more
-        // disruptive than losing the tint, so degrade to a neutral surface
-        // while retaining direction in foreground and the +/- marker.
-        theme.diff_add_fg = Color::LightGreen;
-        theme.diff_add_bg = Color::Black;
-        theme.diff_del_fg = Color::LightRed;
-        theme.diff_del_bg = Color::Black;
+        // Even the smallest palette keeps add/delete as distinct surfaces;
+        // terminal-defined ANSI colours preserve user palette preferences.
+        theme.diff_add_fg = Color::Black;
+        theme.diff_add_bg = Color::Green;
+        theme.diff_del_fg = Color::White;
+        theme.diff_del_bg = Color::Red;
         theme.diff_hunk = Color::Cyan;
         theme.diff_context = Color::DarkGray;
         theme.stall_warn = Color::Yellow;
@@ -302,7 +296,7 @@ impl Theme {
         theme.accent = Color::Blue;
         theme.selected_bg = Color::Gray;
         theme.selected_fg = Color::Black;
-        theme.gutter = Color::LightGreen;
+        theme.gutter = Color::Magenta;
         theme.gutter_frozen = Color::DarkGray;
         theme.success = Color::LightGreen;
         theme.warn = Color::Yellow;
@@ -317,12 +311,12 @@ impl Theme {
         theme.md_link = Color::Blue;
         theme.md_blockquote = Color::LightGreen;
         theme.md_list_marker = Color::Blue;
-        // See `dark_ansi`: on a light 16-colour terminal the default-like
-        // neutral surface is white, with direction carried by readable text.
-        theme.diff_add_fg = Color::Green;
-        theme.diff_add_bg = Color::White;
-        theme.diff_del_fg = Color::Red;
-        theme.diff_del_bg = Color::White;
+        // See `dark_ansi`: direction remains a row-level surface rather than
+        // collapsing into coloured punctuation on limited terminals.
+        theme.diff_add_fg = Color::Black;
+        theme.diff_add_bg = Color::LightGreen;
+        theme.diff_del_fg = Color::Black;
+        theme.diff_del_bg = Color::LightRed;
         theme.diff_hunk = Color::Blue;
         theme.diff_context = Color::DarkGray;
         theme.stall_warn = Color::Yellow;
@@ -572,10 +566,10 @@ mod tests {
     }
 
     #[test]
-    fn indexed_theme_uses_quiet_edit_surfaces() {
+    fn indexed_theme_preserves_distinct_add_and_delete_surfaces() {
         let dark = Theme::dark_256();
-        assert_eq!(dark.diff_add_bg, Color::Indexed(234), "{dark:?}");
-        assert_eq!(dark.diff_del_bg, Color::Indexed(234), "{dark:?}");
+        assert_eq!(dark.diff_add_bg, Color::Indexed(22), "{dark:?}");
+        assert_eq!(dark.diff_del_bg, Color::Indexed(52), "{dark:?}");
         assert_ne!(dark.diff_add_fg, dark.diff_del_fg, "{dark:?}");
 
         for theme in [dark, Theme::light_256()] {
@@ -583,6 +577,7 @@ mod tests {
             assert!(matches!(theme.diff_del_bg, Color::Indexed(_)), "{theme:?}");
             assert_ne!(theme.diff_add_bg, Color::Reset, "{theme:?}");
             assert_ne!(theme.diff_del_bg, Color::Reset, "{theme:?}");
+            assert_ne!(theme.diff_add_bg, theme.diff_del_bg, "{theme:?}");
         }
     }
 
@@ -616,10 +611,11 @@ mod tests {
     }
 
     #[test]
-    fn dark_palette_uses_emerald_activity_and_reserves_red_for_failure() {
+    fn dark_palette_separates_live_activity_focus_success_and_failure() {
         let theme = Theme::dark();
         let (ar, ag, ab) = color_to_rgb(theme.accent);
         let (gr, gg, gb) = color_to_rgb(theme.gutter);
+        let (sr, sg, sb) = color_to_rgb(theme.success);
         let (er, eg, eb) = color_to_rgb(theme.error);
 
         assert!(
@@ -627,9 +623,15 @@ mod tests {
             "accent should read as a cool focus color: {theme:?}"
         );
         assert!(
-            gg > gr && gg > gb,
-            "live activity should use the high-salience emerald gutter: {theme:?}"
+            gr > gg && gb > gg,
+            "live activity should be a high-chroma violet signal: {theme:?}"
         );
+        assert_ne!(theme.gutter, theme.accent);
+        assert!(
+            sg > sr && sg > sb,
+            "completed success markers should remain emerald: {theme:?}"
+        );
+        assert_ne!(theme.gutter, theme.success);
         assert!(
             er > eg && er > eb,
             "only the error role should carry a warm failure hue: {theme:?}"
@@ -639,7 +641,7 @@ mod tests {
     }
 
     #[test]
-    fn diff_rows_stay_restrained_at_every_terminal_color_level() {
+    fn diff_rows_keep_readable_semantic_surfaces_at_every_color_level() {
         let dark = Theme::dark();
         let (_, add_g, _) = color_to_rgb(dark.diff_add_bg);
         let (del_r, _, _) = color_to_rgb(dark.diff_del_bg);
@@ -653,16 +655,16 @@ mod tests {
         );
 
         let dark_ansi = Theme::dark_ansi();
-        assert_eq!(dark_ansi.diff_add_bg, Color::Black);
-        assert_eq!(dark_ansi.diff_del_bg, Color::Black);
-        assert_eq!(dark_ansi.diff_add_fg, Color::LightGreen);
-        assert_eq!(dark_ansi.diff_del_fg, Color::LightRed);
+        assert_eq!(dark_ansi.diff_add_bg, Color::Green);
+        assert_eq!(dark_ansi.diff_del_bg, Color::Red);
+        assert_eq!(dark_ansi.diff_add_fg, Color::Black);
+        assert_eq!(dark_ansi.diff_del_fg, Color::White);
 
         let light_ansi = Theme::light_ansi();
-        assert_eq!(light_ansi.diff_add_bg, Color::White);
-        assert_eq!(light_ansi.diff_del_bg, Color::White);
-        assert_eq!(light_ansi.diff_add_fg, Color::Green);
-        assert_eq!(light_ansi.diff_del_fg, Color::Red);
+        assert_eq!(light_ansi.diff_add_bg, Color::LightGreen);
+        assert_eq!(light_ansi.diff_del_bg, Color::LightRed);
+        assert_eq!(light_ansi.diff_add_fg, Color::Black);
+        assert_eq!(light_ansi.diff_del_fg, Color::Black);
     }
 
     #[test]

--- a/crates/astra-cli/tests/tui_pty_journey.rs
+++ b/crates/astra-cli/tests/tui_pty_journey.rs
@@ -291,6 +291,7 @@ impl PtyAstra {
         let deadline = Instant::now() + timeout;
         loop {
             if let Some(status) = self.child.try_wait().expect("poll Astra child") {
+                self.drain_output_after_exit();
                 return status;
             }
             assert!(
@@ -299,6 +300,22 @@ impl PtyAstra {
                 self.output_tail()
             );
             self.receive(Duration::from_millis(50));
+        }
+    }
+
+    fn drain_output_after_exit(&mut self) {
+        // Once the child has exited, PTY EOF is authoritative. Join the sole
+        // reader first, then consume every chunk it published; a wall-clock
+        // grace period can lose the final post-terminal resume line on a busy
+        // test host.
+        if let Some(reader) = self.reader.take() {
+            reader
+                .join()
+                .expect("join PTY output reader after child exit");
+        }
+        while let Ok(chunk) = self.output_rx.try_recv() {
+            self.screen.process(&chunk);
+            self.output.extend_from_slice(&chunk);
         }
     }
 
@@ -723,6 +740,31 @@ async fn ctrl_o_round_trip_preserves_composer_draft_in_a_real_pty() {
     astra.write(b"/exit\r");
     let status = astra.wait_for_exit(Duration::from_secs(10));
     assert!(status.success(), "Astra exit status: {status}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exit_after_a_completed_turn_prints_a_copyable_resume_command() {
+    let _journey = pty_journey_lock().lock().await;
+    let mock = astra_cli::cli::mock_llm::MockLlmServer::start(
+        astra_cli::cli::mock_llm::MockScenario::Slow,
+    )
+    .await
+    .expect("start scripted LLM server");
+    let home = tempfile::tempdir().expect("temporary isolated Astra home");
+    seed_trusted_workspace(home.path());
+    let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
+
+    astra.wait_for("Message", Duration::from_secs(15));
+    astra.write(b"create_a_resumable_session\r");
+    astra.wait_for("successfully.", Duration::from_secs(10));
+    astra.write(b"/exit\r");
+
+    let status = astra.wait_for_exit(Duration::from_secs(10));
+    assert!(status.success(), "Astra exit status: {status}");
+    let output = astra.output_tail();
+    assert!(output.contains("Stopping"), "{output}");
+    assert!(output.contains("Resume this session with:"), "{output}");
+    assert!(output.contains("astra --resume mock-session"), "{output}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/astra-cli/tests/tui_pty_journey.rs
+++ b/crates/astra-cli/tests/tui_pty_journey.rs
@@ -415,7 +415,7 @@ async fn sighup_while_idle_converges_through_tui_shutdown() {
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), "http://127.0.0.1:9");
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.signal(nix::sys::signal::Signal::SIGHUP);
 
     let status = astra.wait_for_exit(Duration::from_secs(10));
@@ -437,7 +437,7 @@ async fn sighup_during_an_active_turn_converges_through_tui_shutdown() {
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.write(b"keep_this_turn_active_until_shutdown\r");
     astra.wait_for("Sending", UI_TRANSITION_TIMEOUT);
 
@@ -459,7 +459,7 @@ async fn ctrl_c_projects_stopping_until_a_slow_turn_settles() {
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.write(b"hold this turn open\r");
 
     // Synchronize on the request reaching the provider. A transient activity
@@ -484,7 +484,7 @@ async fn ctrl_c_projects_stopping_until_a_slow_turn_settles() {
         astra.screen_diagnostic()
     );
     mock.release_held_response();
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
 }
 
 fn is_agent_journey_child_request(request: &serde_json::Value) -> bool {
@@ -704,7 +704,7 @@ async fn ctrl_o_round_trip_preserves_composer_draft_in_a_real_pty() {
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), "http://127.0.0.1:9");
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
 
     // A single token stays contiguous in the terminal byte stream even when
     // ratatui positions separately styled words with cursor movement codes.
@@ -737,7 +737,7 @@ async fn ctrl_o_opens_during_an_active_turn_and_receives_live_completion() {
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.write(b"complete_this_live_transcript_journey\r");
     astra.wait_for("Sending", UI_TRANSITION_TIMEOUT);
 
@@ -746,7 +746,7 @@ async fn ctrl_o_opens_during_an_active_turn_and_receives_live_completion() {
     astra.wait_for("successfully.", Duration::from_secs(10));
 
     astra.write(&[0x0f]);
-    astra.wait_for("Enter send", Duration::from_secs(10));
+    astra.wait_for("Message Astra", Duration::from_secs(10));
     astra.write(b"/exit\r");
     let status = astra.wait_for_exit(Duration::from_secs(10));
     assert!(status.success(), "Astra exit status: {status}");
@@ -764,7 +764,7 @@ async fn ctrl_o_replays_tool_history_after_a_real_tool_turn() {
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.write(b"/allow prompt\r");
     astra.wait_for("Mode → Ask", UI_TRANSITION_TIMEOUT);
     astra.write(b"exercise_tool_history_in_transcript\r");
@@ -779,7 +779,7 @@ async fn ctrl_o_replays_tool_history_after_a_real_tool_turn() {
     astra.wait_for("Ran Write file", UI_TRANSITION_TIMEOUT);
 
     astra.write(&[0x0f]);
-    astra.wait_for("Enter send", UI_TRANSITION_TIMEOUT);
+    astra.wait_for("Message Astra", UI_TRANSITION_TIMEOUT);
     astra.write(b"/exit\r");
     let status = astra.wait_for_exit(Duration::from_secs(10));
     assert!(status.success(), "Astra exit status: {status}");
@@ -797,7 +797,7 @@ async fn ctrl_o_round_trip_preserves_a_live_tool_approval() {
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.write(b"/allow prompt\r");
     astra.wait_for("Mode → Ask", UI_TRANSITION_TIMEOUT);
     astra.write(b"request_a_write_and_wait_for_my_approval\r");
@@ -829,7 +829,7 @@ async fn ctrl_g_reopens_a_child_transcript_after_completion() {
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.write(b"delegate_one_child_and_keep_it_observable\r");
     wait_for_agent_journey_child_request(&mock, &mut astra, UI_TRANSITION_TIMEOUT).await;
 
@@ -890,7 +890,7 @@ async fn foreground_fanout_stays_observable_and_synthesizes_once_after_full_sett
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.write(b"launch_three_reviews_as_one_group\r");
     wait_for_three_fanout_children(&mock, &mut astra).await;
     astra.wait_for("↳ Work · Three mock reviews", UI_TRANSITION_TIMEOUT);
@@ -1023,7 +1023,7 @@ async fn foreground_status_guidance_uses_canonical_group_truth_and_never_claims_
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.write(b"launch_then_ask_foreground_status\r");
     wait_for_three_fanout_children(&mock, &mut astra).await;
     astra.wait_for("parent waits for the complete group", UI_TRANSITION_TIMEOUT);
@@ -1144,7 +1144,7 @@ async fn failed_fanout_slot_preserves_its_cause_and_still_synthesizes_once() {
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.write(b"launch_three_reviews_with_one_unhappy_child\r");
     wait_for_three_fanout_children(&mock, &mut astra).await;
     astra.wait_for("↳ Work · Three mock reviews", UI_TRANSITION_TIMEOUT);
@@ -1227,7 +1227,7 @@ async fn ctrl_b_promotes_the_whole_fanout_and_wakes_once_after_settlement() {
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.write(b"launch_then_explicitly_background_the_group\r");
     wait_for_three_fanout_children(&mock, &mut astra).await;
     astra.wait_for("↳ Work · Three mock reviews", UI_TRANSITION_TIMEOUT);
@@ -1304,7 +1304,7 @@ async fn background_group_is_queryable_before_its_single_terminal_wake() {
     seed_trusted_workspace(home.path());
     let mut astra = PtyAstra::spawn(home.path(), &mock.base_url);
 
-    astra.wait_for("Enter send", Duration::from_secs(15));
+    astra.wait_for("Message Astra", Duration::from_secs(15));
     astra.write(b"launch_then_ask_about_background_state\r");
     wait_for_three_fanout_children(&mock, &mut astra).await;
     astra.wait_for("↳ Work · Three mock reviews", UI_TRANSITION_TIMEOUT);

--- a/crates/astra-turn-core/src/compression_types.rs
+++ b/crates/astra-turn-core/src/compression_types.rs
@@ -271,7 +271,13 @@ impl From<Message> for Value {
         // conversation metadata and are stripped only at the provider wire
         // boundary.
         for (k, v) in m.extra {
-            if !k.starts_with('_') || k == astra_turn_types::USER_TURN_SEMANTICS_FIELD {
+            if !k.starts_with('_')
+                || matches!(
+                    k.as_str(),
+                    astra_turn_types::USER_TURN_SEMANTICS_FIELD
+                        | astra_turn_types::BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD
+                )
+            {
                 map.insert(k, v);
             }
         }
@@ -610,7 +616,7 @@ mod tests {
     }
 
     #[test]
-    fn canonical_conversion_preserves_stable_semantics_but_strips_dynamic_extras() {
+    fn canonical_conversion_preserves_stable_identity_but_strips_dynamic_extras() {
         // Dynamic telemetry counters (`_messages_removed`, `_turns_removed`,
         // `_reactive`, `_compact_boundary`) live in `extra` but must NOT
         // cross the provider wire: they change across re-compactions and
@@ -626,6 +632,10 @@ mod tests {
             astra_turn_types::USER_TURN_SEMANTICS_FIELD: {
                 "schema_version": 1,
                 "objective_relation": "refine"
+            },
+            astra_turn_types::BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD: {
+                "schema_version": 1,
+                "turn_chain_id": "chain-1"
             },
             "custom_provider_field": {"ok": true}
         });
@@ -651,6 +661,11 @@ mod tests {
             back.get(astra_turn_types::USER_TURN_SEMANTICS_FIELD)
                 .is_some(),
             "stable turn semantics must survive canonical compaction"
+        );
+        assert!(
+            back.get(astra_turn_types::BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD)
+                .is_some(),
+            "bridge turn identity must survive context optimization"
         );
         // Non-`_`-prefixed extras still pass through.
         assert_eq!(back["custom_provider_field"], json!({"ok": true}));

--- a/crates/astra-turn-core/src/context/optimizer.rs
+++ b/crates/astra-turn-core/src/context/optimizer.rs
@@ -289,13 +289,30 @@ fn drop_oldest_rounds(messages: &mut Vec<Value>, pressure: f64) -> u32 {
         messages,
     );
     let mut units = Vec::<Vec<usize>>::new();
+    let mut active_bridge_turn: Option<&str> = None;
     for (idx, message) in messages.iter().enumerate() {
         let role = message.get("role").and_then(Value::as_str);
         if role == Some("system") {
             continue;
         }
-        if role == Some("user") || units.is_empty() {
+        let bridge_turn = message
+            .get(astra_turn_types::BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD)
+            .and_then(Value::as_object)
+            .filter(|provenance| {
+                provenance.get("schema_version").and_then(Value::as_u64)
+                    == Some(u64::from(
+                        astra_turn_types::BRIDGE_TURN_MESSAGE_PROVENANCE_SCHEMA_VERSION,
+                    ))
+            })
+            .and_then(|provenance| provenance.get("turn_chain_id"))
+            .and_then(Value::as_str)
+            .filter(|turn_chain_id| !turn_chain_id.is_empty());
+        let starts_unit = units.is_empty()
+            || (role == Some("user")
+                && (bridge_turn.is_none() || bridge_turn != active_bridge_turn));
+        if starts_unit {
             units.push(Vec::new());
+            active_bridge_turn = bridge_turn;
         }
         if let Some(unit) = units.last_mut() {
             unit.push(idx);
@@ -1110,6 +1127,29 @@ mod tests {
             ],
             "a user request and every assistant/tool continuation it caused form one atomic unit"
         );
+    }
+
+    #[test]
+    fn round_dropping_keeps_guidance_in_the_same_active_bridge_turn_atomic() {
+        let mut messages = vec![
+            serde_json::json!({"role": "user", "content": "old request"}),
+            serde_json::json!({"role": "assistant", "content": "old answer"}),
+            serde_json::json!({"role": "user", "content": "current request"}),
+            serde_json::json!({"role": "assistant", "content": "current progress"}),
+            serde_json::json!({"role": "user", "content": "keep it readonly"}),
+            serde_json::json!({"role": "assistant", "content": "continued progress"}),
+        ];
+        for message in &mut messages[2..] {
+            assert!(astra_turn_types::mark_bridge_turn_message(
+                message,
+                "chain-current"
+            ));
+        }
+
+        assert!(drop_oldest_rounds(&mut messages, 1.0) > 0);
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0]["content"], "current request");
+        assert_eq!(messages[2]["content"], "keep it readonly");
     }
 
     #[test]

--- a/crates/astra-turn-core/src/prompt_facing.rs
+++ b/crates/astra-turn-core/src/prompt_facing.rs
@@ -172,9 +172,14 @@ pub fn sanitize_canonical_continuation_messages_with_turn_semantics(
     let messages = messages
         .into_iter()
         .skip(start)
-        .filter(|message| {
-            message.get("_compact_boundary").and_then(Value::as_bool) != Some(true)
-                && !is_runtime_owned_message(message)
+        .filter_map(|mut message| {
+            let keep = message.get("_compact_boundary").and_then(Value::as_bool) != Some(true)
+                && !is_runtime_owned_message(&message);
+            if !keep {
+                return None;
+            }
+            astra_turn_types::clear_bridge_turn_message_provenance(&mut message);
+            Some(message)
         })
         .collect::<Vec<_>>();
 

--- a/crates/astra-turn-types/src/bridge_turn.rs
+++ b/crates/astra-turn-types/src/bridge_turn.rs
@@ -1,0 +1,126 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use thiserror::Error;
+
+pub const BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD: &str = "_astra_bridge_turn";
+pub const BRIDGE_TURN_MESSAGE_PROVENANCE_SCHEMA_VERSION: u8 = 1;
+
+/// Producer-owned identity for a conversational message created by one
+/// active bridge turn. This is transport metadata: it survives context
+/// optimization so the bridge can locate the current-turn suffix, then is
+/// removed before provider delivery and canonical persistence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BridgeTurnMessageProvenanceV1 {
+    pub schema_version: u8,
+    pub turn_chain_id: String,
+}
+
+#[derive(Debug, Error)]
+pub enum BridgeTurnMessageProvenanceError {
+    #[error("bridge-turn provenance belongs to a non-conversational message (role={role:?})")]
+    InvalidOwner { role: Option<String> },
+    #[error("malformed bridge-turn provenance: {0}")]
+    Malformed(#[source] serde_json::Error),
+    #[error("unsupported bridge-turn provenance schema version {found}; expected {expected}")]
+    UnsupportedSchemaVersion { found: u8, expected: u8 },
+    #[error("bridge-turn provenance has an empty turn_chain_id")]
+    EmptyTurnChainId,
+}
+
+fn is_conversational_role(role: Option<&str>) -> bool {
+    matches!(role, Some("user" | "assistant" | "tool"))
+}
+
+/// Attach bridge-turn identity without deriving it from message text.
+/// Returns `false` for malformed/non-conversational messages or an empty id.
+pub fn mark_bridge_turn_message(message: &mut Value, turn_chain_id: &str) -> bool {
+    if turn_chain_id.is_empty()
+        || !is_conversational_role(message.get("role").and_then(Value::as_str))
+    {
+        return false;
+    }
+    let Some(object) = message.as_object_mut() else {
+        return false;
+    };
+    object.insert(
+        BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD.to_string(),
+        json!(BridgeTurnMessageProvenanceV1 {
+            schema_version: BRIDGE_TURN_MESSAGE_PROVENANCE_SCHEMA_VERSION,
+            turn_chain_id: turn_chain_id.to_string(),
+        }),
+    );
+    true
+}
+
+pub fn bridge_turn_message_provenance(
+    message: &Value,
+) -> Result<Option<BridgeTurnMessageProvenanceV1>, BridgeTurnMessageProvenanceError> {
+    let Some(raw) = message.get(BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD) else {
+        return Ok(None);
+    };
+    let role = message
+        .get("role")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    if !is_conversational_role(role.as_deref()) {
+        return Err(BridgeTurnMessageProvenanceError::InvalidOwner { role });
+    }
+    let provenance: BridgeTurnMessageProvenanceV1 =
+        serde_json::from_value(raw.clone()).map_err(BridgeTurnMessageProvenanceError::Malformed)?;
+    if provenance.schema_version != BRIDGE_TURN_MESSAGE_PROVENANCE_SCHEMA_VERSION {
+        return Err(BridgeTurnMessageProvenanceError::UnsupportedSchemaVersion {
+            found: provenance.schema_version,
+            expected: BRIDGE_TURN_MESSAGE_PROVENANCE_SCHEMA_VERSION,
+        });
+    }
+    if provenance.turn_chain_id.is_empty() {
+        return Err(BridgeTurnMessageProvenanceError::EmptyTurnChainId);
+    }
+    Ok(Some(provenance))
+}
+
+pub fn clear_bridge_turn_message_provenance(message: &mut Value) {
+    if let Some(object) = message.as_object_mut() {
+        object.remove(BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provenance_round_trips_only_on_conversational_messages() {
+        let mut user = json!({"role": "user", "content": "inspect"});
+        assert!(mark_bridge_turn_message(&mut user, "chain-1"));
+        assert_eq!(
+            bridge_turn_message_provenance(&user)
+                .unwrap()
+                .unwrap()
+                .turn_chain_id,
+            "chain-1"
+        );
+        clear_bridge_turn_message_provenance(&mut user);
+        assert_eq!(bridge_turn_message_provenance(&user).unwrap(), None);
+
+        let mut system = json!({"role": "system", "content": "runtime"});
+        assert!(!mark_bridge_turn_message(&mut system, "chain-1"));
+    }
+
+    #[test]
+    fn malformed_producer_metadata_fails_closed() {
+        let message = json!({
+            "role": "user",
+            "content": "inspect",
+            BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD: {
+                "schema_version": 1,
+                "turn_chain_id": ""
+            }
+        });
+        assert!(matches!(
+            bridge_turn_message_provenance(&message),
+            Err(BridgeTurnMessageProvenanceError::EmptyTurnChainId)
+        ));
+    }
+}

--- a/crates/astra-turn-types/src/lib.rs
+++ b/crates/astra-turn-types/src/lib.rs
@@ -6,6 +6,7 @@
 mod agent_communication;
 mod agent_transcript_evidence;
 mod agent_transcript_location;
+mod bridge_turn;
 mod canonical_tool_pairing;
 mod context_identity;
 mod context_window;
@@ -33,6 +34,11 @@ pub use agent_communication::{
 };
 pub use agent_transcript_evidence::AgentTranscriptEvidence;
 pub use agent_transcript_location::AgentTranscriptLocation;
+pub use bridge_turn::{
+    BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD, BRIDGE_TURN_MESSAGE_PROVENANCE_SCHEMA_VERSION,
+    BridgeTurnMessageProvenanceError, BridgeTurnMessageProvenanceV1,
+    bridge_turn_message_provenance, clear_bridge_turn_message_provenance, mark_bridge_turn_message,
+};
 pub use canonical_tool_pairing::{CanonicalToolPairingError, validate_canonical_tool_pairing};
 pub use context_identity::{
     ContextIdentityError, LLM_ARTIFACT_EVIDENCE_CONTRACT_VERSION,

--- a/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -1481,8 +1481,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
             consecutive_context_window_errors: &mut state.consecutive_context_window_errors,
         },
     );
-    let transcript_appended = state.messages[transcript_append_start..].to_vec();
-    state.record_prompt_history_messages(transcript_appended);
+    state.record_appended_prompt_history_from(transcript_append_start);
     if let Some(session_id) = state.current_session_id.as_deref() {
         host.on_session_bound(session_id);
         if let Some(buffer) = state.turn_event_buffer.as_mut()

--- a/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/crates/runtime/src/turn/agentic_loop/host.rs
@@ -2427,10 +2427,28 @@ impl AgenticLoopState {
 
     /// Append a genuine conversational item to prompt history and, when this
     /// is a locally durable child run, to its ordered transcript capture.
-    /// Runtime context must use the typed volatile lanes instead.
-    pub fn push_prompt_history_message(&mut self, message: Value) {
+    /// Runtime context must use the typed volatile lanes instead. Root bridge
+    /// turns stamp append-only identity here so history optimization cannot
+    /// erase the current-turn boundary.
+    pub fn push_prompt_history_message(&mut self, mut message: Value) {
+        if let Some(turn_chain_id) = self.bridge_turn_chain_id.as_deref() {
+            astra_turn_types::mark_bridge_turn_message(&mut message, turn_chain_id);
+        }
         self.messages.push(message.clone());
         self.record_prompt_history_messages(std::iter::once(message));
+    }
+
+    /// Stamp and capture a suffix appended by a lower-level routine that had
+    /// direct mutable access to `messages`.
+    pub fn record_appended_prompt_history_from(&mut self, start: usize) {
+        let start = start.min(self.messages.len());
+        if let Some(turn_chain_id) = self.bridge_turn_chain_id.as_deref() {
+            for message in &mut self.messages[start..] {
+                astra_turn_types::mark_bridge_turn_message(message, turn_chain_id);
+            }
+        }
+        let appended = self.messages[start..].to_vec();
+        self.record_prompt_history_messages(appended);
     }
 
     /// Record items appended by a lower-level routine that receives a mutable
@@ -3684,6 +3702,36 @@ pub(crate) mod tests {
             vec![task, repeated.clone(), repeated]
         );
         assert!(state.take_run_transcript_capture().is_empty());
+    }
+
+    #[test]
+    fn bridge_turn_identity_covers_all_append_paths_without_text_matching() {
+        let mut state = make_test_loop_state();
+        state.bridge_turn_chain_id = Some("chain-current".into());
+        state.begin_run_transcript_capture(std::iter::empty());
+
+        state.push_prompt_history_message(json!({"role": "user", "content": "same"}));
+        let direct_start = state.messages.len();
+        state.messages.extend([
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"}
+                }]
+            }),
+            json!({"role": "tool", "tool_call_id": "call-1", "content": "same"}),
+        ]);
+        state.record_appended_prompt_history_from(direct_start);
+
+        assert!(state.messages.iter().all(|message| {
+            astra_turn_types::bridge_turn_message_provenance(message)
+                .unwrap()
+                .is_some_and(|provenance| provenance.turn_chain_id == "chain-current")
+        }));
+        assert_eq!(state.take_run_transcript_capture(), state.messages);
     }
 
     #[test]

--- a/crates/runtime/src/turn/agentic_loop/tool_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/tool_phase.rs
@@ -1322,8 +1322,7 @@ pub(crate) async fn execute_tool_phase<H: AgenticLoopHost>(
         })
         .await;
     }
-    let transcript_appended = state.messages[transcript_append_start..].to_vec();
-    state.record_prompt_history_messages(transcript_appended);
+    state.record_appended_prompt_history_from(transcript_append_start);
 
     // Record LLM round in the turn event buffer and advance the round counter.
     // Also post-process new ToolCallRecords to set batch_id and parallel flags.

--- a/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/crates/runtime/src/turn/bridge/inprocess.rs
@@ -462,6 +462,7 @@ fn start_bridge_canonical_renewal(
 fn canonical_bridge_current_turn_suffix_is_valid(
     messages: &[Value],
     allow_leading_system: bool,
+    allow_additional_user_inputs: bool,
 ) -> bool {
     let mut index = 0;
     if allow_leading_system {
@@ -485,6 +486,12 @@ fn canonical_bridge_current_turn_suffix_is_valid(
     index += 1;
 
     while index < messages.len() {
+        if allow_additional_user_inputs
+            && messages[index].get("role").and_then(Value::as_str) == Some("user")
+        {
+            index += 1;
+            continue;
+        }
         let Some(calls) = messages[index]
             .get("tool_calls")
             .and_then(Value::as_array)
@@ -524,10 +531,58 @@ fn canonical_bridge_current_turn_suffix_is_valid(
     true
 }
 
+fn canonical_bridge_provenance_suffix_start(
+    messages: &[Value],
+    turn_chain_id: &str,
+) -> Result<Option<usize>, String> {
+    let mut current_start = None;
+    for (index, message) in messages.iter().enumerate() {
+        let provenance = astra_turn_types::bridge_turn_message_provenance(message)
+            .map_err(|error| format!("bridge prompt has invalid turn provenance: {error}"))?;
+        let belongs_to_current = provenance
+            .as_ref()
+            .is_some_and(|provenance| provenance.turn_chain_id == turn_chain_id);
+        match (current_start, belongs_to_current) {
+            (None, true) => current_start = Some(index),
+            (Some(_), false) => {
+                return Err(
+                    "bridge prompt current-turn provenance must form one contiguous suffix".into(),
+                );
+            }
+            _ => {}
+        }
+    }
+    Ok(current_start)
+}
+
+fn clear_bridge_turn_provenance(messages: &mut [Value]) {
+    for message in messages {
+        astra_turn_types::clear_bridge_turn_message_provenance(message);
+    }
+}
+
 fn admit_canonical_bridge_prompt(
     mut prior_messages: Vec<Value>,
-    request_messages: Vec<Value>,
+    mut request_messages: Vec<Value>,
+    turn_chain_id: Option<&str>,
 ) -> Result<(Vec<Value>, Vec<Value>), String> {
+    if let Some(turn_chain_id) = turn_chain_id
+        && let Some(current_start) =
+            canonical_bridge_provenance_suffix_start(&request_messages, turn_chain_id)?
+    {
+        let current_turn = astra_turn_core::prompt_facing::sanitize_canonical_continuation_messages_with_turn_semantics(
+            request_messages[current_start..].to_vec(),
+        )
+        .map_err(|error| format!("bridge prompt has invalid turn semantics: {error}"))?;
+        if !canonical_bridge_current_turn_suffix_is_valid(&current_turn, false, true) {
+            return Err(
+                "bridge prompt provenance identifies an invalid current-turn transcript".into(),
+            );
+        }
+        clear_bridge_turn_provenance(&mut request_messages);
+        return Ok((current_turn, request_messages));
+    }
+
     let mut request_canonical =
         astra_turn_core::prompt_facing::sanitize_canonical_continuation_messages_with_turn_semantics(
             request_messages.clone(),
@@ -546,7 +601,7 @@ fn admit_canonical_bridge_prompt(
         (request_canonical, provider_messages)
     };
 
-    if !canonical_bridge_current_turn_suffix_is_valid(&current_turn, !had_canonical_head) {
+    if !canonical_bridge_current_turn_suffix_is_valid(&current_turn, !had_canonical_head, false) {
         return Err(
             "bridge prompt must contain exactly one structurally valid current-turn suffix".into(),
         );
@@ -596,7 +651,7 @@ async fn begin_bridge_canonical_admission(
         None => Vec::new(),
     };
     let (current_turn_canonical_messages, provider_messages) =
-        admit_canonical_bridge_prompt(prior_messages, request_messages)
+        admit_canonical_bridge_prompt(prior_messages, request_messages, Some(turn_chain_id))
             .map_err(|error| (StatusCode::CONFLICT, error))?;
 
     let (lease, release_writer_on_finish, release_writer_on_admission_failure) =
@@ -6416,9 +6471,86 @@ mod tests {
             json!({"role": "user", "content": "current"}),
         ];
 
-        let error = admit_canonical_bridge_prompt(prior, divergent)
+        let error = admit_canonical_bridge_prompt(prior, divergent, None)
             .expect_err("a completed client-side history must not be reinterpreted as one turn");
         assert!(error.contains("structurally valid current-turn suffix"));
+    }
+
+    #[test]
+    fn canonical_bridge_prompt_uses_typed_turn_suffix_after_history_optimization() {
+        let prior = vec![
+            json!({"role": "user", "content": "discarded old request"}),
+            json!({"role": "assistant", "content": "discarded old answer"}),
+            json!({"role": "user", "content": "retained request"}),
+            json!({"role": "assistant", "content": "retained answer"}),
+        ];
+        let mut request = vec![
+            json!({"role": "user", "content": "retained request"}),
+            json!({"role": "assistant", "content": "retained answer"}),
+            json!({"role": "user", "content": "inspect current changes"}),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"}
+                }]
+            }),
+            json!({"role": "tool", "tool_call_id": "call-1", "content": "evidence"}),
+            json!({"role": "user", "content": "keep this readonly"}),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-2",
+                    "type": "function",
+                    "function": {"name": "git_diff", "arguments": "{}"}
+                }]
+            }),
+            json!({"role": "tool", "tool_call_id": "call-2", "content": "diff"}),
+        ];
+        for message in &mut request[2..] {
+            assert!(astra_turn_types::mark_bridge_turn_message(
+                message,
+                "chain-current"
+            ));
+        }
+
+        let (current_turn, provider_messages) =
+            admit_canonical_bridge_prompt(prior, request, Some("chain-current")).unwrap();
+
+        assert_eq!(current_turn.len(), 6);
+        assert_eq!(current_turn[0]["content"], "inspect current changes");
+        assert_eq!(current_turn[3]["content"], "keep this readonly");
+        assert!(current_turn.iter().all(|message| {
+            message
+                .get(astra_turn_types::BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD)
+                .is_none()
+        }));
+        assert_eq!(provider_messages.len(), 8);
+        assert_eq!(provider_messages[0]["content"], "retained request");
+        assert!(provider_messages.iter().all(|message| {
+            message
+                .get(astra_turn_types::BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD)
+                .is_none()
+        }));
+    }
+
+    #[test]
+    fn canonical_bridge_prompt_rejects_noncontiguous_typed_turn_identity() {
+        let mut request = vec![
+            json!({"role": "user", "content": "current"}),
+            json!({"role": "assistant", "content": "unmarked terminal history"}),
+        ];
+        assert!(astra_turn_types::mark_bridge_turn_message(
+            &mut request[0],
+            "chain-current"
+        ));
+
+        let error = admit_canonical_bridge_prompt(Vec::new(), request, Some("chain-current"))
+            .expect_err("typed current-turn identity must be a suffix");
+        assert!(error.contains("one contiguous suffix"));
     }
 
     #[test]

--- a/crates/runtime/src/turn/cloud/session_end_governance.rs
+++ b/crates/runtime/src/turn/cloud/session_end_governance.rs
@@ -210,9 +210,10 @@ pub async fn run_session_end_governance(
             Ok(memory_id) if !memory_id.is_empty() => {
                 report.episode_memory_id = Some(memory_id);
                 report.episode_chars = overview.chars().count();
-                eprintln!(
-                    "[session-end] Stored episode ({} chars) for session {session_id}",
-                    report.episode_chars
+                tracing::debug!(
+                    session_id,
+                    episode_chars = report.episode_chars,
+                    "session-end episode stored"
                 );
             }
             Ok(_) => {
@@ -223,7 +224,11 @@ pub async fn run_session_end_governance(
             Err(e) => {
                 safe_to_purge_working = false;
                 report.working_retained_due_to_episode_failure = true;
-                eprintln!("[session-end] store_episode failed: {e}");
+                tracing::warn!(
+                    session_id,
+                    error = %e,
+                    "session-end episode persistence failed; retaining working memory"
+                );
             }
         }
     }
@@ -233,15 +238,24 @@ pub async fn run_session_end_governance(
         match client.purge_working(session_id).await {
             Ok(n) => {
                 report.working_purged = n;
-                eprintln!("[session-end] Purged {n} working memories for session {session_id}");
+                tracing::debug!(
+                    session_id,
+                    working_memories_purged = n,
+                    "session-end working memory purged"
+                );
             }
             Err(e) => {
-                eprintln!("[session-end] Failed to purge working memory: {e}");
+                tracing::warn!(
+                    session_id,
+                    error = %e,
+                    "session-end working-memory purge failed"
+                );
             }
         }
     } else {
-        eprintln!(
-            "[session-end] Retained working memory for session {session_id} because episode persistence failed"
+        tracing::warn!(
+            session_id,
+            "session-end retained working memory because episode persistence failed"
         );
     }
 
@@ -267,16 +281,22 @@ pub async fn run_session_end_governance(
                         report.scenes_stored += 1;
                     }
                     Ok(_) => report.scenes_stored += 1,
-                    Err(e) => {
-                        eprintln!("[session-end] store_scene failed: {e}");
-                    }
+                    Err(e) => tracing::warn!(
+                        session_id,
+                        error = %e,
+                        "session-end scene persistence failed"
+                    ),
                 }
             }
         }
         Err(e) => {
-            // Cooldown rejection is expected under hot activity; log at
-            // warn and keep going.
-            eprintln!("[session-end] reflect skipped/failed: {e}");
+            // Cooldown rejection is expected under hot activity; keep it in
+            // structured debug logs and continue without user-facing noise.
+            tracing::debug!(
+                session_id,
+                error = %e,
+                "session-end reflection skipped or failed"
+            );
         }
     }
 

--- a/crates/runtime/src/turn/llm/client.rs
+++ b/crates/runtime/src/turn/llm/client.rs
@@ -2550,6 +2550,7 @@ fn strip_internal_runtime_markers(messages: &mut [Value]) {
         if let Some(object) = message.as_object_mut() {
             object.remove(astra_turn_types::RUNTIME_MESSAGE_PROVENANCE_FIELD);
             object.remove(astra_turn_types::USER_TURN_SEMANTICS_FIELD);
+            object.remove(astra_turn_types::BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD);
             object.remove("_compact_boundary");
         }
     }
@@ -8649,6 +8650,10 @@ mod tests {
             "schema_version": 1,
             "objective_relation": "continue"
         });
+        runtime[astra_turn_types::BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD] = json!({
+            "schema_version": 1,
+            "turn_chain_id": "chain-current"
+        });
 
         let out = consolidate_system_messages_for_provider(&[runtime], "openai");
 
@@ -8661,6 +8666,11 @@ mod tests {
         assert!(
             out[0]
                 .get(astra_turn_types::USER_TURN_SEMANTICS_FIELD)
+                .is_none()
+        );
+        assert!(
+            out[0]
+                .get(astra_turn_types::BRIDGE_TURN_MESSAGE_PROVENANCE_FIELD)
                 .is_none()
         );
         assert!(out[0].get("_compact_boundary").is_none());


### PR DESCRIPTION
## Summary

Fix canonical bridge admission for long-running, context-optimized turns.

The bridge previously inferred the current turn by requiring the provider prompt to begin with the complete canonical history. Context optimization can legitimately prune older completed units, so that inference failed late in a tool-heavy turn and rejected the request.

This change introduces versioned, producer-owned bridge-turn provenance bound to the stable `turn_chain_id`:

- identify the current canonical suffix structurally, without text matching;
- keep multiple in-turn user guidance messages in the same atomic optimization unit;
- preserve provenance through internal context optimization only;
- strip it before provider delivery and canonical persistence.

## Impact

Long sessions and tool-heavy turns can continue after history pruning without silently changing the canonical boundary. Provider prompts and persisted conversations remain free of bridge metadata.

## Validation

- `cargo test -p astra-turn-types bridge_turn --lib`
- `cargo test -p astra-turn-core round_dropping_ --lib`
- `cargo test -p astra-runtime canonical_bridge_prompt_ --lib`
- `cargo test -p astra-runtime bridge_turn_identity_covers_all_append_paths_without_text_matching --lib`
- `cargo test -p astra-runtime provider_projection_strips_runtime_ownership_and_boundary_metadata --lib`
- `cargo check -p astra-cli`
