### PR TITLE
fix(storage): release MatrixOne bootstrap pools without shutdown wait

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -174,9 +174,9 @@ fn try_allocate_with_cap(max: u64, cap: u64) -> Result<(), ConnectionQuotaError>
 
 /// Release `max` connections back to the global counter.
 ///
-/// Callers that obtain a pool via [`connect_matrixone`] and later call
-/// `.close()` on it should invoke this immediately after closing so the
-/// quota is recycled.
+/// Callers that obtain a raw pool via [`connect_matrixone`] must invoke this
+/// when the pool is no longer used. Prefer [`DedicatedPool`] for bounded
+/// lifetimes so quota release and MatrixOne socket teardown stay coupled.
 pub fn release_global_connections(max: u64) {
     loop {
         let current = GLOBAL_CONNECTION_ALLOCATED.load(Ordering::Acquire);
@@ -269,6 +269,31 @@ mod connection_quota_tests {
         assert_eq!(GLOBAL_CONNECTION_ALLOCATED.load(Ordering::Acquire), 5);
         assert!(try_allocate_with_cap(5, 10).is_ok());
         assert_eq!(GLOBAL_CONNECTION_ALLOCATED.load(Ordering::Acquire), 10);
+    }
+
+    #[tokio::test]
+    async fn dedicated_pool_release_consumes_pool_and_returns_quota() {
+        let _g = crate::sync_poison::recover_mutex_lock(&TEST_MUTEX);
+        reset_quota();
+        GLOBAL_CONNECTION_ALLOCATED.store(1, Ordering::Release);
+        let settings = MatrixOneSettings {
+            db_pool_max_connections: 1,
+            db_pool_min_connections: 0,
+            ..MatrixOneSettings::default()
+        };
+        let pool = MySqlPoolOptions::new()
+            .max_connections(1)
+            .min_connections(0)
+            .connect_lazy(&settings.database_url_with_password())
+            .expect("lazy pool should not connect");
+
+        DedicatedPool::new(pool, 1).release();
+
+        assert_eq!(
+            GLOBAL_CONNECTION_ALLOCATED.load(Ordering::Acquire),
+            0,
+            "releasing a dedicated pool must return its reserved quota"
+        );
     }
 
     #[test]
@@ -697,10 +722,11 @@ pub async fn connect_matrixone(settings: &MatrixOneSettings) -> Result<Pool<MySq
 /// has a bounded lifetime.  The wrapper calls [`release_global_connections`]
 /// in its [`Drop`] impl so the quota is automatically recycled.
 ///
-/// Call [`DedicatedPool::close`] explicitly before drop to close
-/// connections promptly.  `Drop` is a safety net that releases the
-/// quota counter but cannot `.await` [`Pool::close`][sqlx::Pool::close].
-/// For long-lived pools prefer [`SharedPool`].
+/// Call [`DedicatedPool::release`] when the bounded operation completes.
+/// MatrixOne does not complete SQLx's MySQL shutdown handshake, so dedicated
+/// pools synchronously detach and drop their idle connections instead of
+/// awaiting [`Pool::close`][sqlx::Pool::close]. For long-lived pools prefer
+/// [`SharedPool`].
 pub struct DedicatedPool {
     pub(crate) pool: Pool<MySql>,
     pub(crate) max_connections: u64,
@@ -723,14 +749,16 @@ impl DedicatedPool {
         }
     }
 
-    /// Close the pool and release the global connection quota.
+    /// Close idle sockets, release the global connection quota, and consume the pool.
     ///
-    /// Prefer calling this explicitly before drop to ensure connections
-    /// are released back to the database promptly.  `Drop` is a safety
-    /// net that only releases the quota counter; it cannot `.await`
-    /// [`Pool::close`].
-    pub async fn close(self) {
-        self.pool.close().await;
+    /// SQLx's graceful and hard MySQL close paths both wait for stream shutdown,
+    /// which MatrixOne does not complete. Detaching each idle connection and
+    /// dropping the raw socket closes it immediately without spawning SQLx's
+    /// asynchronous pool-return path.
+    pub fn release(self) {
+        while let Some(connection) = self.pool.try_acquire() {
+            drop(connection.detach());
+        }
         self.release_quota();
     }
 

--- a/crates/services/src/storage.rs
+++ b/crates/services/src/storage.rs
@@ -895,7 +895,7 @@ async fn wait_for_core_schema_visibility(settings: &MatrixOneSettings) -> Result
     loop {
         let verify_pool = DedicatedPool::new(connect_matrixone(&verify_settings).await?, 1);
         let visibility_result = verify_core_schema_visible(&verify_pool, &settings.database).await;
-        verify_pool.close().await;
+        verify_pool.release();
         match visibility_result {
             Ok(CoreSchemaVisibility::Visible) => return Ok(()),
             Ok(CoreSchemaVisibility::Lag(_)) if tokio::time::Instant::now() < deadline => {
@@ -1275,7 +1275,7 @@ async fn ensure_matrixone_database_exists(
         crate::snapshot_sql::quote_mysql_identifier(&settings.database)
     );
     let create_result = query(&ddl).execute(&*admin_pool).await.map(|_| ());
-    admin_pool.close().await;
+    admin_pool.release();
     create_result
 }
 
@@ -2427,15 +2427,15 @@ pub async fn ensure_core_schema(
     let lease_pool = match connect_matrixone(&schema_settings).await {
         Ok(lease_pool) => DedicatedPool::new(lease_pool, 1),
         Err(error) => {
-            pool.close().await;
+            pool.release();
             return Err(error);
         }
     };
     let database_lease = match CoreSchemaDatabaseLease::acquire(&lease_pool).await {
         Ok(lease) => lease,
         Err(error) => {
-            lease_pool.close().await;
-            pool.close().await;
+            lease_pool.release();
+            pool.release();
             return Err(error);
         }
     };
@@ -2443,8 +2443,8 @@ pub async fn ensure_core_schema(
         ensure_core_schema_while_leased(settings, (*pool).clone(), database_lease.holder_id())
             .await;
     let release_result = database_lease.release().await;
-    lease_pool.close().await;
-    pool.close().await;
+    lease_pool.release();
+    pool.release();
     let bootstrap_result = match (schema_result, release_result) {
         (Ok(()), Ok(())) => Ok(()),
         (Err(schema_error), Ok(())) => Err(schema_error),


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

N/A — diagnosed from the Astra 0.0.13 dev rollout, where startup created the configured MatrixOne database but never reached schema bootstrap or opened the HTTP listener.

## What this PR does / why we need it

SQLx 0.8.6 waits for a MySQL stream shutdown handshake in both `Pool::close()` and the raw connection hard-close path. MatrixOne does not complete that handshake, so Astra blocked indefinitely while closing the one-connection administrative pool immediately after `CREATE DATABASE IF NOT EXISTS`.

This PR gives bounded MatrixOne pools one explicit release contract:

- drain idle SQLx pool connections;
- detach and directly drop each raw connection socket, avoiding SQLx's asynchronous return and shutdown-handshake paths;
- return the reserved global connection quota;
- use that owner method at every schema-bootstrap pool boundary.

The change adds no timeout, retry, compatibility path, or fallback. Long-lived runtime pools remain unchanged.

## Architecture and complexity delta

- Canonical owner changed or extended: `astra_core::DedicatedPool` owns bounded pool teardown and quota release.
- Existing implementations/callers searched: all `DedicatedPool::new` construction sites and all explicit dedicated-pool close calls.
- Superseded code, states, tables, shims, and self-only tests removed: the blocking async `DedicatedPool::close` contract is replaced by the synchronous consuming `release` contract.
- Net code/state/table delta: 2 Rust files; no schema, configuration, or persistent-state changes.
- If parallel implementations remain, the external boundary and retirement condition: `SharedPool` remains intentionally separate because it owns long-lived runtime connections rather than bounded bootstrap pools.

## Production wiring and verification

- Public product entrypoint exercised: MatrixOne database creation and core schema bootstrap, the startup path that blocked before Astra opened its listener.
- Unhappy paths exercised: lease-pool connection/acquisition failures continue to release every already-created dedicated pool and preserve the original error.
- Real MatrixOne verification:
  - baseline SQLx `Pool::close().await` did not return within 20 seconds;
  - the production `connect_matrixone` + `DedicatedPool::release` path completed 20 consecutive connect/query/release cycles in 8.57 seconds without exhausting connections;
  - a full fresh-catalog bootstrap progressed past the repaired pool-shutdown boundary; on the shared remote test cluster its 174-second DDL run hit the existing 30-second schema-lease expiry, which is independent of this PR.
- Verification:
  - `cargo test -p astra-core connection_quota_tests -- --nocapture`
  - `cargo test -p astra-services storage:: --lib`
  - `make lint`
  - `make format-check`
  - `git diff --check`

