### PR TITLE
fix(sessions): fence event writes during deletion

### DIFF
--- a/crates/astra-cli/src/cli/cloud_sync.rs
+++ b/crates/astra-cli/src/cli/cloud_sync.rs
@@ -16,7 +16,8 @@ use astra_services::session_journal;
 use astra_services::state_sync::pref_keys;
 use astra_services::{
     SyncOutboxDeliverySettlement, SyncOutboxJournalDelta, SyncOutboxJournalDeltaOutcome,
-    SyncOutboxRecord, SyncOutboxSettlementReport, SyncOutboxStatus, SyncOutboxStore,
+    SyncOutboxPoisonKind, SyncOutboxRecord, SyncOutboxSettlementReport, SyncOutboxStatus,
+    SyncOutboxStore,
 };
 use astra_turn_core::tool_health_persistence::ToolHealthEntry;
 use serde_json::{Value, json};
@@ -1210,15 +1211,38 @@ async fn try_drain_sync_outbox_for_snapshot(
             client.post_sync_outbox_event_json(Some(token.as_str()), &body),
         )
         .await;
+        let mut terminal_rejection = None;
         let delivery_error = match delivery {
             Ok(Ok(ack)) if ack.confirms(&record.record_id, &record.payload_hash) => None,
             Ok(Ok(ack)) => Some(format!("cloud returned an uncorrelated sync ack: {ack:?}")),
-            Ok(Err(error)) => Some(error.to_string()),
+            Ok(Err(error)) => {
+                terminal_rejection = terminal_sync_outbox_rejection(&error);
+                Some(error.to_string())
+            }
             Err(_) => Some(format!(
                 "cloud event delivery timed out after {}ms",
                 SYNC_OUTBOX_RECORD_DELIVERY_TIMEOUT.as_millis()
             )),
         };
+        // A cloud session that was deleted can never accept this record, so it
+        // is parked with its reason instead of burning the retry budget and
+        // landing in retry-exhausted poison that repair would re-queue forever.
+        if let Some((kind, reason)) = terminal_rejection {
+            tracing::warn!(
+                target: "astra_cli::cloud_sync",
+                record_id = %record.record_id,
+                session_id = %record.session_id,
+                ?kind,
+                %reason,
+                "sync outbox record rejected terminally by cloud"
+            );
+            settlements.push(SyncOutboxDeliverySettlement::Rejected {
+                record_id: record.record_id,
+                kind,
+                reason,
+            });
+            continue;
+        }
         let delivery_confirmed = delivery_error.is_none()
             || reconcile_sync_outbox_delivery(&client, &token, &record).await;
         if delivery_confirmed {
@@ -1302,6 +1326,29 @@ fn unix_ms() -> Option<u64> {
             );
             None
         }
+    }
+}
+
+/// Classify a delivery failure that no retry can resolve.
+///
+/// The decision reads the machine-owned `error_code` from the JSON error body,
+/// never the human-facing prose, so wording changes on the server cannot flip
+/// an outbox record between retryable and terminal.
+fn terminal_sync_outbox_rejection(
+    error: &astra_thin_client::ThinClientError,
+) -> Option<(SyncOutboxPoisonKind, String)> {
+    let astra_thin_client::ThinClientError::Api { status, body } = error else {
+        return None;
+    };
+    if status.as_u16() != 409 {
+        return None;
+    }
+    let parsed: astra_core::ErrorResponse = serde_json::from_str(body).ok()?;
+    let error_code = parsed.error_code.as_deref()?;
+    if error_code == astra_core::ERROR_CODE_SESSION_DELETED {
+        Some((SyncOutboxPoisonKind::SessionDeletedUpstream, parsed.detail))
+    } else {
+        None
     }
 }
 
@@ -1524,11 +1571,60 @@ mod tests {
         reconcile_sync_outbox_journal, record_settlement_result,
         release_sync_outbox_drain_schedule, release_sync_outbox_retry_wake_schedule,
         run_sync_outbox_io, schedule_sync_outbox_journal_ingestion,
-        should_append_cloud_pull_journal, try_claim_sync_outbox_drain_schedule,
+        should_append_cloud_pull_journal, terminal_sync_outbox_rejection,
+        try_claim_sync_outbox_drain_schedule,
     };
     use astra_services::session_journal::{JournalEvent, JournalWriter, ProcessJournalDirGuard};
-    use astra_services::{SyncOutboxSettlementReport, SyncOutboxStatus, SyncOutboxStore};
+    use astra_services::{
+        SyncOutboxPoisonKind, SyncOutboxSettlementReport, SyncOutboxStatus, SyncOutboxStore,
+    };
     use fs2::FileExt;
