### PR TITLE
fix(runtime): preserve compacted canonical turns

### DIFF
--- a/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
+++ b/crates/astra-cli/src/cli/chat_stream/sse_loop/mod.rs
@@ -985,6 +985,7 @@ pub(crate) async fn stream_chat_sse(
         max_turn_input_tokens: effective_max_turn_input_tokens,
         budget_wrapup_injected: false,
         context_compression_triggered: false,
+        canonical_rewrite_state: Default::default(),
         budget_wrapup_ignored_rounds: 0,
         compact_tier_applied: astra_turn_core::compaction_types::CompactionTier::Normal,
         skill_produced_output: false,

--- a/crates/astra-cli/src/cli/delegate_subrun.rs
+++ b/crates/astra-cli/src/cli/delegate_subrun.rs
@@ -619,6 +619,7 @@ impl SubRunExecutor for CliDelegateSubRunExecutor {
             max_turn_input_tokens: astra_core::RuntimeLimits::global().max_turn_input_tokens,
             budget_wrapup_injected: false,
             context_compression_triggered: false,
+            canonical_rewrite_state: Default::default(),
             budget_wrapup_ignored_rounds: 0,
             compact_tier_applied: astra_turn_core::compaction_types::CompactionTier::Normal,
             skill_produced_output: false,

--- a/crates/astra-cli/src/cli/skill_subrun.rs
+++ b/crates/astra-cli/src/cli/skill_subrun.rs
@@ -1021,6 +1021,7 @@ impl SkillSubRunExecutor for CliSkillSubRunExecutor {
             max_turn_input_tokens: astra_core::RuntimeLimits::global().max_turn_input_tokens,
             budget_wrapup_injected: false,
             context_compression_triggered: false,
+            canonical_rewrite_state: Default::default(),
             budget_wrapup_ignored_rounds: 0,
             compact_tier_applied: astra_turn_core::compaction_types::CompactionTier::Normal,
             skill_produced_output: false,

--- a/crates/astra-cli/src/cli/spawn_subrun.rs
+++ b/crates/astra-cli/src/cli/spawn_subrun.rs
@@ -985,6 +985,7 @@ impl SpawnAgentExecutor for CliSpawnAgentExecutor {
             max_turn_input_tokens: astra_core::RuntimeLimits::global().max_turn_input_tokens,
             budget_wrapup_injected: false,
             context_compression_triggered: false,
+            canonical_rewrite_state: Default::default(),
             budget_wrapup_ignored_rounds: 0,
             compact_tier_applied: astra_turn_core::compaction_types::CompactionTier::Normal,
             skill_produced_output: false,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -174,9 +174,8 @@ fn try_allocate_with_cap(max: u64, cap: u64) -> Result<(), ConnectionQuotaError>
 
 /// Release `max` connections back to the global counter.
 ///
-/// Callers that obtain a pool via [`connect_matrixone`] and later call
-/// `.close()` on it should invoke this immediately after closing so the
-/// quota is recycled.
+/// Callers that obtain a raw pool via [`connect_matrixone`] must invoke this
+/// only after every connection owned by that pool has been closed.
 pub fn release_global_connections(max: u64) {
     loop {
         let current = GLOBAL_CONNECTION_ALLOCATED.load(Ordering::Acquire);
@@ -647,11 +646,12 @@ impl std::error::Error for InvalidTransition {}
 
 /// Create an explicit one-shot connection pool.
 ///
-/// **Prefer [`DedicatedPool`] or [`SharedPool`] instead.**  This function
+/// **Prefer [`SharedPool`] instead for long-lived runtime wiring.**  This function
 /// allocates from the global connection quota but the caller is responsible
 /// for calling [`release_global_connections`] after closing the pool —
-/// forgetting to do so permanently leaks quota.  `DedicatedPool` automates
-/// release on drop, and `SharedPool` manages the lifecycle completely.
+/// forgetting to do so permanently leaks quota. `SharedPool` manages the
+/// lifecycle completely; bounded bootstrap owners must close their sockets
+/// before returning the reservation.
 ///
 /// This is for call sites that intentionally want a dedicated pool.
 /// Long-lived runtime wiring should inject [`SharedPool`] instead of
@@ -688,72 +688,6 @@ pub async fn connect_matrixone(settings: &MatrixOneSettings) -> Result<Pool<MySq
             release_global_connections(max);
             Err(e)
         }
-    }
-}
-
-/// A short-lived pool that releases its global connection quota on drop.
-///
-/// Prefer this over calling [`connect_matrixone`] directly when the pool
-/// has a bounded lifetime.  The wrapper calls [`release_global_connections`]
-/// in its [`Drop`] impl so the quota is automatically recycled.
-///
-/// Call [`DedicatedPool::close`] explicitly before drop to close
-/// connections promptly.  `Drop` is a safety net that releases the
-/// quota counter but cannot `.await` [`Pool::close`][sqlx::Pool::close].
-/// For long-lived pools prefer [`SharedPool`].
-pub struct DedicatedPool {
-    pub(crate) pool: Pool<MySql>,
-    pub(crate) max_connections: u64,
-    /// Prevents double-release of global connection quota across
-    /// `close()` + `Drop` paths.
-    quota_released: Arc<AtomicBool>,
-}
-
-impl DedicatedPool {
-    /// Build a `DedicatedPool` from an already-allocated pool.
-    ///
-    /// The caller must have already reserved `max_connections` via
-    /// [`try_allocate_global_connections`] (which [`connect_matrixone`]
-    /// does internally).
-    pub fn new(pool: Pool<MySql>, max_connections: u64) -> Self {
-        Self {
-            pool,
-            max_connections,
-            quota_released: Arc::new(AtomicBool::new(false)),
-        }
-    }
-
-    /// Close the pool and release the global connection quota.
-    ///
-    /// Prefer calling this explicitly before drop to ensure connections
-    /// are released back to the database promptly.  `Drop` is a safety
-    /// net that only releases the quota counter; it cannot `.await`
-    /// [`Pool::close`].
-    pub async fn close(self) {
-        self.pool.close().await;
-        self.release_quota();
-    }
-
-    /// Release the global connection quota exactly once.
-    fn release_quota(&self) {
-        if !self.quota_released.swap(true, Ordering::AcqRel) {
-            release_global_connections(self.max_connections);
-        }
-    }
-
-    // Access the underlying pool via Deref — DedicatedPool derefs to Pool<MySql>.
-}
-
-impl std::ops::Deref for DedicatedPool {
-    type Target = Pool<MySql>;
-    fn deref(&self) -> &Self::Target {
-        &self.pool
-    }
-}
-
-impl Drop for DedicatedPool {
-    fn drop(&mut self) {
-        self.release_quota();
     }
 }
 

--- a/crates/runtime/src/messaging/e2e_loop_tests.rs
+++ b/crates/runtime/src/messaging/e2e_loop_tests.rs
@@ -240,6 +240,7 @@ mod tests {
             max_turn_input_tokens: 0,
             budget_wrapup_injected: false,
             context_compression_triggered: false,
+            canonical_rewrite_state: Default::default(),
             budget_wrapup_ignored_rounds: 0,
             compact_tier_applied: astra_turn_core::compaction_types::CompactionTier::Normal,
             skill_produced_output: false,

--- a/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -34,7 +34,9 @@ use astra_server_types::ws_progress_callback::ProgressEvent;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use crate::turn::canonical_commit::{canonical_commit_delta, pack_canonical_turn_segments};
+use crate::turn::canonical_commit::{
+    CanonicalRewriteProof, canonical_commit_delta, pack_canonical_turn_segments,
+};
 use crate::turn::run_control::{RunControlProvider, RunControlStatus, UserIntentProvider};
 use astra_core::{
     ErrorResponse, SharedPool, connect_matrixone, error_response, error_response_coded,
@@ -2710,7 +2712,6 @@ struct CanonicalTurnAdmission {
     lease: astra_turn_types::ConversationWriterLeaseV1,
     reservation: astra_turn_types::TurnReservationV1,
     prior_messages: Vec<Value>,
-    prior_message_count: usize,
     had_canonical_head: bool,
     /// Leases supplied as an explicit controller capability outlive one run;
     /// only leases acquired internally by this run are released here.
@@ -3088,7 +3089,6 @@ impl AgenticRunLifecycleService {
                 ));
             }
         };
-        let prior_message_count = prior_messages.len();
         let renewal_cancel = CancellationToken::new();
         let heartbeat_cancel = renewal_cancel.clone();
         let heartbeat_run_cancel = authority_loss_cancel;
@@ -3161,7 +3161,6 @@ impl AgenticRunLifecycleService {
             lease,
             reservation,
             prior_messages,
-            prior_message_count,
             had_canonical_head: head.is_some(),
             release_writer_on_finish,
             release_started: Arc::new(AtomicBool::new(false)),
@@ -3174,7 +3173,7 @@ impl AgenticRunLifecycleService {
     async fn commit_canonical_turn(
         admission: Option<&CanonicalTurnAdmission>,
         messages: &[Value],
-        compaction_rewrote_prefix: bool,
+        rewrite_proof: Option<&CanonicalRewriteProof>,
         cancellation_requested: bool,
         run_id: &str,
     ) -> Result<bool, astra_core::ClassifiedError> {
@@ -3184,10 +3183,10 @@ impl AgenticRunLifecycleService {
         admission.renewal_cancel.cancel();
         let result = async {
             let Some((mode, logical_segments)) = canonical_commit_delta(
-                admission.prior_message_count,
+                &admission.prior_messages,
                 admission.had_canonical_head,
                 messages,
-                compaction_rewrote_prefix,
+                rewrite_proof,
                 cancellation_requested,
             )?
             else {
@@ -3203,7 +3202,20 @@ impl AgenticRunLifecycleService {
                 conversation_seq: base
                     .map_or(1, |cursor| cursor.conversation_seq.saturating_add(1)),
                 compaction_generation: if replaces_history {
-                    base.map_or(1, |cursor| cursor.compaction_generation.saturating_add(1))
+                    let proof = rewrite_proof.ok_or_else(|| {
+                        "canonical replacement is missing its typed rewrite proof".to_string()
+                    })?;
+                    let cursor = base.ok_or_else(|| {
+                        "canonical replacement is missing its admitted base cursor".to_string()
+                    })?;
+                    if proof.base_root() != cursor.canonical_root_hash {
+                        return Err(
+                            "canonical rewrite proof does not match the admitted base root".into(),
+                        );
+                    }
+                    proof.replacement_generation().ok_or_else(|| {
+                        "canonical rewrite proof has no resulting compaction generation".to_string()
+                    })?
                 } else {
                     base.map_or(0, |cursor| cursor.compaction_generation)
                 },
@@ -7082,6 +7094,7 @@ impl AgenticRunLifecycleService {
             max_turn_input_tokens,
             budget_wrapup_injected: false,
             context_compression_triggered: false,
+            canonical_rewrite_state: Default::default(),
             budget_wrapup_ignored_rounds: 0,
             compact_tier_applied: astra_turn_core::compaction_types::CompactionTier::Normal,
             skill_produced_output: false,
@@ -8465,7 +8478,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 }
             }
         }
-        let mut canonical_turn = match self
+        let canonical_turn = match self
             .prepare_canonical_turn(
                 &user_id,
                 &session_id,
@@ -8526,11 +8539,19 @@ impl RunLifecycleService for AgenticRunLifecycleService {
 
         loop_state.session_turn =
             infer_session_turn(self.shared_pool.as_ref(), &user_id, &session_id).await;
-        if let Some(admission) = canonical_turn.as_mut()
+        if let Some(admission) = canonical_turn.as_ref()
             && admission.had_canonical_head
         {
-            admission.prior_messages.append(&mut loop_state.messages);
-            loop_state.messages = std::mem::take(&mut admission.prior_messages);
+            let mut messages = admission.prior_messages.clone();
+            messages.append(&mut loop_state.messages);
+            loop_state.messages = messages;
+            if let Some(base) = admission.reservation.expected_cursor.as_ref() {
+                loop_state.initialize_canonical_rewrite_proof(
+                    &admission.prior_messages,
+                    &base.canonical_root_hash,
+                    base.compaction_generation,
+                );
+            }
         }
         self.configure_host_approval_audit_context(
             &mut host,
@@ -8995,7 +9016,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                     match Self::commit_canonical_turn(
                         canonical_turn.as_ref(),
                         &loop_state.messages,
-                        loop_state.context_compression_triggered,
+                        loop_state.canonical_rewrite_proof(),
                         bg_cancel_flag.load(Ordering::Acquire)
                             || bg_llm_cancel_token.is_cancelled(),
                         &bg_run_id,
@@ -9848,7 +9869,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 agent_id: None,
                 event_tx: Some(event_tx.clone()),
             });
-        let mut canonical_turn = match self
+        let canonical_turn = match self
             .prepare_canonical_turn(
                 &user_id,
                 &session_id,
@@ -9909,11 +9930,19 @@ impl RunLifecycleService for AgenticRunLifecycleService {
 
         state.session_turn =
             infer_session_turn(self.shared_pool.as_ref(), &user_id, &session_id).await;
-        if let Some(admission) = canonical_turn.as_mut()
+        if let Some(admission) = canonical_turn.as_ref()
             && admission.had_canonical_head
         {
-            admission.prior_messages.append(&mut state.messages);
-            state.messages = std::mem::take(&mut admission.prior_messages);
+            let mut messages = admission.prior_messages.clone();
+            messages.append(&mut state.messages);
+            state.messages = messages;
+            if let Some(base) = admission.reservation.expected_cursor.as_ref() {
+                state.initialize_canonical_rewrite_proof(
+                    &admission.prior_messages,
+                    &base.canonical_root_hash,
+                    base.compaction_generation,
+                );
+            }
         }
         let fresh_session_current_date = state
             .pipeline_session
@@ -10627,7 +10656,7 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                     match Self::commit_canonical_turn(
                         canonical_turn.as_ref(),
                         &state.messages,
-                        state.context_compression_triggered,
+                        state.canonical_rewrite_proof(),
                         bg_cancel_flag.load(Ordering::Acquire)
                             || bg_llm_cancel_token.is_cancelled(),
                         &bg_run_id,
@@ -13432,6 +13461,7 @@ impl SubRunExecutor for ServerSubRunExecutor {
             max_turn_input_tokens,
             budget_wrapup_injected: false,
             context_compression_triggered: false,
+            canonical_rewrite_state: Default::default(),
             budget_wrapup_ignored_rounds: 0,
             compact_tier_applied: astra_turn_core::compaction_types::CompactionTier::Normal,
             skill_produced_output: false,

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -102,6 +102,15 @@ fn compaction_commits_the_complete_replacement_projection() {
 }
 
 #[test]
+fn unexplained_canonical_prefix_shrink_remains_rejected() {
+    let shortened = vec![json!({"role": "user", "content": "unexpected tail"})];
+
+    let error = canonical_commit_delta(20, true, &shortened, false, false).unwrap_err();
+
+    assert!(error.contains("shorter than the admitted prefix"));
+}
+
+#[test]
 fn fresh_request_admission_accounts_for_large_non_message_payloads() {
     let mut request = test_request("small");
     let baseline = fresh_request_admission_bytes(&request).unwrap();

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -77,11 +77,11 @@ fn canonical_segment_packing_bounds_ordinary_groups_without_reordering() {
 fn cancelled_turn_without_a_delta_does_not_become_a_commit_failure() {
     let prior = vec![json!({"role": "user", "content": "already committed"})];
     assert_eq!(
-        canonical_commit_delta(1, true, &prior, false, true).unwrap(),
+        canonical_commit_delta(&prior, true, &prior, None, true).unwrap(),
         None
     );
     assert!(
-        canonical_commit_delta(1, true, &prior, false, false)
+        canonical_commit_delta(&prior, true, &prior, None, false)
             .unwrap_err()
             .contains("no committable messages")
     );
@@ -89,11 +89,16 @@ fn cancelled_turn_without_a_delta_does_not_become_a_commit_failure() {
 
 #[test]
 fn compaction_commits_the_complete_replacement_projection() {
+    let prior = vec![json!({"role": "user", "content": "old"})];
+    let base_root = astra_turn_types::canonical_conversation_root(&prior);
+    let mut proof = CanonicalRewriteProof::new(&prior, &base_root, 0);
+    let permit = proof.begin(&prior);
     let compacted = vec![
         json!({"role": "user", "content": "summary"}),
         json!({"role": "assistant", "content": "current"}),
     ];
-    let (mode, packs) = canonical_commit_delta(20, true, &compacted, true, false)
+    proof.finish(permit, &compacted);
+    let (mode, packs) = canonical_commit_delta(&prior, true, &compacted, Some(&proof), false)
         .unwrap()
         .unwrap();
 
@@ -103,11 +108,42 @@ fn compaction_commits_the_complete_replacement_projection() {
 
 #[test]
 fn unexplained_canonical_prefix_shrink_remains_rejected() {
+    let prior = vec![json!({"role": "user", "content": "committed"})];
     let shortened = vec![json!({"role": "user", "content": "unexpected tail"})];
 
-    let error = canonical_commit_delta(20, true, &shortened, false, false).unwrap_err();
+    let error = canonical_commit_delta(&prior, true, &shortened, None, false).unwrap_err();
 
-    assert!(error.contains("shorter than the admitted prefix"));
+    assert!(error.contains("without a verified compaction rewrite"));
+}
+
+#[test]
+fn unrelated_prefix_mutation_after_compaction_is_rejected() {
+    let prior = vec![json!({"role": "user", "content": "committed"})];
+    let compacted = vec![json!({"role": "system", "content": "summary"})];
+    let base_root = astra_turn_types::canonical_conversation_root(&prior);
+    let mut proof = CanonicalRewriteProof::new(&prior, &base_root, 0);
+    let permit = proof.begin(&prior);
+    proof.finish(permit, &compacted);
+
+    let mutated = vec![json!({"role": "system", "content": "unrelated mutation"})];
+    let error = canonical_commit_delta(&prior, true, &mutated, Some(&proof), false).unwrap_err();
+
+    assert!(error.contains("without a verified compaction rewrite"));
+}
+
+#[test]
+fn compaction_cannot_authorize_an_already_mutated_prefix() {
+    let prior = vec![json!({"role": "user", "content": "committed"})];
+    let mutated_before_compaction = vec![json!({"role": "user", "content": "unrelated mutation"})];
+    let compacted = vec![json!({"role": "system", "content": "summary"})];
+    let base_root = astra_turn_types::canonical_conversation_root(&prior);
+    let mut proof = CanonicalRewriteProof::new(&prior, &base_root, 0);
+    let permit = proof.begin(&mutated_before_compaction);
+    proof.finish(permit, &compacted);
+
+    let error = canonical_commit_delta(&prior, true, &compacted, Some(&proof), false).unwrap_err();
+
+    assert!(error.contains("without a verified compaction rewrite"));
 }
 
 #[test]

--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -98,6 +98,7 @@ fn apply_pre_turn_summary(
     pressure: f64,
     summary_text: String,
 ) -> CompactionEvent {
+    let rewrite_permit = state.begin_canonical_rewrite();
     let max_tokens = state.max_turn_input_tokens;
     let (tokens_before, old_count) = (
         crate::turn::agentic_loop::lifecycle::estimate_context_pressure(
@@ -126,6 +127,7 @@ fn apply_pre_turn_summary(
             )
         }),
     );
+    state.finish_canonical_rewrite(rewrite_permit);
     state.compact_tier_applied = CompactionTier::CompactHistory;
     state.context_compression_triggered = true;
 
@@ -9772,6 +9774,9 @@ mod tests {
                 "content": format!("answer {index}: {}", "detail ".repeat(80))
             }));
         }
+        let admitted_messages = state.messages.clone();
+        let admitted_root = astra_turn_types::canonical_conversation_root(&admitted_messages);
+        state.initialize_canonical_rewrite_proof(&admitted_messages, &admitted_root, 0);
         let messages_before = state.messages.len();
         let tokens_before = crate::turn::agentic_loop::lifecycle::estimate_context_pressure(
             &state.messages,
@@ -9805,10 +9810,10 @@ mod tests {
         assert!(state.context_compression_triggered);
 
         let (mode, packs) = crate::turn::canonical_commit::canonical_commit_delta(
-            messages_before,
+            &admitted_messages,
             true,
             &state.messages,
-            state.context_compression_triggered,
+            state.canonical_rewrite_proof(),
             false,
         )
         .expect("pre-turn compaction must produce a canonical replacement")
@@ -11138,6 +11143,7 @@ mod tests {
             max_turn_input_tokens: 0,
             budget_wrapup_injected: false,
             context_compression_triggered: false,
+            canonical_rewrite_state: Default::default(),
             budget_wrapup_ignored_rounds: 0,
             compact_tier_applied: CompactionTier::Normal,
             skill_produced_output: false,

--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -127,6 +127,7 @@ fn apply_pre_turn_summary(
         }),
     );
     state.compact_tier_applied = CompactionTier::CompactHistory;
+    state.context_compression_triggered = true;
 
     let tokens_after = crate::turn::agentic_loop::lifecycle::estimate_context_pressure(
         &state.messages,
@@ -9801,6 +9802,19 @@ mod tests {
         );
         assert_eq!(event.messages_after, state.messages.len());
         assert_eq!(state.compact_tier_applied, CompactionTier::CompactHistory);
+        assert!(state.context_compression_triggered);
+
+        let (mode, packs) = crate::turn::canonical_commit::canonical_commit_delta(
+            messages_before,
+            true,
+            &state.messages,
+            state.context_compression_triggered,
+            false,
+        )
+        .expect("pre-turn compaction must produce a canonical replacement")
+        .expect("pre-turn compaction must remain committable");
+        assert_eq!(mode, astra_turn_types::CanonicalDeltaModeV1::Replace);
+        assert!(!packs.is_empty());
     }
 
     #[test]

--- a/crates/runtime/src/server/server_skill_subrun.rs
+++ b/crates/runtime/src/server/server_skill_subrun.rs
@@ -529,6 +529,7 @@ impl SkillSubRunExecutor for ServerSkillSubRunExecutor {
             max_turn_input_tokens: astra_core::RuntimeLimits::global().max_turn_input_tokens,
             budget_wrapup_injected: false,
             context_compression_triggered: false,
+            canonical_rewrite_state: Default::default(),
             budget_wrapup_ignored_rounds: 0,
             compact_tier_applied: astra_turn_core::compaction_types::CompactionTier::Normal,
             skill_produced_output: false,

--- a/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -1698,6 +1698,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                     sess.recovery.record_ptl_error();
                 }
 
+                let rewrite_permit = state.begin_canonical_rewrite();
                 let outcome = super::super::compaction_replay::try_compact_for_retry_checked(
                     &mut state.messages,
                     &mut state.compaction_effectiveness,
@@ -1707,6 +1708,7 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
                 );
                 match outcome {
                     super::super::compaction_replay::CompactionReplayOutcome::Compacted(result) => {
+                        state.finish_canonical_rewrite(rewrite_permit);
                         let tier_label = result.tier.to_string();
                         // Feed compaction stats into pipeline for reserve estimation.
                         if let Some(ref mut sess) = state.pipeline_session {
@@ -2643,6 +2645,7 @@ async fn handle_token_budget<H: AgenticLoopHost>(
     if !state.budget_wrapup_injected
         && state.compaction_effectiveness.attempt_count < MAX_REACTIVE_BUDGET_COMPACTION_ATTEMPTS
     {
+        let rewrite_permit = state.begin_canonical_rewrite();
         let budget = super::super::TokenBudget {
             max_prompt_tokens: state.max_turn_input_tokens,
             last_measured_tokens: measured,
@@ -2692,6 +2695,7 @@ async fn handle_token_budget<H: AgenticLoopHost>(
         }
 
         if total_freed > 0 {
+            state.finish_canonical_rewrite(rewrite_permit);
             let pressure = measured as f64 / state.max_turn_input_tokens as f64;
             state.context_compression_triggered = true;
             state.step_recorder.record_compaction_with_kind(

--- a/crates/runtime/src/turn/agentic_loop/finalization.rs
+++ b/crates/runtime/src/turn/agentic_loop/finalization.rs
@@ -2203,7 +2203,7 @@ mod tests {
     }
 
     #[test]
-    fn turn_finalization_preserves_compression_for_canonical_commit() {
+    fn turn_finalization_preserves_compression_observability() {
         let mut state = make_state();
         state.context_compression_triggered = true;
 
@@ -2211,7 +2211,7 @@ mod tests {
 
         assert!(
             state.context_compression_triggered,
-            "canonical commit runs after finalization and must still observe a prefix rewrite"
+            "turn tracing must retain whether provider-visible compaction occurred"
         );
     }
 

--- a/crates/runtime/src/turn/agentic_loop/finalization.rs
+++ b/crates/runtime/src/turn/agentic_loop/finalization.rs
@@ -984,7 +984,6 @@ fn reset_per_turn_advisory_state(state: &mut AgenticLoopState) {
     // `budget_wrapup_injected` is still true from the previous turn),
     // which was exactly the stale-state bug the code-review called out.
     state.budget_wrapup_injected = false;
-    state.context_compression_triggered = false;
     state.budget_wrapup_ignored_rounds = 0;
     // Defensive reset: last_finish_reason is rewritten before every LLM call
     // in execution_phase.rs, but resetting here prevents stale leakage if a
@@ -2200,6 +2199,19 @@ mod tests {
         assert!(
             guard.context_traces[0].token_budget.compression_triggered,
             "trace must report actual context compaction independently of budget wrap-up policy"
+        );
+    }
+
+    #[test]
+    fn turn_finalization_preserves_compression_for_canonical_commit() {
+        let mut state = make_state();
+        state.context_compression_triggered = true;
+
+        reset_per_turn_advisory_state(&mut state);
+
+        assert!(
+            state.context_compression_triggered,
+            "canonical commit runs after finalization and must still observe a prefix rewrite"
         );
     }
 

--- a/crates/runtime/src/turn/agentic_loop/host.rs
+++ b/crates/runtime/src/turn/agentic_loop/host.rs
@@ -1965,6 +1965,15 @@ pub fn runtime_volatile_injections_edge_profile_value(
 
 /// Created by the CLI/host from session parameters; mutated by the runtime
 /// during multi-turn execution. Consumed at the end to produce results.
+/// Opaque runtime-owned authority for canonical history rewrites.
+///
+/// External loop hosts can construct an empty state, but only the runtime can
+/// initialize or advance the contained proof.
+#[derive(Debug, Clone, Default)]
+pub struct CanonicalRewriteState {
+    proof: Option<crate::turn::canonical_commit::CanonicalRewriteProof>,
+}
+
 pub struct AgenticLoopState {
     // ── Message context ──
     pub messages: Vec<Value>,
@@ -2205,6 +2214,10 @@ pub struct AgenticLoopState {
     /// user turn. This is observability state only; unlike the budget wrap-up
     /// flag it must never change execution policy.
     pub context_compression_triggered: bool,
+    /// Typed authority proving that persisted canonical history was rewritten
+    /// only by an explicit compaction operation. Observability flags must not
+    /// authorize a canonical Replace commit.
+    pub canonical_rewrite_state: CanonicalRewriteState,
     /// Counts how many post-wrap-up rounds still emitted tool_calls. Task #43
     /// hybrid enforcement: the first such round triggers a physical lockout
     /// (tool_calls dropped, `restricted_tools` populated, loop continues so the
@@ -2413,6 +2426,47 @@ pub fn runtime_manifest_for_model(
 }
 
 impl AgenticLoopState {
+    pub(crate) fn initialize_canonical_rewrite_proof(
+        &mut self,
+        admitted_prefix: &[Value],
+        base_root: &str,
+        base_compaction_generation: u64,
+    ) {
+        self.canonical_rewrite_state.proof =
+            Some(crate::turn::canonical_commit::CanonicalRewriteProof::new(
+                admitted_prefix,
+                base_root,
+                base_compaction_generation,
+            ));
+    }
+
+    pub(crate) fn canonical_rewrite_proof(
+        &self,
+    ) -> Option<&crate::turn::canonical_commit::CanonicalRewriteProof> {
+        self.canonical_rewrite_state.proof.as_ref()
+    }
+
+    pub(crate) fn begin_canonical_rewrite(
+        &self,
+    ) -> Option<crate::turn::canonical_commit::CanonicalRewritePermit> {
+        self.canonical_rewrite_state
+            .proof
+            .as_ref()
+            .map(|proof| proof.begin(&self.messages))
+    }
+
+    pub(crate) fn finish_canonical_rewrite(
+        &mut self,
+        permit: Option<crate::turn::canonical_commit::CanonicalRewritePermit>,
+    ) {
+        let Some(permit) = permit else {
+            return;
+        };
+        if let Some(proof) = self.canonical_rewrite_state.proof.as_mut() {
+            proof.finish(permit, &self.messages);
+        }
+    }
+
     /// Begin recording selected prompt-history items for a child run's
     /// canonical transcript. The caller chooses the initial visible child
     /// items, excluding inherited/system context that is not part of the
@@ -3607,6 +3661,7 @@ pub fn make_test_loop_state_for_model(model: Option<&str>) -> AgenticLoopState {
         max_turn_input_tokens: 0,
         budget_wrapup_injected: false,
         context_compression_triggered: false,
+        canonical_rewrite_state: Default::default(),
         budget_wrapup_ignored_rounds: 0,
         compact_tier_applied: CompactionTier::Normal,
         skill_produced_output: false,
@@ -4469,6 +4524,7 @@ pub(crate) mod tests {
             max_turn_input_tokens: 0,
             budget_wrapup_injected: false,
             context_compression_triggered: false,
+            canonical_rewrite_state: Default::default(),
             budget_wrapup_ignored_rounds: 0,
             compact_tier_applied: CompactionTier::Normal,
             skill_produced_output: false,

--- a/crates/runtime/src/turn/agentic_loop/lifecycle.rs
+++ b/crates/runtime/src/turn/agentic_loop/lifecycle.rs
@@ -1092,6 +1092,11 @@ pub(crate) async fn run_loop_preamble<H: AgenticLoopHost>(
     host: &mut H,
     state: &mut AgenticLoopState,
 ) {
+    // This flag is a turn outcome consumed by the canonical commit after the
+    // agentic loop returns. Reset it when a new turn actually starts, not
+    // during finalization, so prefix rewrites remain observable to commit.
+    state.context_compression_triggered = false;
+
     if state
         .skills
         .session_event_hooks
@@ -2148,6 +2153,17 @@ mod tests {
             pure_user_intent_for_runtime_decision(message),
             "review literal <system-reminder> syntax"
         );
+    }
+
+    #[tokio::test]
+    async fn loop_preamble_starts_fresh_compression_tracking() {
+        let mut state = make_state();
+        state.context_compression_triggered = true;
+        let mut host = MockHost::new(Vec::new());
+
+        run_loop_preamble(&mut host, &mut state).await;
+
+        assert!(!state.context_compression_triggered);
     }
 
     fn agent_record(

--- a/crates/runtime/src/turn/agentic_loop/lifecycle.rs
+++ b/crates/runtime/src/turn/agentic_loop/lifecycle.rs
@@ -1262,11 +1262,13 @@ fn run_proactive_compaction<H: AgenticLoopHost>(
         CompactionEngine::default_pipeline_for(max_tokens)
     };
     let messages_before = state.messages.len();
+    let rewrite_permit = state.begin_canonical_rewrite();
     let outcome = pipeline.compress_if_needed(&mut state.messages, &budget);
     state
         .compaction_effectiveness
         .record_compaction(outcome.total_tokens_freed);
     if outcome.total_tokens_freed > 0 {
+        state.finish_canonical_rewrite(rewrite_permit);
         let messages_after = state.messages.len();
         let messages_removed = messages_before.saturating_sub(messages_after);
         let layer_descriptions: Vec<String> = outcome
@@ -2020,6 +2022,7 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
             }
             .ok()
         });
+        let rewrite_permit = state.begin_canonical_rewrite();
         let mc = if !pipeline_allows_clearing {
             // Cascade detected: skip clearing this turn to break the loop.
             astra_turn_core::microcompact::CompactStats::default()
@@ -2043,6 +2046,7 @@ pub(crate) async fn prepare_turn_iteration<H: AgenticLoopHost>(
             )
         };
         if mc.results_compacted > 0 {
+            state.finish_canonical_rewrite(rewrite_permit);
             state.context_compression_triggered = true;
             let event = CompactionEvent::new(
                 CompactionKind::Microcompact,

--- a/crates/runtime/src/turn/bridge/inprocess.rs
+++ b/crates/runtime/src/turn/bridge/inprocess.rs
@@ -347,7 +347,11 @@ impl BridgeCanonicalAdmission {
             )
             .map_err(|error| format!("bridge result has invalid turn semantics: {error}"))?;
         let Some((mode, logical_segments)) = crate::turn::canonical_commit::canonical_commit_delta(
-            0, false, &canonical, false, false,
+            &[],
+            false,
+            &canonical,
+            None,
+            false,
         )?
         else {
             return Err("bridge terminal result produced no canonical delta".into());

--- a/crates/runtime/src/turn/canonical_commit.rs
+++ b/crates/runtime/src/turn/canonical_commit.rs
@@ -1,23 +1,97 @@
 use serde_json::Value;
 
+#[derive(Debug, Clone)]
+pub(crate) struct CanonicalRewriteProof {
+    base_root: String,
+    base_compaction_generation: u64,
+    authorized_prefix_len: usize,
+    authorized_prefix_root: String,
+    rewritten: bool,
+    valid: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CanonicalRewritePermit {
+    valid: bool,
+}
+
+impl CanonicalRewriteProof {
+    pub(crate) fn new(
+        admitted_prefix: &[Value],
+        base_root: &str,
+        base_compaction_generation: u64,
+    ) -> Self {
+        let admitted_root = astra_turn_types::canonical_conversation_root(admitted_prefix);
+        Self {
+            base_root: base_root.to_string(),
+            base_compaction_generation,
+            authorized_prefix_len: admitted_prefix.len(),
+            authorized_prefix_root: admitted_root.clone(),
+            rewritten: false,
+            valid: admitted_root == base_root,
+        }
+    }
+
+    pub(crate) fn begin(&self, messages: &[Value]) -> CanonicalRewritePermit {
+        CanonicalRewritePermit {
+            valid: self.valid
+                && messages.len() >= self.authorized_prefix_len
+                && astra_turn_types::canonical_conversation_root(
+                    &messages[..self.authorized_prefix_len],
+                ) == self.authorized_prefix_root,
+        }
+    }
+
+    pub(crate) fn finish(&mut self, permit: CanonicalRewritePermit, messages: &[Value]) {
+        if !permit.valid {
+            self.valid = false;
+            return;
+        }
+        self.authorized_prefix_len = messages.len();
+        self.authorized_prefix_root = astra_turn_types::canonical_conversation_root(messages);
+        self.rewritten = true;
+    }
+
+    fn authorizes(&self, messages: &[Value]) -> bool {
+        self.valid
+            && self.rewritten
+            && messages.len() >= self.authorized_prefix_len
+            && astra_turn_types::canonical_conversation_root(
+                &messages[..self.authorized_prefix_len],
+            ) == self.authorized_prefix_root
+    }
+
+    pub(crate) fn replacement_generation(&self) -> Option<u64> {
+        self.valid
+            .then(|| self.base_compaction_generation.saturating_add(1))
+    }
+
+    pub(crate) fn base_root(&self) -> &str {
+        &self.base_root
+    }
+}
+
 pub(crate) fn canonical_commit_delta(
-    prior_message_count: usize,
+    prior_messages: &[Value],
     had_canonical_head: bool,
     messages: &[Value],
-    compaction_rewrote_prefix: bool,
+    rewrite_proof: Option<&CanonicalRewriteProof>,
     cancellation_requested: bool,
 ) -> Result<Option<(astra_turn_types::CanonicalDeltaModeV1, Vec<Vec<Value>>)>, String> {
-    let mode = if compaction_rewrote_prefix && had_canonical_head {
+    let prefix_preserved = messages.starts_with(prior_messages);
+    let rewrite_authorized =
+        had_canonical_head && rewrite_proof.is_some_and(|proof| proof.authorizes(messages));
+    let mode = if prefix_preserved {
+        astra_turn_types::CanonicalDeltaModeV1::Append
+    } else if rewrite_authorized {
         astra_turn_types::CanonicalDeltaModeV1::Replace
     } else {
-        astra_turn_types::CanonicalDeltaModeV1::Append
+        return Err("canonical conversation mutated the admitted prefix without a verified compaction rewrite".into());
     };
     let changed_messages = if mode == astra_turn_types::CanonicalDeltaModeV1::Replace {
         messages
     } else {
-        messages.get(prior_message_count..).ok_or_else(|| {
-            "canonical conversation became shorter than the admitted prefix".to_string()
-        })?
+        &messages[prior_messages.len()..]
     };
     let canonical_changed =
         astra_turn_core::prompt_facing::sanitize_canonical_continuation_messages_with_turn_semantics(

--- a/crates/runtime/src/turn/loop_dispatcher.rs
+++ b/crates/runtime/src/turn/loop_dispatcher.rs
@@ -359,6 +359,7 @@ mod tests {
             max_turn_input_tokens: 0,
             budget_wrapup_injected: false,
             context_compression_triggered: false,
+            canonical_rewrite_state: Default::default(),
             budget_wrapup_ignored_rounds: 0,
             compact_tier_applied: astra_turn_core::compaction_types::CompactionTier::Normal,
             skill_produced_output: false,

--- a/crates/runtime/tests/system_matrix_http_e2e/harness.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/harness.rs
@@ -556,21 +556,40 @@ pub async fn wait_for_agent_event_types(
     types: &[&str],
     timeout: std::time::Duration,
 ) {
+    let expected_counts = types
+        .iter()
+        .map(|event_type| (*event_type, 1_i64))
+        .collect::<Vec<_>>();
+    wait_for_agent_event_type_counts(pool, user_id, session_id, &expected_counts, timeout).await;
+}
+
+/// Poll until every `event_type` reaches its expected row count for this session, or `timeout`.
+///
+/// Bridge turns persist some observability events asynchronously after the SSE response completes.
+/// Callers that assert a session-wide projection must wait for every expected turn event, rather
+/// than merely observing one row of each type.
+pub async fn wait_for_agent_event_type_counts(
+    pool: &sqlx::MySqlPool,
+    user_id: &str,
+    session_id: &str,
+    expected_counts: &[(&str, i64)],
+    timeout: std::time::Duration,
+) {
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
         let mut ok = true;
-        for et in types {
+        for (event_type, expected_count) in expected_counts {
             let n: i64 = sqlx::query_scalar(
                 "SELECT COUNT(*) FROM agent_events \
                  WHERE session_id = ? AND user_id = ? AND event_type = ?",
             )
             .bind(session_id)
             .bind(user_id)
-            .bind(*et)
+            .bind(*event_type)
             .fetch_one(pool)
             .await
             .unwrap_or(0);
-            if n < 1 {
+            if n < *expected_count {
                 ok = false;
                 break;
             }
@@ -580,7 +599,7 @@ pub async fn wait_for_agent_event_types(
         }
         if tokio::time::Instant::now() >= deadline {
             panic!(
-                "timeout ({timeout:?}) waiting for agent_events types {types:?} for user_id={user_id} session_id={session_id}"
+                "timeout ({timeout:?}) waiting for agent_events counts {expected_counts:?} for user_id={user_id} session_id={session_id}"
             );
         }
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;

--- a/crates/runtime/tests/system_matrix_http_e2e/journey_bridge_session_state.rs
+++ b/crates/runtime/tests/system_matrix_http_e2e/journey_bridge_session_state.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 use super::harness::{
     bootstrap, cleanup_session_data, get_json, post_json, seeded_model_selection,
-    sse_first_data_json_with_type, wait_for_agent_event_types,
+    sse_first_data_json_with_type, wait_for_agent_event_type_counts,
 };
 
 const REAL_USER_MESSAGE: &str = "review the branch with three independent agents";
@@ -177,16 +177,16 @@ pub async fn run_cli_bridge_session_views_remain_consistent() {
     .await;
     assert_ne!(first_run_id, reconciliation_run_id);
 
-    wait_for_agent_event_types(
+    wait_for_agent_event_type_counts(
         pool,
         user_id,
         &session_id,
         &[
-            "user_query",
-            "runtime_reconciliation",
-            "llm_response",
-            "routing_decision",
-            "context_trace_signal",
+            ("user_query", 1),
+            ("runtime_reconciliation", 1),
+            ("llm_response", 2),
+            ("routing_decision", 2),
+            ("context_trace_signal", 2),
         ],
         std::time::Duration::from_secs(20),
     )

--- a/crates/services/src/storage.rs
+++ b/crates/services/src/storage.rs
@@ -1,8 +1,8 @@
 use crate::auth::DatabaseUserRecord;
 use crate::auth::session::SessionRecord;
 use astra_core::{
-    DedicatedPool, ErrorResponse, MatrixOneSettings, connect_matrixone, identity::USER_ID_MAX_LEN,
-    internal_error,
+    ErrorResponse, MatrixOneSettings, connect_matrixone, identity::USER_ID_MAX_LEN, internal_error,
+    release_global_connections,
 };
 use axum::{Json, http::StatusCode};
 use sha2::Digest;
@@ -37,6 +37,76 @@ const EDGE_PENDING_DISPATCH_LEGACY_ARCHIVE_TABLE: &str =
     "edge_pending_dispatch_legacy_owner_request_v1";
 const TOOL_INVOCATION_LEDGER_REQUIRED_COLUMNS: &[&str] = &["identity_key"];
 const TOOL_INVOCATION_LEDGER_REQUIRED_VARCHAR_WIDTHS: &[(&str, u64)] = &[("identity_key", 71)];
+
+/// Sole owner of a short-lived MatrixOne bootstrap pool.
+///
+/// MatrixOne does not complete SQLx's MySQL shutdown handshake. Teardown
+/// therefore waits for every checked-out connection to return, detaches each
+/// socket from SQLx, drops it synchronously, and only then returns the global
+/// connection reservation. Keeping this type private prevents bootstrap code
+/// from cloning the pool beyond that ownership boundary.
+struct BootstrapPool {
+    pool: sqlx::Pool<MySql>,
+    max_connections: u64,
+    released: bool,
+}
+
+impl BootstrapPool {
+    fn new(pool: sqlx::Pool<MySql>, max_connections: u64) -> Self {
+        Self {
+            pool,
+            max_connections,
+            released: false,
+        }
+    }
+
+    fn pool(&self) -> &sqlx::Pool<MySql> {
+        &self.pool
+    }
+
+    async fn release(mut self) -> Result<(), sqlx::Error> {
+        while self.pool.size() > 0 {
+            let connection = self.pool.acquire().await?;
+            drop(connection.detach());
+        }
+        release_global_connections(self.max_connections);
+        self.released = true;
+        Ok(())
+    }
+}
+
+impl Drop for BootstrapPool {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        if self.pool.size() == 0 {
+            release_global_connections(self.max_connections);
+            self.released = true;
+        } else {
+            tracing::error!(
+                target: "astra_services::storage",
+                live_connections = self.pool.size(),
+                reserved_connections = self.max_connections,
+                "bootstrap pool dropped with live connections; retaining global quota reservation"
+            );
+        }
+    }
+}
+
+fn finish_bootstrap_operation<T>(
+    operation: Result<T, sqlx::Error>,
+    release: Result<(), sqlx::Error>,
+) -> Result<T, sqlx::Error> {
+    match (operation, release) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(operation_error), Err(release_error)) => Err(sqlx::Error::Protocol(format!(
+            "bootstrap operation failed: {operation_error}; pool teardown also failed: {release_error}"
+        ))),
+    }
+}
 
 /// Standard column width for `agent_id` across all tables.
 /// All `agent_id`, `edge_agent_id`, `holder_agent_id`, and `parent_agent_id`
@@ -893,9 +963,11 @@ async fn wait_for_core_schema_visibility(settings: &MatrixOneSettings) -> Result
     verify_settings.db_pool_min_connections = 0;
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
     loop {
-        let verify_pool = DedicatedPool::new(connect_matrixone(&verify_settings).await?, 1);
-        let visibility_result = verify_core_schema_visible(&verify_pool, &settings.database).await;
-        verify_pool.close().await;
+        let verify_pool = BootstrapPool::new(connect_matrixone(&verify_settings).await?, 1);
+        let visibility_result =
+            verify_core_schema_visible(verify_pool.pool(), &settings.database).await;
+        let visibility_result =
+            finish_bootstrap_operation(visibility_result, verify_pool.release().await);
         match visibility_result {
             Ok(CoreSchemaVisibility::Visible) => return Ok(()),
             Ok(CoreSchemaVisibility::Lag(_)) if tokio::time::Instant::now() < deadline => {
@@ -1269,14 +1341,13 @@ async fn ensure_matrixone_database_exists(
     admin_settings.database = bootstrap_catalog.to_string();
     admin_settings.db_pool_max_connections = 1;
     admin_settings.db_pool_min_connections = 0;
-    let admin_pool = DedicatedPool::new(connect_matrixone(&admin_settings).await?, 1);
+    let admin_pool = BootstrapPool::new(connect_matrixone(&admin_settings).await?, 1);
     let ddl = format!(
         "CREATE DATABASE IF NOT EXISTS {}",
         crate::snapshot_sql::quote_mysql_identifier(&settings.database)
     );
-    let create_result = query(&ddl).execute(&*admin_pool).await.map(|_| ());
-    admin_pool.close().await;
-    create_result
+    let create_result = query(&ddl).execute(admin_pool.pool()).await.map(|_| ());
+    finish_bootstrap_operation(create_result, admin_pool.release().await)
 }
 
 fn validate_schema_identifier(raw: &str, kind: &str) -> Result<(), sqlx::Error> {
@@ -2423,28 +2494,30 @@ pub async fn ensure_core_schema(
     let mut schema_settings = settings.clone();
     schema_settings.db_pool_max_connections = 1;
     schema_settings.db_pool_min_connections = 0;
-    let pool = DedicatedPool::new(connect_matrixone(&schema_settings).await?, 1);
+    let pool = BootstrapPool::new(connect_matrixone(&schema_settings).await?, 1);
     let lease_pool = match connect_matrixone(&schema_settings).await {
-        Ok(lease_pool) => DedicatedPool::new(lease_pool, 1),
+        Ok(lease_pool) => BootstrapPool::new(lease_pool, 1),
         Err(error) => {
-            pool.close().await;
-            return Err(error);
+            return finish_bootstrap_operation(Err(error), pool.release().await);
         }
     };
-    let database_lease = match CoreSchemaDatabaseLease::acquire(&lease_pool).await {
+    let database_lease = match CoreSchemaDatabaseLease::acquire(lease_pool.pool()).await {
         Ok(lease) => lease,
         Err(error) => {
-            lease_pool.close().await;
-            pool.close().await;
-            return Err(error);
+            let lease_release = lease_pool.release().await;
+            let pool_release = pool.release().await;
+            return finish_bootstrap_operation(
+                finish_bootstrap_operation(Err(error), lease_release),
+                pool_release,
+            );
         }
     };
     let schema_result =
-        ensure_core_schema_while_leased(settings, (*pool).clone(), database_lease.holder_id())
+        ensure_core_schema_while_leased(settings, pool.pool().clone(), database_lease.holder_id())
             .await;
     let release_result = database_lease.release().await;
-    lease_pool.close().await;
-    pool.close().await;
+    let lease_pool_release = lease_pool.release().await;
+    let pool_release = pool.release().await;
     let bootstrap_result = match (schema_result, release_result) {
         (Ok(()), Ok(())) => Ok(()),
         (Err(schema_error), Ok(())) => Err(schema_error),
@@ -2453,6 +2526,8 @@ pub async fn ensure_core_schema(
             "core schema bootstrap failed: {schema_error}; bootstrap lease release also failed: {release_error}"
         ))),
     };
+    let bootstrap_result = finish_bootstrap_operation(bootstrap_result, lease_pool_release);
+    let bootstrap_result = finish_bootstrap_operation(bootstrap_result, pool_release);
     match bootstrap_result {
         Ok(()) => wait_for_core_schema_visibility(settings).await,
         Err(error) => Err(error),
@@ -8450,6 +8525,80 @@ pub async fn cleanup_expired_data(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires ASTRA_TEST_DB_IT=1 and a real MySQL/MatrixOne instance"]
+    async fn bootstrap_pool_release_waits_for_checked_out_connection() {
+        let _ = dotenvy::dotenv();
+        assert_eq!(
+            std::env::var("ASTRA_TEST_DB_IT").as_deref(),
+            Ok("1"),
+            "set ASTRA_TEST_DB_IT=1 for the real connection test"
+        );
+        let mut settings = MatrixOneSettings::from_env();
+        settings.database = std::env::var("ASTRA_DATABASE_BOOTSTRAP_CATALOG")
+            .unwrap_or_else(|_| "mysql".to_string());
+        settings.db_pool_max_connections = 1;
+        settings.db_pool_min_connections = 0;
+        let pool = BootstrapPool::new(
+            connect_matrixone(&settings)
+                .await
+                .expect("connect a real one-slot bootstrap pool"),
+            1,
+        );
+        let mut checked_out = pool
+            .pool()
+            .acquire()
+            .await
+            .expect("check out the real connection");
+        let connection_id: u64 = sqlx::query_scalar("SELECT CONNECTION_ID()")
+            .fetch_one(&mut *checked_out)
+            .await
+            .expect("read the checked-out server connection id");
+        let observer = sqlx::mysql::MySqlPoolOptions::new()
+            .max_connections(1)
+            .connect(&settings.database_url_with_password())
+            .await
+            .expect("connect an independent server-side observer");
+
+        let started = tokio::time::Instant::now();
+        let release = tokio::spawn(pool.release());
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(
+            !release.is_finished(),
+            "teardown must retain the quota while a connection is checked out"
+        );
+        let live_before_return: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM information_schema.PROCESSLIST WHERE conn_id = ?",
+        )
+        .bind(connection_id)
+        .fetch_one(&observer)
+        .await
+        .expect("observe the checked-out server connection");
+        assert_eq!(live_before_return, 1);
+
+        drop(checked_out);
+        release
+            .await
+            .expect("teardown task")
+            .expect("release waits for return, then detaches the socket");
+        let live_after_release: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM information_schema.PROCESSLIST WHERE conn_id = ?",
+        )
+        .bind(connection_id)
+        .fetch_one(&observer)
+        .await
+        .expect("observe server connection teardown");
+
+        assert!(
+            started.elapsed() >= std::time::Duration::from_millis(100),
+            "quota must not be returned while a connection remains checked out"
+        );
+        assert_eq!(
+            live_after_release, 0,
+            "detached socket must be gone server-side"
+        );
+    }
 
     #[tokio::test]
     async fn dropping_schema_lease_cancels_heartbeat_task() {


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

N/A — both failures were diagnosed from production-like MOI traces rather than an existing GitHub issue.

## What this PR does / why we need it

This PR fixes two independent lifecycle failures observed in the MOI/Astra path.

### Preserve compacted canonical turns without weakening commit authority

Long turns can compact the canonical conversation before execution. Canonical commit previously identified rewrites using an observational boolean, which could both miss a valid pre-turn rewrite and authorize an unrelated later mutation.

- Compare the admitted canonical messages exactly before selecting `Append`.
- Introduce an opaque, typed canonical rewrite proof rooted in the admitted canonical root and compaction generation.
- Advance that proof only around explicit runtime-owned compaction mutations.
- Require the resulting proved root before selecting `Replace`; unrelated prefix mutations remain fail-closed.
- Keep `context_compression_triggered` observational only.
- Add regressions for valid replacement, unexplained shrinkage, mutation before compaction, and mutation after compaction.

### Drain MatrixOne bootstrap pools before releasing quota

Schema bootstrap creates short-lived SQLx pools. MatrixOne does not complete SQLx's graceful MySQL shutdown handshake, while draining only immediately-idle connections can return Astra's global quota before checked-out sockets are gone.

- Keep the short-lived pool behind a private `BootstrapPool` owner; no public `Deref` or clonable wrapper is exposed.
- On teardown, wait for checked-out connections to return, detach and close every socket, then release the global quota.
- If teardown fails with live connections, retain the reservation rather than reporting false capacity.
- Route database creation, schema lease/bootstrap, and visibility probes through the same owner operation.
- Add an ignored real-MatrixOne test that checks a real checked-out connection remains visible in `information_schema.PROCESSLIST` while teardown waits and disappears after release completes.

## Architecture and complexity delta

- Canonical rewrite authority remains internal to the runtime; external loop hosts can only construct an empty opaque state.
- Canonical hashing reuses the existing `canonical_conversation_root` implementation.
- Bootstrap pool teardown has one private owner in `astra-services`.
- No fallback, timeout workaround, configuration switch, schema change, or compatibility shim was added.
- History remains based on `efaab851a`; no merge-from-main commit is included.

## Verification

- `make format-check`
- `make lint`
- `cargo check -p astra-runtime`
- `cargo check -p astra-services`
- `cargo test -p astra-core connection_quota_tests -- --nocapture` — 13 passed
- `cargo test -p astra-services --lib storage::tests --no-fail-fast` — 25 passed, 1 ignored
- `ASTRA_TEST_DB_IT=1 cargo test -p astra-services --lib bootstrap_pool_release_waits_for_checked_out_connection -- --ignored --nocapture` — passed against real MatrixOne
- `cargo test -p astra-runtime --lib server::run::lifecycle::tests --no-fail-fast` — 325 passed, 15 ignored
- `cargo test -p astra-runtime --lib pre_turn_summary_event_matches_the_applied_state_mutation --no-fail-fast` — passed
- `git diff --check efaab851a..HEAD`

### Stabilize bridge session-state integration test

Bridge observability events are deliberately persisted asynchronously after each SSE response. The MatrixOne integration journey previously waited for at least one row per event type, then compared two separately-read projections while the second turn could still commit its auxiliary rows. The test now waits for the complete two-turn event cardinality before asserting the durable event count and `agent_sessions.event_count` agreement. This preserves the assertion and production behavior; it removes only the test’s temporal read race.

Additional verification:

- `cargo fmt --check --manifest-path crates/runtime/Cargo.toml`
- ignored real-MatrixOne `e2e_matrix_cli_bridge_session_views_remain_consistent` — 21 consecutive passes