+
+    fn api_error(status: u16, body: &str) -> astra_thin_client::ThinClientError {
+        astra_thin_client::ThinClientError::Api {
+            status: reqwest::StatusCode::from_u16(status).expect("status"),
+            body: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn only_the_deleted_session_error_code_parks_a_record_terminally() {
+        let deleted = api_error(
+            409,
+            r#"{"detail":"Session s-1 was deleted","error_code":"SESSION_DELETED"}"#,
+        );
+        let (kind, reason) =
+            terminal_sync_outbox_rejection(&deleted).expect("deleted session must be terminal");
+        assert_eq!(kind, SyncOutboxPoisonKind::SessionDeletedUpstream);
+        assert_eq!(reason, "Session s-1 was deleted");
+
+        // Still deleting, owned elsewhere, or a transient fault: all retryable.
+        for retryable in [
+            api_error(
+                409,
+                r#"{"detail":"Session s-1 is being deleted","error_code":"SESSION_DELETING"}"#,
+            ),
+            api_error(
+                409,
+                r#"{"detail":"lost a race","error_code":"SESSION_WRITE_CONFLICT"}"#,
+            ),
+            api_error(503, r#"{"detail":"Session s-1 was deleted"}"#),
+            // Prose alone must never decide: only the typed code does.
+            api_error(409, r#"{"detail":"Session s-1 was deleted"}"#),
+            api_error(409, "not json"),
+        ] {
+            assert!(
+                terminal_sync_outbox_rejection(&retryable).is_none(),
+                "must stay retryable: {retryable:?}"
+            );
+        }
+
+        assert!(
+            terminal_sync_outbox_rejection(&astra_thin_client::ThinClientError::InvalidAuthHeader)
+                .is_none(),
+            "transport-shaped errors carry no cloud verdict"
+        );
+    }
 
     #[test]
     fn journal_ingest_retry_budget_quarantines_and_success_resets() {

--- a/crates/astra-cli/src/cli/slash/slash_sync.rs
+++ b/crates/astra-cli/src/cli/slash/slash_sync.rs
@@ -60,6 +60,9 @@ pub(crate) async fn handle_sync_command(arg: &str, _state: &SessionState) {
                 cli_dim!(
                     "Payload hash mismatch records remain poisoned until the conflicting source is inspected."
                 );
+                cli_dim!(
+                    "Records for sessions deleted in the cloud stay poisoned by design; no retry can deliver them."
+                );
                 if !report.cloud_configured {
                     cli_dim!("ASTRA_API_URL is not configured; records remain durable locally.");
                 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -829,6 +829,17 @@ impl ErrorResponse {
     }
 }
 
+/// Session-scoped write was refused because deletion intent is already
+/// persisted for a session row that still exists.
+pub const ERROR_CODE_SESSION_DELETING: &str = "SESSION_DELETING";
+/// Session-scoped write was refused because the session was hard-deleted and a
+/// deletion fence forbids recreating it. Terminal: retrying can never succeed.
+pub const ERROR_CODE_SESSION_DELETED: &str = "SESSION_DELETED";
+/// `session_id` exists under a different owner.
+pub const ERROR_CODE_SESSION_FOREIGN_OWNER: &str = "SESSION_FOREIGN_OWNER";
+/// Session-scoped write lost a race against a concurrent writer; retryable.
+pub const ERROR_CODE_SESSION_WRITE_CONFLICT: &str = "SESSION_WRITE_CONFLICT";
+
 pub fn error_response(
     status: StatusCode,
     detail: impl Into<String>,

--- a/crates/services/src/events.rs
+++ b/crates/services/src/events.rs
@@ -12,7 +12,8 @@ use astra_core::{
 use crate::db_row::RowExt as EventDbRow;
 use crate::pagination::MAX_API_LIST_LIMIT;
 use crate::storage::{
-    add_agent_session_event_count_or_create, agent_session_exists_for_user,
+    add_agent_session_event_count_or_create, agent_session_accepts_events_for_user,
+    agent_session_deletion_fence_exists_for_user, agent_session_exists_for_user,
     bump_agent_session_event_count,
 };
 use crate::sync_outbox::{sync_outbox_canonical_payload_hash, sync_outbox_stable_event_id};
@@ -1040,10 +1041,10 @@ async fn ensure_event_session_requirement(
     if sync_outbox_ingestion {
         return ensure_sync_event_session_header(tx, session_id, user_id).await;
     }
-    let exists = agent_session_exists_for_user(&mut **tx, session_id, user_id)
+    let writable = agent_session_accepts_events_for_user(&mut **tx, session_id, user_id)
         .await
         .map_err(internal_error)?;
-    if exists {
+    if writable {
         Ok(())
     } else {
         Err(error_response(
@@ -1061,11 +1062,28 @@ async fn ensure_sync_event_session_header(
     match add_agent_session_event_count_or_create(&mut **tx, session_id, user_id, 0, None).await {
         Ok(()) => Ok(()),
         Err(sqlx::Error::RowNotFound) => {
+            let writable = agent_session_accepts_events_for_user(&mut **tx, session_id, user_id)
+                .await
+                .map_err(internal_error)?;
+            if writable {
+                return Ok(());
+            }
             let exists = agent_session_exists_for_user(&mut **tx, session_id, user_id)
                 .await
                 .map_err(internal_error)?;
             if exists {
-                Ok(())
+                Err(error_response(
+                    StatusCode::CONFLICT,
+                    format!("Session {session_id} is being deleted"),
+                ))
+            } else if agent_session_deletion_fence_exists_for_user(&mut **tx, session_id, user_id)
+                .await
+                .map_err(internal_error)?
+            {
+                Err(error_response(
+                    StatusCode::CONFLICT,
+                    format!("Session {session_id} was deleted"),
+                ))
             } else {
                 Err(error_response(
                     StatusCode::CONFLICT,

--- a/crates/services/src/events.rs
+++ b/crates/services/src/events.rs
@@ -5,16 +5,16 @@ use sqlx::{Acquire, MySql, QueryBuilder, Row, query};
 use uuid::Uuid;
 
 use astra_core::{
-    ErrorResponse, MatrixOneSettings, SharedPool, error_response, internal_error,
-    is_duplicate_key_error,
+    ERROR_CODE_SESSION_DELETED, ERROR_CODE_SESSION_DELETING, ERROR_CODE_SESSION_FOREIGN_OWNER,
+    ERROR_CODE_SESSION_WRITE_CONFLICT, ErrorResponse, MatrixOneSettings, SharedPool,
+    error_response, error_response_coded, internal_error, is_duplicate_key_error,
 };
 
 use crate::db_row::RowExt as EventDbRow;
 use crate::pagination::MAX_API_LIST_LIMIT;
 use crate::storage::{
-    add_agent_session_event_count_or_create, agent_session_accepts_events_for_user,
-    agent_session_deletion_fence_exists_for_user, agent_session_exists_for_user,
-    bump_agent_session_event_count,
+    SessionWriteAdmission, add_agent_session_event_count_or_create, bump_agent_session_event_count,
+    classify_session_write_admission,
 };
 use crate::sync_outbox::{sync_outbox_canonical_payload_hash, sync_outbox_stable_event_id};
 use astra_core::canonical_names::{
@@ -758,15 +758,18 @@ impl EventService for DatabaseEventService {
         let event_count_delta =
             crate::storage::rows_affected_to_i64(insert_result.rows_affected(), "create_event")
                 .map_err(internal_error)?;
-        bump_agent_session_event_count(
+        // Deletion can win between the admission check above and this write.
+        // That is a refused write, not an internal fault, so the caller learns
+        // the session is going away instead of seeing a 500.
+        let summary_write = bump_agent_session_event_count(
             &mut *tx,
             &session_id,
             &user_id,
             event_count_delta,
             Some(&event_id),
         )
-        .await
-        .map_err(internal_error)?;
+        .await;
+        map_session_summary_write(&mut tx, &session_id, &user_id, summary_write).await?;
 
         let select_sql = format!(
             "SELECT {} FROM agent_events WHERE event_id = ? AND user_id = ?",
@@ -1022,13 +1025,82 @@ impl EventService for DatabaseEventService {
             .await
             .map_err(internal_error)?;
         if delete_result.rows_affected() > 0 {
-            bump_agent_session_event_count(&mut *tx, &record.session_id, &user_id, -1, None)
-                .await
-                .map_err(internal_error)?;
+            let summary_write =
+                bump_agent_session_event_count(&mut *tx, &record.session_id, &user_id, -1, None)
+                    .await;
+            map_session_summary_write(&mut tx, &record.session_id, &user_id, summary_write).await?;
         }
         tx.commit().await.map_err(internal_error)?;
 
         Ok(())
+    }
+}
+
+/// Map a refused session write onto the owner-visible boundary error.
+///
+/// `Writable` means the refusal did not come from session state (a concurrent
+/// writer took the row): retryable conflict, not an internal fault.
+fn session_write_rejection(
+    admission: SessionWriteAdmission,
+    session_id: &str,
+) -> (StatusCode, Json<ErrorResponse>) {
+    match admission {
+        SessionWriteAdmission::Deleting => error_response_coded(
+            StatusCode::CONFLICT,
+            format!("Session {session_id} is being deleted"),
+            ERROR_CODE_SESSION_DELETING,
+        ),
+        SessionWriteAdmission::Fenced => error_response_coded(
+            StatusCode::CONFLICT,
+            format!("Session {session_id} was deleted"),
+            ERROR_CODE_SESSION_DELETED,
+        ),
+        SessionWriteAdmission::ForeignOwner => error_response_coded(
+            StatusCode::CONFLICT,
+            format!("session_id {session_id} is owned by another user"),
+            ERROR_CODE_SESSION_FOREIGN_OWNER,
+        ),
+        SessionWriteAdmission::Missing => error_response(
+            StatusCode::NOT_FOUND,
+            format!("Session {session_id} not found"),
+        ),
+        SessionWriteAdmission::Writable => error_response_coded(
+            StatusCode::CONFLICT,
+            format!("Session {session_id} write lost a concurrent race; retry"),
+            ERROR_CODE_SESSION_WRITE_CONFLICT,
+        ),
+    }
+}
+
+/// Resolve why a session summary write was refused and turn it into a boundary
+/// error. Only call this after a helper signalled [`sqlx::Error::RowNotFound`].
+async fn reject_refused_session_write(
+    tx: &mut sqlx::Transaction<'_, MySql>,
+    session_id: &str,
+    user_id: &str,
+) -> (StatusCode, Json<ErrorResponse>) {
+    match classify_session_write_admission(tx, session_id, user_id).await {
+        Ok(admission) => session_write_rejection(admission, session_id),
+        Err(error) => internal_error(format!(
+            "session {session_id} write refusal could not be classified: {error}"
+        )),
+    }
+}
+
+/// Map a session summary write result, classifying refusals instead of
+/// surfacing them as internal faults.
+async fn map_session_summary_write(
+    tx: &mut sqlx::Transaction<'_, MySql>,
+    session_id: &str,
+    user_id: &str,
+    result: Result<(), sqlx::Error>,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(sqlx::Error::RowNotFound) => {
+            Err(reject_refused_session_write(tx, session_id, user_id).await)
+        }
+        Err(error) => Err(internal_error(error)),
     }
 }
 
@@ -1041,16 +1113,18 @@ async fn ensure_event_session_requirement(
     if sync_outbox_ingestion {
         return ensure_sync_event_session_header(tx, session_id, user_id).await;
     }
-    let writable = agent_session_accepts_events_for_user(&mut **tx, session_id, user_id)
+    let admission = classify_session_write_admission(tx, session_id, user_id)
         .await
         .map_err(internal_error)?;
-    if writable {
-        Ok(())
-    } else {
-        Err(error_response(
+    match admission {
+        SessionWriteAdmission::Writable => Ok(()),
+        // A session id owned by somebody else must stay indistinguishable from
+        // one that never existed on this non-sync path.
+        SessionWriteAdmission::ForeignOwner => Err(error_response(
             StatusCode::NOT_FOUND,
-            format!("Session {} not found", session_id),
-        ))
+            format!("Session {session_id} not found"),
+        )),
+        rejected => Err(session_write_rejection(rejected, session_id)),
     }
 }
 
@@ -1062,34 +1136,24 @@ async fn ensure_sync_event_session_header(
     match add_agent_session_event_count_or_create(&mut **tx, session_id, user_id, 0, None).await {
         Ok(()) => Ok(()),
         Err(sqlx::Error::RowNotFound) => {
-            let writable = agent_session_accepts_events_for_user(&mut **tx, session_id, user_id)
+            // A no-op upsert also reports zero rows for a live session whose
+            // summary already holds these values, so writability decides.
+            let admission = classify_session_write_admission(tx, session_id, user_id)
                 .await
                 .map_err(internal_error)?;
-            if writable {
+            if admission.is_writable() {
                 return Ok(());
             }
-            let exists = agent_session_exists_for_user(&mut **tx, session_id, user_id)
-                .await
-                .map_err(internal_error)?;
-            if exists {
-                Err(error_response(
+            // This path creates the header on demand, so "no row anywhere" is a
+            // lost race rather than a missing session: keep it retryable.
+            if admission == SessionWriteAdmission::Missing {
+                return Err(error_response_coded(
                     StatusCode::CONFLICT,
-                    format!("Session {session_id} is being deleted"),
-                ))
-            } else if agent_session_deletion_fence_exists_for_user(&mut **tx, session_id, user_id)
-                .await
-                .map_err(internal_error)?
-            {
-                Err(error_response(
-                    StatusCode::CONFLICT,
-                    format!("Session {session_id} was deleted"),
-                ))
-            } else {
-                Err(error_response(
-                    StatusCode::CONFLICT,
-                    format!("session_id {session_id} is owned by another user"),
-                ))
+                    format!("Session {session_id} header could not be created; retry"),
+                    ERROR_CODE_SESSION_WRITE_CONFLICT,
+                ));
             }
+            Err(session_write_rejection(admission, session_id))
         }
         Err(error) => Err(internal_error(error)),
     }
@@ -1125,10 +1189,12 @@ async fn repair_sync_event_session_summary(
         .as_ref()
         .map(|row| event_row_string(row, "event_id"))
         .transpose()?;
-    query(
+    // Same deletion fence as every other session summary writer: a replayed
+    // sync event must not rewrite the summary of a session that is going away.
+    let result = query(
         "UPDATE agent_sessions \
          SET event_count = ?, last_event_id = ?, updated_at = NOW(6), last_active_at = NOW(6) \
-         WHERE session_id = ? AND user_id = ?",
+         WHERE session_id = ? AND user_id = ? AND status <> 'deleting'",
     )
     .bind(event_count)
     .bind(last_event_id)
@@ -1137,6 +1203,14 @@ async fn repair_sync_event_session_summary(
     .execute(&mut **tx)
     .await
     .map_err(internal_error)?;
+    if result.rows_affected() == 0 {
+        let admission = classify_session_write_admission(tx, session_id, user_id)
+            .await
+            .map_err(internal_error)?;
+        if !admission.is_writable() {
+            return Err(session_write_rejection(admission, session_id));
+        }
+    }
     Ok(())
 }
 
@@ -1348,6 +1422,64 @@ impl From<EventListRecord> for EventListResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- session write rejection ---
+
+    #[test]
+    fn refused_session_writes_are_reported_as_typed_client_errors() {
+        // A refused write is a fact about session state, never an internal
+        // fault: deletion races must stay 4xx with a machine-readable code so
+        // clients can tell "retry later" from "never again".
+        for (admission, expected_status, expected_code) in [
+            (
+                SessionWriteAdmission::Deleting,
+                StatusCode::CONFLICT,
+                Some(ERROR_CODE_SESSION_DELETING),
+            ),
+            (
+                SessionWriteAdmission::Fenced,
+                StatusCode::CONFLICT,
+                Some(ERROR_CODE_SESSION_DELETED),
+            ),
+            (
+                SessionWriteAdmission::ForeignOwner,
+                StatusCode::CONFLICT,
+                Some(ERROR_CODE_SESSION_FOREIGN_OWNER),
+            ),
+            (
+                SessionWriteAdmission::Writable,
+                StatusCode::CONFLICT,
+                Some(ERROR_CODE_SESSION_WRITE_CONFLICT),
+            ),
+            (SessionWriteAdmission::Missing, StatusCode::NOT_FOUND, None),
+        ] {
+            let (status, body) = session_write_rejection(admission, "session-1");
+            assert_eq!(status, expected_status, "{admission:?} status");
+            assert_eq!(
+                body.0.error_code.as_deref(),
+                expected_code,
+                "{admission:?} error code"
+            );
+            assert!(
+                body.0.detail.contains("session-1"),
+                "{admission:?} detail must name the session: {}",
+                body.0.detail
+            );
+        }
+    }
+
+    #[test]
+    fn only_a_live_owner_session_admits_writes() {
+        assert!(SessionWriteAdmission::Writable.is_writable());
+        for refused in [
+            SessionWriteAdmission::Deleting,
+            SessionWriteAdmission::Fenced,
+            SessionWriteAdmission::ForeignOwner,
+            SessionWriteAdmission::Missing,
+        ] {
+            assert!(!refused.is_writable(), "{refused:?} must not admit writes");
+        }
+    }
 
     // --- metadata_tool_name ---
 

--- a/crates/services/src/events.rs
+++ b/crates/services/src/events.rs
@@ -1159,6 +1159,10 @@ async fn ensure_sync_event_session_header(
     }
 }
 
+pub(crate) const REPAIR_SYNC_EVENT_SESSION_SUMMARY_SQL: &str = "UPDATE agent_sessions \
+     SET event_count = ?, last_event_id = ?, updated_at = NOW(6), last_active_at = NOW(6) \
+     WHERE session_id = ? AND user_id = ? AND status <> 'deleting'";
+
 async fn repair_sync_event_session_summary(
     tx: &mut sqlx::Transaction<'_, MySql>,
     session_id: &str,
@@ -1191,18 +1195,14 @@ async fn repair_sync_event_session_summary(
         .transpose()?;
     // Same deletion fence as every other session summary writer: a replayed
     // sync event must not rewrite the summary of a session that is going away.
-    let result = query(
-        "UPDATE agent_sessions \
-         SET event_count = ?, last_event_id = ?, updated_at = NOW(6), last_active_at = NOW(6) \
-         WHERE session_id = ? AND user_id = ? AND status <> 'deleting'",
-    )
-    .bind(event_count)
-    .bind(last_event_id)
-    .bind(session_id)
-    .bind(user_id)
-    .execute(&mut **tx)
-    .await
-    .map_err(internal_error)?;
+    let result = query(REPAIR_SYNC_EVENT_SESSION_SUMMARY_SQL)
+        .bind(event_count)
+        .bind(last_event_id)
+        .bind(session_id)
+        .bind(user_id)
+        .execute(&mut **tx)
+        .await
+        .map_err(internal_error)?;
     if result.rows_affected() == 0 {
         let admission = classify_session_write_admission(tx, session_id, user_id)
             .await

--- a/crates/services/src/session_lifecycle.rs
+++ b/crates/services/src/session_lifecycle.rs
@@ -1074,6 +1074,30 @@ pub(crate) struct SessionHardDeleteOutcome {
     pub cleanup_errors: Vec<String>,
 }
 
+/// Persist the owner-scoped deletion fence.
+///
+/// The fence outlives the session row: it is what stops a delayed create-or-
+/// update writer from resurrecting a session after the row is gone. It is
+/// therefore written in the same transaction that records deletion intent, and
+/// only a completed deletion (or the reaper's retention prune) retires it.
+async fn persist_session_deletion_fence(
+    tx: &mut sqlx::Transaction<'_, MySql>,
+    session_id: &str,
+    user_id: &str,
+) -> Result<(), String> {
+    query(
+        "INSERT INTO agent_session_deletion_fences (user_id, session_id, deleted_at) \
+         VALUES (?, ?, CURRENT_TIMESTAMP(6)) \
+         ON DUPLICATE KEY UPDATE deleted_at = deleted_at",
+    )
+    .bind(user_id)
+    .bind(session_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(|source| format!("delete_session.mark_deleting.fence: {source}"))?;
+    Ok(())
+}
+
 async fn mark_session_deleting(
     pool: &Pool<MySql>,
     session_id: &str,
@@ -1106,19 +1130,11 @@ async fn mark_session_deleting(
                 .map_err(|source| format!("delete_session.mark_deleting.confirm: {source}"))?
                 .is_some();
         if still_exists {
-            query(
-                "INSERT INTO agent_session_deletion_fences (user_id, session_id, deleted_at) \
-                 VALUES (?, ?, CURRENT_TIMESTAMP(6)) \
-                 ON DUPLICATE KEY UPDATE deleted_at = deleted_at",
-            )
-            .bind(user_id)
-            .bind(session_id)
-            .execute(&mut *tx)
-            .await
-            .map_err(|source| format!("delete_session.mark_deleting.fence: {source}"))?;
+            persist_session_deletion_fence(&mut tx, session_id, user_id).await?;
             tx.commit()
                 .await
                 .map_err(|source| format!("delete_session.mark_deleting.commit: {source}"))?;
+            log_session_deletion_fence_persisted(session_id, user_id);
             return Ok(());
         }
         return Err(
@@ -1126,22 +1142,66 @@ async fn mark_session_deleting(
         );
     }
 
-    query(
-        "INSERT INTO agent_session_deletion_fences (user_id, session_id, deleted_at) \
-         VALUES (?, ?, CURRENT_TIMESTAMP(6)) \
-         ON DUPLICATE KEY UPDATE deleted_at = deleted_at",
-    )
-    .bind(user_id)
-    .bind(session_id)
-    .execute(&mut *tx)
-    .await
-    .map_err(|source| format!("delete_session.mark_deleting.fence: {source}"))?;
+    persist_session_deletion_fence(&mut tx, session_id, user_id).await?;
 
     tx.commit()
         .await
         .map_err(|source| format!("delete_session.mark_deleting.commit: {source}"))?;
+    log_session_deletion_fence_persisted(session_id, user_id);
 
     Ok(())
+}
+
+const SESSION_DELETION_FENCE_PRUNE_SQL: &str = "DELETE FROM agent_session_deletion_fences \
+     WHERE deleted_at < DATE_SUB(NOW(6), INTERVAL ? DAY) \
+       AND NOT EXISTS ( \
+           SELECT 1 FROM agent_sessions \
+           WHERE agent_sessions.user_id = agent_session_deletion_fences.user_id \
+             AND agent_sessions.session_id = agent_session_deletion_fences.session_id \
+       ) \
+     LIMIT ?";
+
+/// Retire deletion fences that have outlived the delayed writers they fence.
+///
+/// Every hard delete — including the reaper's own retention sweeps — leaves a
+/// fence behind, so without this prune the tombstone table grows to one row per
+/// session ever created while sitting on the session write path. A fence only
+/// has to outlive the writers that could still arrive for a deleted session, so
+/// it is retired once `retention_days` have passed and no session row exists
+/// for that owner/session; a session still stuck in `deleting` keeps its fence
+/// (and a later delete retry re-persists it either way).
+pub(crate) async fn prune_expired_session_deletion_fences(
+    pool: &Pool<MySql>,
+    retention_days: u32,
+    batch_limit: u32,
+) -> Result<u64, String> {
+    if retention_days == 0 || batch_limit == 0 {
+        return Ok(0);
+    }
+    // One bounded batch per sweep, like the reaper's other steps: a backlog
+    // drains across sweeps instead of holding this one open.
+    query(SESSION_DELETION_FENCE_PRUNE_SQL)
+        .bind(i64::from(retention_days))
+        .bind(batch_limit)
+        .execute(pool)
+        .await
+        .map(|result| result.rows_affected())
+        .map_err(|source| format!("session_reaper.prune_session_deletion_fences: {source}"))
+}
+
+/// Record that the fence is now authoritative.
+///
+/// After this point every session write is refused, including when the
+/// destructive pass below fails and leaves the row in `deleting`: the reaper
+/// retries such sessions, and until it succeeds this log line is what explains
+/// why writers are being turned away.
+fn log_session_deletion_fence_persisted(session_id: &str, user_id: &str) {
+    tracing::info!(
+        target: "astra_services::session_lifecycle",
+        %session_id,
+        %user_id,
+        "session deletion fence persisted; session writes are now refused"
+    );
 }
 
 pub(crate) async fn hard_delete_session(
@@ -1317,6 +1377,46 @@ mod tests {
                 "unsafe workspace id must not be sanitized into another deletable path: {unsafe_id:?}"
             );
         }
+    }
+
+    #[test]
+    fn deletion_fence_prune_keeps_fences_that_still_guard_a_session() {
+        let normalized = SESSION_DELETION_FENCE_PRUNE_SQL
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(
+            normalized.contains("deleted_at < DATE_SUB(NOW(6), INTERVAL ? DAY)"),
+            "fence prune must be bounded by an explicit retention window: {normalized}"
+        );
+        assert!(
+            normalized.contains("NOT EXISTS ( SELECT 1 FROM agent_sessions"),
+            "fence prune must keep fences whose session row still exists: {normalized}"
+        );
+        assert!(
+            normalized.ends_with("LIMIT ?"),
+            "fence prune must stay bounded per sweep: {normalized}"
+        );
+    }
+
+    #[tokio::test]
+    async fn deletion_fence_prune_is_disabled_by_a_zero_retention_window() {
+        // A zero window would otherwise retire fences the instant they are
+        // written, which is exactly when delayed writers still show up.
+        let pool =
+            sqlx::Pool::<MySql>::connect_lazy("mysql://unreachable-host/astra").expect("lazy pool");
+
+        assert_eq!(
+            prune_expired_session_deletion_fences(&pool, 0, 500).await,
+            Ok(0),
+            "zero retention must skip the prune without touching the database"
+        );
+        assert_eq!(
+            prune_expired_session_deletion_fences(&pool, 30, 0).await,
+            Ok(0),
+            "zero batch limit must skip the prune without touching the database"
+        );
     }
 
     #[test]

--- a/crates/services/src/session_lifecycle.rs
+++ b/crates/services/src/session_lifecycle.rs
@@ -1079,6 +1079,10 @@ async fn mark_session_deleting(
     session_id: &str,
     user_id: &str,
 ) -> Result<(), String> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|source| format!("delete_session.mark_deleting.begin: {source}"))?;
     let result = query(
         "UPDATE agent_sessions \
          SET status = 'deleting', \
@@ -1088,7 +1092,7 @@ async fn mark_session_deleting(
     )
     .bind(session_id)
     .bind(user_id)
-    .execute(pool)
+    .execute(&mut *tx)
     .await
     .map_err(|source| format!("delete_session.mark_deleting: {source}"))?;
 
@@ -1097,17 +1101,45 @@ async fn mark_session_deleting(
             query("SELECT 1 FROM agent_sessions WHERE session_id = ? AND user_id = ? LIMIT 1")
                 .bind(session_id)
                 .bind(user_id)
-                .fetch_optional(pool)
+                .fetch_optional(&mut *tx)
                 .await
                 .map_err(|source| format!("delete_session.mark_deleting.confirm: {source}"))?
                 .is_some();
         if still_exists {
+            query(
+                "INSERT INTO agent_session_deletion_fences (user_id, session_id, deleted_at) \
+                 VALUES (?, ?, CURRENT_TIMESTAMP(6)) \
+                 ON DUPLICATE KEY UPDATE deleted_at = deleted_at",
+            )
+            .bind(user_id)
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|source| format!("delete_session.mark_deleting.fence: {source}"))?;
+            tx.commit()
+                .await
+                .map_err(|source| format!("delete_session.mark_deleting.commit: {source}"))?;
             return Ok(());
         }
         return Err(
             "delete_session.mark_deleting: session not found or not owned by user".to_string(),
         );
     }
+
+    query(
+        "INSERT INTO agent_session_deletion_fences (user_id, session_id, deleted_at) \
+         VALUES (?, ?, CURRENT_TIMESTAMP(6)) \
+         ON DUPLICATE KEY UPDATE deleted_at = deleted_at",
+    )
+    .bind(user_id)
+    .bind(session_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|source| format!("delete_session.mark_deleting.fence: {source}"))?;
+
+    tx.commit()
+        .await
+        .map_err(|source| format!("delete_session.mark_deleting.commit: {source}"))?;
 
     Ok(())
 }

--- a/crates/services/src/session_reaper.rs
+++ b/crates/services/src/session_reaper.rs
@@ -9,7 +9,9 @@
 
 use std::{collections::BTreeMap, time::Duration};
 
-use crate::session_lifecycle::{SessionTableDeleteOutcome, hard_delete_session};
+use crate::session_lifecycle::{
+    SessionTableDeleteOutcome, hard_delete_session, prune_expired_session_deletion_fences,
+};
 use sqlx::Pool;
 use sqlx::mysql::MySql;
 
@@ -22,6 +24,12 @@ pub struct SessionReaperPolicy {
     pub end_after_idle_secs: u64,
     /// Days after `ended_at` before deleting the row (default: 1 day).
     pub delete_after_ended_days: u32,
+    /// Days a session deletion fence is kept after the session row is gone
+    /// (default: 30 days). The fence must outlive every delayed writer that
+    /// could still arrive for a deleted session — in practice the local sync
+    /// outbox retention — but not longer, or the tombstone table grows to one
+    /// row per session ever created. Set to 0 to disable the prune.
+    pub deletion_fence_retention_days: u32,
     /// Maximum rows to mutate per sweep (prevents lock contention).
     pub batch_limit: u32,
 }
@@ -29,9 +37,10 @@ pub struct SessionReaperPolicy {
 impl Default for SessionReaperPolicy {
     fn default() -> Self {
         Self {
-            idle_after_secs: 30 * 60,      // 30 minutes
-            end_after_idle_secs: 2 * 3600, // 2 hours
-            delete_after_ended_days: 1,    // 1 day
+            idle_after_secs: 30 * 60,          // 30 minutes
+            end_after_idle_secs: 2 * 3600,     // 2 hours
+            delete_after_ended_days: 1,        // 1 day
+            deletion_fence_retention_days: 30, // 30 days
             batch_limit: 500,
         }
     }
@@ -46,6 +55,8 @@ pub struct ReaperSweepResult {
     pub marked_ended: u64,
     /// Ended session rows deleted.
     pub deleted: u64,
+    /// Expired session deletion fences retired past their retention window.
+    pub deletion_fences_pruned: u64,
     /// Expired fork-retention pins released.
     pub expired_fork_pins_released: u64,
     /// Fork records whose child session no longer exists.
@@ -200,6 +211,15 @@ pub async fn reap_sessions(
             }
         }
     }
+
+    // 4. Retire deletion fences left by the deletes above once no delayed
+    //    writer can still arrive for those sessions.
+    result.deletion_fences_pruned = prune_expired_session_deletion_fences(
+        pool,
+        policy.deletion_fence_retention_days,
+        policy.batch_limit,
+    )
+    .await?;
 
     const MODEL_REQUEST_CONTEXT_RETENTION_DAYS: u32 = 30;
     result.model_request_context_events_expired = sqlx::query(

--- a/crates/services/src/storage.rs
+++ b/crates/services/src/storage.rs
@@ -1074,6 +1074,78 @@ where
     Ok(row.is_some())
 }
 
+/// Why a session-scoped write is or is not admitted.
+///
+/// Session write helpers signal refusal with [`sqlx::Error::RowNotFound`],
+/// which cannot distinguish "never existed" from "deletion already won". Every
+/// boundary that has to answer a client (HTTP status, sync settlement) resolves
+/// the reason through this enum instead of guessing from the row count, so the
+/// refusal stays a typed fact rather than a 500.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionWriteAdmission {
+    /// Owner-visible session row exists and has not started deleting.
+    Writable,
+    /// Owner-visible session row exists and deletion intent is persisted.
+    Deleting,
+    /// Session row is gone and a deletion fence forbids recreating it.
+    /// Terminal: no retry can make this write succeed.
+    Fenced,
+    /// `session_id` exists under a different owner.
+    ForeignOwner,
+    /// No session row, no fence, no foreign owner.
+    Missing,
+}
+
+impl SessionWriteAdmission {
+    pub fn is_writable(self) -> bool {
+        matches!(self, Self::Writable)
+    }
+}
+
+/// Session status that persists deletion intent. Must match the `'deleting'`
+/// literal used by the session write guards in this module.
+pub const SESSION_STATUS_DELETING: &str = "deleting";
+
+/// Resolve why a session write was refused.
+///
+/// Short-circuits on the common answers: one query settles `Writable`/
+/// `Deleting`, and the fence/foreign-owner lookups only run once the session
+/// row is already known to be gone.
+pub async fn classify_session_write_admission(
+    conn: &mut sqlx::MySqlConnection,
+    session_id: &str,
+    user_id: &str,
+) -> Result<SessionWriteAdmission, sqlx::Error> {
+    let status: Option<String> = sqlx::query_scalar(
+        "SELECT status FROM agent_sessions WHERE session_id = ? AND user_id = ? LIMIT 1",
+    )
+    .bind(session_id)
+    .bind(user_id)
+    .fetch_optional(&mut *conn)
+    .await?;
+    if let Some(status) = status {
+        return Ok(if status == SESSION_STATUS_DELETING {
+            SessionWriteAdmission::Deleting
+        } else {
+            SessionWriteAdmission::Writable
+        });
+    }
+    if agent_session_deletion_fence_exists_for_user(&mut *conn, session_id, user_id).await? {
+        return Ok(SessionWriteAdmission::Fenced);
+    }
+    let foreign_owner = query("SELECT 1 AS foreign_owner FROM agent_sessions WHERE session_id = ? AND user_id <> ? LIMIT 1")
+        .bind(session_id)
+        .bind(user_id)
+        .fetch_optional(&mut *conn)
+        .await?
+        .is_some();
+    Ok(if foreign_owner {
+        SessionWriteAdmission::ForeignOwner
+    } else {
+        SessionWriteAdmission::Missing
+    })
+}
+
 pub async fn agent_event_exists_for_user_session<'e, E>(
     executor: E,
     event_id: &str,

--- a/crates/services/src/storage.rs
+++ b/crates/services/src/storage.rs
@@ -1036,6 +1036,9 @@ where
     Ok(row.is_some())
 }
 
+const AGENT_SESSION_ACCEPTS_EVENTS_SQL: &str = "SELECT 1 AS writable FROM agent_sessions \
+     WHERE session_id = ? AND user_id = ? AND status <> 'deleting' LIMIT 1";
+
 pub(crate) async fn agent_session_accepts_events_for_user<'e, E>(
     executor: E,
     session_id: &str,
@@ -1044,14 +1047,11 @@ pub(crate) async fn agent_session_accepts_events_for_user<'e, E>(
 where
     E: Executor<'e, Database = MySql>,
 {
-    let row = query(
-        "SELECT 1 AS writable FROM agent_sessions \
-         WHERE session_id = ? AND user_id = ? AND status <> 'deleting' LIMIT 1",
-    )
-    .bind(session_id)
-    .bind(user_id)
-    .fetch_optional(executor)
-    .await?;
+    let row = query(AGENT_SESSION_ACCEPTS_EVENTS_SQL)
+        .bind(session_id)
+        .bind(user_id)
+        .fetch_optional(executor)
+        .await?;
     Ok(row.is_some())
 }
 
@@ -1102,9 +1102,48 @@ impl SessionWriteAdmission {
     }
 }
 
-/// Session status that persists deletion intent. Must match the `'deleting'`
-/// literal used by the session write guards in this module.
+/// Session status that persists deletion intent.
+///
+/// The SQL guards below spell this status inline rather than binding it: the
+/// value is a fixed part of each statement, and threading four more parameters
+/// through `ADD_AGENT_SESSION_EVENT_COUNT_OR_CREATE_SQL`'s duplicate-key branch
+/// would make a mis-ordered bind — comparing `status` against a session id —
+/// silently disable the fence. `session_write_guards_all_fence_on_the_deleting_status`
+/// keeps every guarded statement tied back to this constant instead.
 pub const SESSION_STATUS_DELETING: &str = "deleting";
+
+/// Every statement that may write session summary state, paired with its label.
+///
+/// A session write path that is missing from this list is a path that can write
+/// to a session whose deletion is already persisted, so new writers belong here
+/// with their guard.
+#[cfg(test)]
+const SESSION_WRITE_FENCE_GUARDED_SQL: &[(&str, &str)] = &[
+    (
+        "bump_agent_session_event_count.increment",
+        BUMP_AGENT_SESSION_EVENT_COUNT_INCREMENT_SQL,
+    ),
+    (
+        "bump_agent_session_event_count.decrement",
+        BUMP_AGENT_SESSION_EVENT_COUNT_DECREMENT_SQL,
+    ),
+    (
+        "add_agent_session_event_count_or_create",
+        ADD_AGENT_SESSION_EVENT_COUNT_OR_CREATE_SQL,
+    ),
+    (
+        "touch_agent_session_activity",
+        TOUCH_AGENT_SESSION_ACTIVITY_SQL,
+    ),
+    (
+        "agent_session_accepts_events_for_user",
+        AGENT_SESSION_ACCEPTS_EVENTS_SQL,
+    ),
+    (
+        "repair_sync_event_session_summary",
+        crate::events::REPAIR_SYNC_EVENT_SESSION_SUMMARY_SQL,
+    ),
+];
 
 /// Resolve why a session write was refused.
 ///
@@ -1167,6 +1206,23 @@ where
     Ok(row.is_some())
 }
 
+const BUMP_AGENT_SESSION_EVENT_COUNT_INCREMENT_SQL: &str = "UPDATE agent_sessions \
+     SET event_count = event_count + ?, \
+         updated_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), updated_at), \
+         last_active_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), last_active_at), \
+         last_event_id = COALESCE(?, last_event_id) \
+     WHERE session_id = ? AND user_id = ? AND status <> 'deleting'";
+
+const BUMP_AGENT_SESSION_EVENT_COUNT_DECREMENT_SQL: &str = "UPDATE agent_sessions \
+     SET event_count = CASE \
+             WHEN event_count >= ? THEN event_count - ? \
+             ELSE 0 \
+         END, \
+         updated_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), updated_at), \
+         last_active_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), last_active_at), \
+         last_event_id = COALESCE(?, last_event_id) \
+     WHERE session_id = ? AND user_id = ? AND status <> 'deleting'";
+
 pub async fn bump_agent_session_event_count<'e, E>(
     executor: E,
     session_id: &str,
@@ -1178,40 +1234,23 @@ where
     E: Executor<'e, Database = MySql>,
 {
     let result = if delta >= 0 {
-        query(
-            "UPDATE agent_sessions \
-             SET event_count = event_count + ?, \
-                 updated_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), updated_at), \
-                 last_active_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), last_active_at), \
-                 last_event_id = COALESCE(?, last_event_id) \
-             WHERE session_id = ? AND user_id = ? AND status <> 'deleting'",
-        )
-        .bind(delta)
-        .bind(last_event_id)
-        .bind(session_id)
-        .bind(user_id)
-        .execute(executor)
-        .await?
+        query(BUMP_AGENT_SESSION_EVENT_COUNT_INCREMENT_SQL)
+            .bind(delta)
+            .bind(last_event_id)
+            .bind(session_id)
+            .bind(user_id)
+            .execute(executor)
+            .await?
     } else {
         let decrement = delta.saturating_abs();
-        query(
-            "UPDATE agent_sessions \
-             SET event_count = CASE \
-                     WHEN event_count >= ? THEN event_count - ? \
-                     ELSE 0 \
-                 END, \
-                 updated_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), updated_at), \
-                 last_active_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), last_active_at), \
-                 last_event_id = COALESCE(?, last_event_id) \
-             WHERE session_id = ? AND user_id = ? AND status <> 'deleting'",
-        )
-        .bind(decrement)
-        .bind(decrement)
-        .bind(last_event_id)
-        .bind(session_id)
-        .bind(user_id)
-        .execute(executor)
-        .await?
+        query(BUMP_AGENT_SESSION_EVENT_COUNT_DECREMENT_SQL)
+            .bind(decrement)
+            .bind(decrement)
+            .bind(last_event_id)
+            .bind(session_id)
+            .bind(user_id)
+            .execute(executor)
+            .await?
     };
     if result.rows_affected() == 0 {
         return Err(sqlx::Error::RowNotFound);
@@ -1272,6 +1311,12 @@ where
     Ok(())
 }
 
+const TOUCH_AGENT_SESSION_ACTIVITY_SQL: &str = "UPDATE agent_sessions \
+     SET updated_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), updated_at), \
+         last_active_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), last_active_at), \
+         last_event_id = COALESCE(?, last_event_id) \
+     WHERE session_id = ? AND user_id = ? AND status <> 'deleting'";
+
 pub async fn touch_agent_session_activity<'e, E>(
     executor: E,
     session_id: &str,
@@ -1281,18 +1326,12 @@ pub async fn touch_agent_session_activity<'e, E>(
 where
     E: Executor<'e, Database = MySql> + Copy,
 {
-    let result = query(
-        "UPDATE agent_sessions \
-         SET updated_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), updated_at), \
-             last_active_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), last_active_at), \
-             last_event_id = COALESCE(?, last_event_id) \
-         WHERE session_id = ? AND user_id = ? AND status <> 'deleting'",
-    )
-    .bind(last_event_id)
-    .bind(session_id)
-    .bind(user_id)
-    .execute(executor)
-    .await?;
+    let result = query(TOUCH_AGENT_SESSION_ACTIVITY_SQL)
+        .bind(last_event_id)
+        .bind(session_id)
+        .bind(user_id)
+        .execute(executor)
+        .await?;
     if result.rows_affected() == 0 {
         let writable = agent_session_accepts_events_for_user(executor, session_id, user_id).await?;
         if !writable {
@@ -8664,6 +8703,56 @@ pub async fn cleanup_expired_data(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_write_guards_all_fence_on_the_deleting_status() {
+        // The guard fragment is derived from the constant the Rust-side
+        // classification compares against, so a status rename that misses a
+        // statement fails here instead of silently unfencing that writer.
+        let guard = format!("status <> '{SESSION_STATUS_DELETING}'");
+        for (label, sql) in SESSION_WRITE_FENCE_GUARDED_SQL {
+            assert!(
+                sql.contains(&guard),
+                "{label} must refuse writes to a session whose deletion is persisted: {sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn create_or_update_session_summary_fences_every_duplicate_key_assignment() {
+        // The upsert's duplicate-key branch is the resurrection path: each
+        // assignment carries its own guard, so one unguarded assignment would
+        // let a delayed writer keep a deleting session alive.
+        let guard = format!("status <> '{SESSION_STATUS_DELETING}'");
+        let assignments = ADD_AGENT_SESSION_EVENT_COUNT_OR_CREATE_SQL
+            .split("ON DUPLICATE KEY UPDATE")
+            .nth(1)
+            .expect("upsert must have a duplicate-key branch");
+        for assignment in [
+            "event_count =",
+            "last_event_id =",
+            "updated_at =",
+            "last_active_at =",
+        ] {
+            let clause = assignments
+                .split(assignment)
+                .nth(1)
+                .unwrap_or_else(|| panic!("duplicate-key branch must assign {assignment}"));
+            assert!(
+                clause
+                    .split_once(", ")
+                    .map(|(head, _)| head)
+                    .unwrap_or(clause)
+                    .contains(&guard),
+                "duplicate-key assignment {assignment} must be fenced: {assignments}"
+            );
+        }
+        assert!(
+            ADD_AGENT_SESSION_EVENT_COUNT_OR_CREATE_SQL
+                .contains("NOT EXISTS ( SELECT 1 FROM agent_session_deletion_fences"),
+            "the insert branch must refuse to recreate a fenced session"
+        );
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[ignore = "requires ASTRA_TEST_DB_IT=1 and a real MySQL/MatrixOne instance"]

--- a/crates/services/src/storage.rs
+++ b/crates/services/src/storage.rs
@@ -121,7 +121,7 @@ pub const AGENT_ID_LEN: usize = 255;
 pub const AGENT_EVENT_ID_LEN: usize = 128;
 static CORE_SCHEMA_INIT_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 const CORE_SCHEMA_CONTRACT_COMPONENT: &str = "astra-core";
-pub const CORE_SCHEMA_CONTRACT_VERSION: &str = "2026-07-31-v24";
+pub const CORE_SCHEMA_CONTRACT_VERSION: &str = "2026-08-15-v25";
 const CORE_SCHEMA_CONTRACT_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS astra_schema_contracts (
     component VARCHAR(64) NOT NULL PRIMARY KEY,
     contract_version VARCHAR(64) NOT NULL,
@@ -1036,6 +1036,44 @@ where
     Ok(row.is_some())
 }
 
+pub(crate) async fn agent_session_accepts_events_for_user<'e, E>(
+    executor: E,
+    session_id: &str,
+    user_id: &str,
+) -> Result<bool, sqlx::Error>
+where
+    E: Executor<'e, Database = MySql>,
+{
+    let row = query(
+        "SELECT 1 AS writable FROM agent_sessions \
+         WHERE session_id = ? AND user_id = ? AND status <> 'deleting' LIMIT 1",
+    )
+    .bind(session_id)
+    .bind(user_id)
+    .fetch_optional(executor)
+    .await?;
+    Ok(row.is_some())
+}
+
+pub(crate) async fn agent_session_deletion_fence_exists_for_user<'e, E>(
+    executor: E,
+    session_id: &str,
+    user_id: &str,
+) -> Result<bool, sqlx::Error>
+where
+    E: Executor<'e, Database = MySql>,
+{
+    let row = query(
+        "SELECT 1 AS fenced FROM agent_session_deletion_fences \
+         WHERE session_id = ? AND user_id = ? LIMIT 1",
+    )
+    .bind(session_id)
+    .bind(user_id)
+    .fetch_optional(executor)
+    .await?;
+    Ok(row.is_some())
+}
+
 pub async fn agent_event_exists_for_user_session<'e, E>(
     executor: E,
     event_id: &str,
@@ -1074,7 +1112,7 @@ where
                  updated_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), updated_at), \
                  last_active_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), last_active_at), \
                  last_event_id = COALESCE(?, last_event_id) \
-             WHERE session_id = ? AND user_id = ?",
+             WHERE session_id = ? AND user_id = ? AND status <> 'deleting'",
         )
         .bind(delta)
         .bind(last_event_id)
@@ -1093,7 +1131,7 @@ where
                  updated_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), updated_at), \
                  last_active_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), last_active_at), \
                  last_event_id = COALESCE(?, last_event_id) \
-             WHERE session_id = ? AND user_id = ?",
+             WHERE session_id = ? AND user_id = ? AND status <> 'deleting'",
         )
         .bind(decrement)
         .bind(decrement)
@@ -1118,11 +1156,16 @@ const ADD_AGENT_SESSION_EVENT_COUNT_OR_CREATE_SQL: &str = "INSERT INTO agent_ses
              WHERE session_id = ? AND user_id <> ? \
              LIMIT 1 \
          ) \
+           AND NOT EXISTS ( \
+             SELECT 1 FROM agent_session_deletion_fences \
+             WHERE session_id = ? AND user_id = ? \
+             LIMIT 1 \
+         ) \
          ON DUPLICATE KEY UPDATE \
-         event_count = IF(user_id = VALUES(user_id), event_count + VALUES(event_count), event_count), \
-         last_event_id = IF(user_id = VALUES(user_id), COALESCE(VALUES(last_event_id), last_event_id), last_event_id), \
-         updated_at = IF(user_id = VALUES(user_id) AND last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), updated_at), \
-         last_active_at = IF(user_id = VALUES(user_id) AND last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), last_active_at)";
+         event_count = IF(user_id = VALUES(user_id) AND status <> 'deleting', event_count + VALUES(event_count), event_count), \
+         last_event_id = IF(user_id = VALUES(user_id) AND status <> 'deleting', COALESCE(VALUES(last_event_id), last_event_id), last_event_id), \
+         updated_at = IF(user_id = VALUES(user_id) AND status <> 'deleting' AND last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), updated_at), \
+         last_active_at = IF(user_id = VALUES(user_id) AND status <> 'deleting' AND last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), last_active_at)";
 
 pub async fn add_agent_session_event_count_or_create<'e, E>(
     executor: E,
@@ -1147,6 +1190,8 @@ where
         .bind(last_event_id)
         .bind(session_id)
         .bind(user_id)
+        .bind(session_id)
+        .bind(user_id)
         .execute(executor)
         .await?;
     if result.rows_affected() == 0 {
@@ -1169,7 +1214,7 @@ where
          SET updated_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), updated_at), \
              last_active_at = IF(last_active_at < DATE_SUB(NOW(6), INTERVAL 1 SECOND), NOW(6), last_active_at), \
              last_event_id = COALESCE(?, last_event_id) \
-         WHERE session_id = ? AND user_id = ?",
+         WHERE session_id = ? AND user_id = ? AND status <> 'deleting'",
     )
     .bind(last_event_id)
     .bind(session_id)
@@ -1177,8 +1222,8 @@ where
     .execute(executor)
     .await?;
     if result.rows_affected() == 0 {
-        let exists = agent_session_exists_for_user(executor, session_id, user_id).await?;
-        if !exists {
+        let writable = agent_session_accepts_events_for_user(executor, session_id, user_id).await?;
+        if !writable {
             return Err(sqlx::Error::RowNotFound);
         }
     }
@@ -2884,6 +2929,21 @@ async fn ensure_core_schema_while_leased(
             INDEX idx_agent_sessions_active_plan_id (active_plan_id),
             INDEX idx_agent_sessions_config_version (config_version_id),
             INDEX idx_sessions_project (user_id, project_id, updated_at)
+        )",
+    )
+    .execute(&pool)
+    .await?;
+    core_schema_create!(
+        pool,
+        "agent_session_deletion_fences",
+        // Session identifiers are immutable. Keep this minimal tombstone after
+        // hard deletion so delayed durable writers cannot recreate a session.
+        "CREATE TABLE IF NOT EXISTS agent_session_deletion_fences (
+            user_id VARCHAR(128) NOT NULL,
+            session_id VARCHAR(64) NOT NULL,
+            deleted_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+            PRIMARY KEY (user_id, session_id),
+            INDEX idx_agent_session_deletion_fences_deleted_at (deleted_at)
         )",
     )
     .execute(&pool)

--- a/crates/services/src/sync_outbox.rs
+++ b/crates/services/src/sync_outbox.rs
@@ -1409,9 +1409,10 @@ fn acknowledge_record(
 
 /// Park a record that the cloud refused for a reason no retry can change.
 ///
-/// Unlike [`apply_delivery_failure`] this does not consume the retry budget:
-/// the record is poisoned immediately with the typed reason, so operators see
-/// why it will never be delivered instead of watching it burn attempts.
+/// `attempts` still counts this delivery — it happened, and the count is the
+/// record's delivery history — but unlike [`apply_delivery_failure`] the record
+/// does not wait for that budget to run out: it is poisoned on this attempt
+/// with the typed reason, and never scheduled again.
 fn apply_terminal_rejection(
     record: &mut SyncOutboxRecord,
     kind: SyncOutboxPoisonKind,
@@ -1997,6 +1998,14 @@ mod tests {
             99,
         ));
         assert_eq!(record.state, SyncOutboxRecordState::Poisoned);
+        assert_eq!(
+            record.attempts, 2,
+            "the refused delivery still counts in the record's history"
+        );
+        assert!(
+            record.attempts < SYNC_OUTBOX_MAX_ATTEMPTS,
+            "poisoning must not wait for the retry budget to run out"
+        );
         assert_eq!(
             record.poison_kind,
             Some(SyncOutboxPoisonKind::SessionDeletedUpstream)

--- a/crates/services/src/sync_outbox.rs
+++ b/crates/services/src/sync_outbox.rs
@@ -78,11 +78,16 @@ pub enum SyncOutboxRecordState {
     Poisoned,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SyncOutboxPoisonKind {
     PayloadHashMismatch,
     RetryExhausted,
+    /// The cloud session this record belongs to was deleted, and its deletion
+    /// fence refuses any recreation. Unlike `RetryExhausted` this is terminal
+    /// by fact, not by budget: re-queueing can never make it deliverable, so
+    /// `repair_retry_exhausted_poison` deliberately leaves it alone.
+    SessionDeletedUpstream,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -246,6 +251,12 @@ pub enum SyncOutboxDeliverySettlement {
     Failed {
         record_id: String,
         error: String,
+    },
+    /// The cloud refused this record for a reason no retry can change.
+    Rejected {
+        record_id: String,
+        kind: SyncOutboxPoisonKind,
+        reason: String,
     },
 }
 
@@ -587,6 +598,25 @@ impl SyncOutboxStore {
                             SyncOutboxAckOutcome::NotFound => {
                                 report.missing = report.missing.saturating_add(1);
                             }
+                        }
+                    }
+                    SyncOutboxDeliverySettlement::Rejected {
+                        record_id,
+                        kind,
+                        reason,
+                    } => {
+                        let Some(record) = state
+                            .records
+                            .iter_mut()
+                            .find(|record| record.record_id.as_str() == record_id.as_str())
+                        else {
+                            report.missing = report.missing.saturating_add(1);
+                            continue;
+                        };
+                        if apply_terminal_rejection(record, *kind, reason, now)
+                            || record.state == SyncOutboxRecordState::Poisoned
+                        {
+                            report.poisoned = report.poisoned.saturating_add(1);
                         }
                     }
                     SyncOutboxDeliverySettlement::Failed { record_id, error } => {
@@ -1377,6 +1407,33 @@ fn acknowledge_record(
     }
 }
 
+/// Park a record that the cloud refused for a reason no retry can change.
+///
+/// Unlike [`apply_delivery_failure`] this does not consume the retry budget:
+/// the record is poisoned immediately with the typed reason, so operators see
+/// why it will never be delivered instead of watching it burn attempts.
+fn apply_terminal_rejection(
+    record: &mut SyncOutboxRecord,
+    kind: SyncOutboxPoisonKind,
+    reason: &str,
+    now: u64,
+) -> bool {
+    if matches!(
+        record.state,
+        SyncOutboxRecordState::Acked | SyncOutboxRecordState::Poisoned
+    ) {
+        return false;
+    }
+    record.attempts = record.attempts.saturating_add(1);
+    record.last_error = Some(reason.to_string());
+    record.state = SyncOutboxRecordState::Poisoned;
+    record.poison_kind = Some(kind);
+    record.poison_reason = Some(reason.to_string());
+    record.next_retry_after_unix_ms = None;
+    record.updated_at_unix_ms = now;
+    true
+}
+
 fn apply_delivery_failure(record: &mut SyncOutboxRecord, error: &str, now: u64) -> bool {
     if matches!(
         record.state,
@@ -1859,6 +1916,112 @@ mod tests {
             "repair reopens the record, so the terminal-prefix watermark must move back"
         );
         assert!(!repaired.degraded);
+    }
+
+    #[test]
+    fn deleted_session_rejection_parks_the_record_without_burning_retries() {
+        let (_temp, _guard, store) = test_store();
+        let SyncOutboxEnqueueOutcome::Inserted { record_id, .. } = store
+            .enqueue_journal_event(&event("gpt-5"))
+            .expect("enqueue")
+        else {
+            panic!("insert");
+        };
+
+        let report = store
+            .settle_delivery_batch(&[SyncOutboxDeliverySettlement::Rejected {
+                record_id: record_id.clone(),
+                kind: SyncOutboxPoisonKind::SessionDeletedUpstream,
+                reason: "Session s-1 was deleted".to_string(),
+            }])
+            .expect("settle terminal rejection");
+        assert_eq!(report.poisoned, 1);
+        assert_eq!(report.failed, 0);
+
+        let status = store.status().expect("status");
+        assert_eq!(status.poisoned, 1);
+        assert_eq!(
+            status.pending, 0,
+            "a session that no longer exists must not stay queued for retry"
+        );
+
+        // Repair exists to reopen records that merely ran out of attempts.
+        // Reopening this one would only replay the same refusal forever.
+        assert_eq!(
+            store.repair_retry_exhausted_poison().expect("repair"),
+            0,
+            "terminal session rejections must survive repair"
+        );
+        let after_repair = store.status().expect("status after repair");
+        assert_eq!(after_repair.poisoned, 1);
+        assert_eq!(after_repair.pending, 0);
+
+        let record = store
+            .ready_records(10)
+            .expect("ready records")
+            .into_iter()
+            .find(|candidate| candidate.record_id == record_id);
+        assert!(
+            record.is_none(),
+            "terminally rejected records must never be claimed again"
+        );
+    }
+
+    #[test]
+    fn terminal_rejection_records_its_reason_for_operators() {
+        let mut record = SyncOutboxRecord {
+            schema_version: SYNC_OUTBOX_SCHEMA_VERSION,
+            sequence: 1,
+            record_id: "rec-1".to_string(),
+            domain: SyncDomain::Events,
+            session_id: "sess-1".to_string(),
+            event_type: "config_change".to_string(),
+            event_ts: "2026-07-08T00:00:00Z".to_string(),
+            payload_hash: "sha256:abc".to_string(),
+            payload: serde_json::json!({}),
+            state: SyncOutboxRecordState::InFlight,
+            attempts: 1,
+            next_retry_after_unix_ms: Some(42),
+            last_error: None,
+            poison_kind: None,
+            poison_reason: None,
+            created_at_unix_ms: 1,
+            updated_at_unix_ms: 1,
+            acked_at_unix_ms: None,
+        };
+
+        assert!(apply_terminal_rejection(
+            &mut record,
+            SyncOutboxPoisonKind::SessionDeletedUpstream,
+            "Session sess-1 was deleted",
+            99,
+        ));
+        assert_eq!(record.state, SyncOutboxRecordState::Poisoned);
+        assert_eq!(
+            record.poison_kind,
+            Some(SyncOutboxPoisonKind::SessionDeletedUpstream)
+        );
+        assert_eq!(
+            record.poison_reason.as_deref(),
+            Some("Session sess-1 was deleted")
+        );
+        assert_eq!(
+            record.next_retry_after_unix_ms, None,
+            "a terminal record must not be scheduled for another attempt"
+        );
+
+        // An already settled record keeps its original disposition.
+        let mut acked = record.clone();
+        acked.state = SyncOutboxRecordState::Acked;
+        acked.poison_kind = None;
+        assert!(!apply_terminal_rejection(
+            &mut acked,
+            SyncOutboxPoisonKind::SessionDeletedUpstream,
+            "late rejection",
+            100,
+        ));
+        assert_eq!(acked.state, SyncOutboxRecordState::Acked);
+        assert_eq!(acked.poison_kind, None);
     }
 
     #[test]

--- a/crates/services/tests/services_db_integration.rs
+++ b/crates/services/tests/services_db_integration.rs
@@ -1307,7 +1307,10 @@ async fn session_delete_fences_late_event_writer_and_prevents_session_resurrecti
             .await
     });
 
+    // Back off between polls: the delete task shares this runtime and the
+    // database, so spinning would compete with the very work being awaited.
     tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        let mut delay = std::time::Duration::from_millis(5);
         loop {
             let fenced: i64 = sqlx::query_scalar(
                 "SELECT COUNT(*) FROM agent_session_deletion_fences \
@@ -1321,7 +1324,8 @@ async fn session_delete_fences_late_event_writer_and_prevents_session_resurrecti
             if fenced == 1 {
                 break;
             }
-            tokio::task::yield_now().await;
+            tokio::time::sleep(delay).await;
+            delay = (delay * 2).min(std::time::Duration::from_millis(100));
         }
     })
     .await

--- a/crates/services/tests/services_db_integration.rs
+++ b/crates/services/tests/services_db_integration.rs
@@ -1379,6 +1379,365 @@ async fn session_delete_fences_late_event_writer_and_prevents_session_resurrecti
     cleanup_session_delete_fixture_for_owner(&pool, &user_id, &session_id).await;
 }
 
+#[tokio::test]
+#[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
+async fn session_delete_cleans_up_events_committed_before_deletion_starts() {
+    // The other side of the fence: a writer that wins the race commits
+    // normally, and deletion is still responsible for removing what it wrote.
+    let (shared, settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let session_id = Uuid::new_v4().to_string();
+    let event_id = Uuid::new_v4().to_string();
+    cleanup_session_delete_fixture_for_owner(&pool, &user_id, &session_id).await;
+
+    sqlx::query(
+        "INSERT INTO agent_sessions (session_id, user_id, title, status, event_count) \
+         VALUES (?, ?, 'delete-fence-writer-first-it', 'active', 0)",
+    )
+    .bind(&session_id)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("insert session");
+
+    let mut writer = pool.begin().await.expect("begin early event writer");
+    sqlx::query(
+        "INSERT INTO agent_events \
+         (event_id, session_id, user_id, agent_id, agent_version, event_type, content, `metadata`) \
+         VALUES (?, ?, ?, 'astra-cli', 'test', 'test.event', 'early event', '{}')",
+    )
+    .bind(&event_id)
+    .bind(&session_id)
+    .bind(&user_id)
+    .execute(&mut *writer)
+    .await
+    .expect("insert early event");
+    astra_services::storage::bump_agent_session_event_count(
+        &mut *writer,
+        &session_id,
+        &user_id,
+        1,
+        Some(&event_id),
+    )
+    .await
+    .expect("event writer must be admitted before deletion starts");
+    writer.commit().await.expect("commit early event writer");
+
+    assert_eq!(
+        count_user_session_rows(&pool, "agent_events", &user_id, &session_id).await,
+        1
+    );
+
+    DatabaseSessionService::new(settings)
+        .with_pool(shared)
+        .delete_session(session_id.clone(), user_id.clone())
+        .await
+        .expect("session delete must clean up committed events");
+
+    assert_eq!(
+        count_user_session_rows(&pool, "agent_events", &user_id, &session_id).await,
+        0,
+        "deletion must remove events that committed before it started"
+    );
+    assert_eq!(
+        count_user_session_rows(&pool, "agent_sessions", &user_id, &session_id).await,
+        0
+    );
+    let fenced: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM agent_session_deletion_fences WHERE user_id = ? AND session_id = ?",
+    )
+    .bind(&user_id)
+    .bind(&session_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count deletion fence");
+    assert_eq!(fenced, 1, "a completed delete must leave its fence behind");
+
+    cleanup_session_delete_fixture_for_owner(&pool, &user_id, &session_id).await;
+}
+
+#[tokio::test]
+#[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
+async fn sync_outbox_event_for_deleted_session_reports_terminal_error_code() {
+    // The sync client parks records on this code instead of retrying until the
+    // retry budget is exhausted, so it must survive the whole delete path.
+    let (shared, settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let session_id = Uuid::new_v4().to_string();
+    cleanup_session_delete_fixture_for_owner(&pool, &user_id, &session_id).await;
+
+    sqlx::query(
+        "INSERT INTO agent_sessions (session_id, user_id, title, status, event_count) \
+         VALUES (?, ?, 'delete-fence-sync-it', 'active', 0)",
+    )
+    .bind(&session_id)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("insert session");
+
+    DatabaseSessionService::new(settings.clone())
+        .with_pool(shared.clone())
+        .delete_session(session_id.clone(), user_id.clone())
+        .await
+        .expect("session delete result");
+
+    let mut journal_event = astra_services::session_journal::JournalEvent::config_change(
+        Some(session_id.as_str()),
+        "model",
+        "post-delete-sync",
+    );
+    journal_event.ts = "2026-08-15T00:00:00Z".to_string();
+    let content = serde_json::to_value(&journal_event).expect("journal content");
+    let payload_hash = astra_services::sync_outbox_canonical_payload_hash(&content);
+    let event_id = astra_services::sync_outbox_stable_event_id(&journal_event, &payload_hash)
+        .expect("stable sync outbox event id");
+
+    let error = DatabaseEventService::new(settings)
+        .with_pool(shared)
+        .create_event(
+            user_id.clone(),
+            EventCreateRequestData {
+                ingestion_source: astra_services::events::EventIngestionSource::SyncOutbox,
+                event_id: Some(event_id.clone()),
+                session_id: session_id.clone(),
+                event_type: "config_change".into(),
+                content: content.to_string(),
+                agent_id: None,
+                agent_version: None,
+                parent_event_id: None,
+                parent_event_ids: None,
+                causal_chain_id: None,
+                metadata: Some(serde_json::json!({
+                    "sync_outbox": { "payload_hash": payload_hash }
+                })),
+            },
+        )
+        .await
+        .expect_err("a deleted session must not accept delayed sync events");
+
+    assert_eq!(error.0, axum::http::StatusCode::CONFLICT);
+    assert_eq!(
+        error.1.0.error_code.as_deref(),
+        Some(astra_core::ERROR_CODE_SESSION_DELETED),
+        "the sync client keys its terminal disposition off this code, not the message"
+    );
+    assert_eq!(
+        count_user_session_rows(&pool, "agent_sessions", &user_id, &session_id).await,
+        0,
+        "the refused write must not resurrect the session row"
+    );
+    assert_eq!(
+        count_user_session_rows(&pool, "agent_events", &user_id, &session_id).await,
+        0
+    );
+
+    cleanup_session_delete_fixture_for_owner(&pool, &user_id, &session_id).await;
+}
+
+#[tokio::test]
+#[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
+async fn session_writes_during_deletion_report_conflict_not_internal_error() {
+    let (shared, settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let session_id = Uuid::new_v4().to_string();
+    let event_id = Uuid::new_v4().to_string();
+    cleanup_session_delete_fixture_for_owner(&pool, &user_id, &session_id).await;
+
+    sqlx::query(
+        "INSERT INTO agent_sessions (session_id, user_id, title, status, event_count) \
+         VALUES (?, ?, 'delete-fence-conflict-it', 'active', 1)",
+    )
+    .bind(&session_id)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("insert session");
+    sqlx::query(
+        "INSERT INTO agent_events \
+         (event_id, session_id, user_id, agent_id, agent_version, event_type, content, `metadata`) \
+         VALUES (?, ?, ?, 'astra-cli', 'test', 'test.event', 'existing event', '{}')",
+    )
+    .bind(&event_id)
+    .bind(&session_id)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("insert existing event");
+
+    // Persisted deletion intent, exactly as `mark_session_deleting` leaves it
+    // before the destructive pass runs.
+    sqlx::query(
+        "UPDATE agent_sessions SET status = 'deleting' WHERE session_id = ? AND user_id = ?",
+    )
+    .bind(&session_id)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("mark session deleting");
+    sqlx::query(
+        "INSERT INTO agent_session_deletion_fences (user_id, session_id) VALUES (?, ?) \
+         ON DUPLICATE KEY UPDATE deleted_at = deleted_at",
+    )
+    .bind(&user_id)
+    .bind(&session_id)
+    .execute(&pool)
+    .await
+    .expect("persist deletion fence");
+
+    let event_service = DatabaseEventService::new(settings).with_pool(shared);
+    let create_error = event_service
+        .create_event(
+            user_id.clone(),
+            EventCreateRequestData {
+                ingestion_source: astra_services::events::EventIngestionSource::Client,
+                event_id: None,
+                session_id: session_id.clone(),
+                event_type: "it_create".into(),
+                content: "late".into(),
+                agent_id: None,
+                agent_version: None,
+                parent_event_id: None,
+                parent_event_ids: None,
+                causal_chain_id: None,
+                metadata: None,
+            },
+        )
+        .await
+        .expect_err("a deleting session must not accept new events");
+    assert_eq!(create_error.0, axum::http::StatusCode::CONFLICT);
+    assert_eq!(
+        create_error.1.0.error_code.as_deref(),
+        Some(astra_core::ERROR_CODE_SESSION_DELETING)
+    );
+
+    let delete_error = event_service
+        .delete_event(event_id.clone(), user_id.clone())
+        .await
+        .expect_err("event deletion cannot rewrite a deleting session summary");
+    assert_eq!(
+        delete_error.0,
+        axum::http::StatusCode::CONFLICT,
+        "a deletion race is a conflict, not an internal server error"
+    );
+    assert_eq!(
+        delete_error.1.0.error_code.as_deref(),
+        Some(astra_core::ERROR_CODE_SESSION_DELETING)
+    );
+    assert_eq!(
+        count_user_session_rows(&pool, "agent_events", &user_id, &session_id).await,
+        1,
+        "the refused event delete must roll back instead of half-applying"
+    );
+
+    cleanup_session_delete_fixture_for_owner(&pool, &user_id, &session_id).await;
+}
+
+#[tokio::test]
+#[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
+async fn session_reaper_retires_only_expired_unguarded_deletion_fences() {
+    let (shared, _settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let expired_session = Uuid::new_v4().to_string();
+    let recent_session = Uuid::new_v4().to_string();
+    let guarded_session = Uuid::new_v4().to_string();
+    for session_id in [&expired_session, &recent_session, &guarded_session] {
+        cleanup_session_delete_fixture_for_owner(&pool, &user_id, session_id).await;
+    }
+
+    for (session_id, age_days) in [(&expired_session, 90), (&recent_session, 0)] {
+        sqlx::query(
+            "INSERT INTO agent_session_deletion_fences (user_id, session_id, deleted_at) \
+             VALUES (?, ?, DATE_SUB(NOW(6), INTERVAL ? DAY))",
+        )
+        .bind(&user_id)
+        .bind(session_id)
+        .bind(age_days)
+        .execute(&pool)
+        .await
+        .expect("insert deletion fence");
+    }
+    // An old fence whose session is still being deleted must stay: the delete
+    // has not finished, so delayed writers can still arrive for it.
+    sqlx::query(
+        "INSERT INTO agent_sessions (session_id, user_id, title, status, event_count) \
+         VALUES (?, ?, 'fence-prune-guarded-it', 'deleting', 0)",
+    )
+    .bind(&guarded_session)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("insert guarded session");
+    sqlx::query(
+        "INSERT INTO agent_session_deletion_fences (user_id, session_id, deleted_at) \
+         VALUES (?, ?, DATE_SUB(NOW(6), INTERVAL 90 DAY))",
+    )
+    .bind(&user_id)
+    .bind(&guarded_session)
+    .execute(&pool)
+    .await
+    .expect("insert guarded deletion fence");
+
+    let policy = astra_services::session_reaper::SessionReaperPolicy {
+        // Only the fence prune may act in this sweep.
+        idle_after_secs: 365 * 86_400,
+        end_after_idle_secs: 365 * 86_400,
+        delete_after_ended_days: 365,
+        deletion_fence_retention_days: 1,
+        batch_limit: 500,
+    };
+    let sweep = astra_services::session_reaper::reap_sessions(&pool, &policy)
+        .await
+        .expect("reaper sweep");
+    assert!(
+        sweep.deletion_fences_pruned >= 1,
+        "the sweep must report the fences it retired: {sweep:?}"
+    );
+
+    let fence_count = |session_id: String| {
+        let pool = pool.clone();
+        let user_id = user_id.clone();
+        async move {
+            sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM agent_session_deletion_fences \
+                 WHERE user_id = ? AND session_id = ?",
+            )
+            .bind(&user_id)
+            .bind(&session_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count deletion fence")
+        }
+    };
+    assert_eq!(
+        fence_count(expired_session.clone()).await,
+        0,
+        "an expired fence with no session row must be retired"
+    );
+    assert_eq!(
+        fence_count(recent_session.clone()).await,
+        1,
+        "a fence inside the retention window must survive"
+    );
+    assert_eq!(
+        fence_count(guarded_session.clone()).await,
+        1,
+        "a fence whose session is still deleting must survive"
+    );
+
+    for session_id in [&expired_session, &recent_session, &guarded_session] {
+        cleanup_session_delete_fixture_for_owner(&pool, &user_id, session_id).await;
+    }
+}
+
 async fn insert_harness_run_fixture(
     pool: &sqlx::Pool<sqlx::MySql>,
     user_id: &str,

--- a/crates/services/tests/services_db_integration.rs
+++ b/crates/services/tests/services_db_integration.rs
@@ -1241,6 +1241,7 @@ async fn cleanup_session_delete_fixture_for_owner(
         "agent_session_execution_slots",
         "agent_runs",
         "agent_sessions",
+        "agent_session_deletion_fences",
     ] {
         let sql = format!("DELETE FROM {table} WHERE session_id = ? AND user_id = ?");
         let _ = sqlx::query(&sql)
@@ -1258,6 +1259,124 @@ async fn cleanup_session_delete_fixture_for_owner(
             .execute(pool)
             .await;
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "ASTRA_TEST_DB_IT=1 and live MatrixOne"]
+async fn session_delete_fences_late_event_writer_and_prevents_session_resurrection() {
+    let (shared, settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+
+    let user_id = Uuid::new_v4().to_string();
+    let session_id = Uuid::new_v4().to_string();
+    let event_id = Uuid::new_v4().to_string();
+    cleanup_session_delete_fixture_for_owner(&pool, &user_id, &session_id).await;
+
+    sqlx::query(
+        "INSERT INTO agent_sessions (session_id, user_id, title, status, event_count) \
+         VALUES (?, ?, 'delete-fence-it', 'active', 0)",
+    )
+    .bind(&session_id)
+    .bind(&user_id)
+    .execute(&pool)
+    .await
+    .expect("insert session");
+
+    // Hold an event insert open without touching the session summary. The
+    // delete can persist its fence, but its destructive transaction must wait
+    // for this writer to either commit or roll back.
+    let mut writer = pool.begin().await.expect("begin late event writer");
+    sqlx::query(
+        "INSERT INTO agent_events \
+         (event_id, session_id, user_id, agent_id, agent_version, event_type, content, `metadata`) \
+         VALUES (?, ?, ?, 'astra-cli', 'test', 'test.event', 'late event', '{}')",
+    )
+    .bind(&event_id)
+    .bind(&session_id)
+    .bind(&user_id)
+    .execute(&mut *writer)
+    .await
+    .expect("insert uncommitted late event");
+
+    let delete_session_id = session_id.clone();
+    let delete_user_id = user_id.clone();
+    let delete_task = tokio::spawn(async move {
+        DatabaseSessionService::new(settings)
+            .with_pool(shared)
+            .delete_session(delete_session_id, delete_user_id)
+            .await
+    });
+
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            let fenced: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM agent_session_deletion_fences \
+                 WHERE user_id = ? AND session_id = ?",
+            )
+            .bind(&user_id)
+            .bind(&session_id)
+            .fetch_one(&pool)
+            .await
+            .expect("poll deletion fence");
+            if fenced == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("delete intent must become visible");
+
+    let late_summary = astra_services::storage::bump_agent_session_event_count(
+        &mut *writer,
+        &session_id,
+        &user_id,
+        1,
+        Some(&event_id),
+    )
+    .await;
+    assert!(
+        matches!(late_summary, Err(sqlx::Error::RowNotFound)),
+        "late event writer must be rejected once deletion is fenced: {late_summary:?}"
+    );
+    writer
+        .rollback()
+        .await
+        .expect("roll back late event writer");
+
+    tokio::time::timeout(std::time::Duration::from_secs(10), delete_task)
+        .await
+        .expect("session delete must finish after writer rollback")
+        .expect("session delete task")
+        .expect("session delete result");
+
+    assert_eq!(
+        count_user_session_rows(&pool, "agent_sessions", &user_id, &session_id).await,
+        0
+    );
+    assert_eq!(
+        count_user_session_rows(&pool, "agent_events", &user_id, &session_id).await,
+        0
+    );
+
+    let resurrect = astra_services::storage::add_agent_session_event_count_or_create(
+        &pool,
+        &session_id,
+        &user_id,
+        1,
+        Some("post-delete-event"),
+    )
+    .await;
+    assert!(
+        matches!(resurrect, Err(sqlx::Error::RowNotFound)),
+        "a delayed writer must not recreate a deleted session: {resurrect:?}"
+    );
+    assert_eq!(
+        count_user_session_rows(&pool, "agent_sessions", &user_id, &session_id).await,
+        0
+    );
+
+    cleanup_session_delete_fixture_for_owner(&pool, &user_id, &session_id).await;
 }
 
 async fn insert_harness_run_fixture(

--- a/crates/services/tests/session_reaper_db_integration.rs
+++ b/crates/services/tests/session_reaper_db_integration.rs
@@ -186,6 +186,7 @@ async fn reaper_marks_stale_active_session_idle_then_ended() {
         idle_after_secs: 60,
         end_after_idle_secs: 86_400,
         delete_after_ended_days: 365,
+        deletion_fence_retention_days: 365,
         batch_limit: 500,
     };
     reap_until(&pool, &idle_only, &user_id, &session_id, "idle", 50).await;
@@ -195,6 +196,7 @@ async fn reaper_marks_stale_active_session_idle_then_ended() {
         idle_after_secs: 86_400,
         end_after_idle_secs: 60,
         delete_after_ended_days: 365,
+        deletion_fence_retention_days: 365,
         batch_limit: 500,
     };
     reap_until(&pool, &end_policy, &user_id, &session_id, "ended", 50).await;
@@ -432,6 +434,7 @@ async fn reaper_deletes_full_session_lifecycle_tables() {
         idle_after_secs: 86_400,
         end_after_idle_secs: 86_400,
         delete_after_ended_days: 1,
+        deletion_fence_retention_days: 365,
         batch_limit: 500,
     };
     let (database_rows_deleted, local_bytes_freed) =
@@ -620,6 +623,7 @@ async fn reaper_delete_preserves_foreign_owner_child_rows_with_same_session_id()
         idle_after_secs: 86_400,
         end_after_idle_secs: 86_400,
         delete_after_ended_days: 1,
+        deletion_fence_retention_days: 365,
         batch_limit: 500,
     };
     let (database_rows_deleted, _) =


### PR DESCRIPTION
## Summary

- persist an owner-scoped deletion fence in the same transaction that marks a session deleting
- reject session event summary writes after deletion starts and prevent delayed durable writers from recreating deleted sessions
- bump the core schema contract so existing deployments automatically create the fence table
- add a deterministic MatrixOne regression covering the in-flight writer race and post-delete resurrection

## Why

A late event transaction could insert into agent_events while hard deletion was running, then commit after the delete pass. This left residual rows and made deletion fail verification. Retrying deletion alone did not prevent a delayed create-or-update writer from recreating the session.

The fence makes deletion authoritative at the shared session storage boundary: a writer that wins first commits before deletion and is subsequently cleaned up; a deletion that wins first causes the complete writer transaction to roll back.

## Validation

- cargo fmt --all -- --check
- cargo check -p astra-services --tests
- cargo clippy -p astra-services --tests -- -D warnings
- cargo test -p astra-services --lib session_lifecycle -- --nocapture
- cargo test -p astra-services --lib storage::tests -- --nocapture

The new ignored live-MatrixOne regression was compiled locally but not executed against a shared database because it performs writes; CI will execute the online integration lane.

Fixes #616