### PR TITLE
fix(runtime): avoid duplicate session resume context

### DIFF
--- a/crates/runtime/src/server/run/lifecycle/mod.rs
+++ b/crates/runtime/src/server/run/lifecycle/mod.rs
@@ -856,6 +856,13 @@ fn should_restore_prior_prompt_history(
     request_targets_existing_session && session_has_prior_prompt_history
 }
 
+fn should_build_session_resume_hydration_hint(
+    restore_prior_prompt_history: bool,
+    prompt_message_count: usize,
+) -> bool {
+    restore_prior_prompt_history && prompt_message_count <= 1
+}
+
 fn task_board_settlement_payload(
     snapshot: &crate::turn::agentic_loop::host::TaskBoardSnapshot,
 ) -> Option<Value> {
@@ -9011,18 +9018,8 @@ impl RunLifecycleService for AgenticRunLifecycleService {
             self.session_has_prior_prompt_history(&user_id, &session_id)
                 .await,
         );
-        let session_resume_hint = self
-            .session_resume_hydration_hint_for_session(
-                &user_id,
-                &session_id,
-                &run_id,
-                restore_prior_prompt_history,
-            )
-            .await;
-        let plan_resume_hint = astra_turn_core::resume_hydration::merge_resume_hints(
-            session_resume_hint,
-            plan_resume_snapshot.prompt_hint,
-        );
+        let plan_snapshot_resume_hint = plan_resume_snapshot.prompt_hint;
+        let plan_resume_hint = plan_snapshot_resume_hint.clone();
         let plan_authoring_active = plan_resume_snapshot.authoring_active;
         let task_board_resume_hint = self
             .task_board_resume_hint_for_session(&user_id, &session_id)
@@ -9201,6 +9198,23 @@ impl RunLifecycleService for AgenticRunLifecycleService {
         } else {
             None
         };
+
+        if should_build_session_resume_hydration_hint(
+            restore_prior_prompt_history,
+            loop_state.messages.len(),
+        ) {
+            let session_resume_hint = self
+                .session_resume_hydration_hint_for_session(&user_id, &session_id, &run_id, true)
+                .await;
+            let merged_hint = astra_turn_core::resume_hydration::merge_resume_hints(
+                session_resume_hint,
+                plan_snapshot_resume_hint,
+            );
+            match host.plan_resume_hint_handle().write() {
+                Ok(mut hint) => *hint = merged_hint,
+                Err(poisoned) => *poisoned.into_inner() = merged_hint,
+            }
+        }
 
         self.configure_loop_state_runtime_controls(
             &mut loop_state,
@@ -10613,7 +10627,10 @@ impl RunLifecycleService for AgenticRunLifecycleService {
                 &user_id,
                 &session_id,
                 &run_id,
-                restore_prior_prompt_history,
+                should_build_session_resume_hydration_hint(
+                    restore_prior_prompt_history,
+                    state.messages.len(),
+                ),
             )
             .await;
         let plan_resume_hint = astra_turn_core::resume_hydration::merge_resume_hints(

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -3507,6 +3507,16 @@ fn resume_hydration_requires_existing_session_with_prior_prompt_history() {
     );
 }
 
+#[test]
+fn session_resume_hydration_hint_is_only_needed_without_restored_prompt_messages() {
+    assert!(should_build_session_resume_hydration_hint(true, 1));
+    assert!(
+        !should_build_session_resume_hydration_hint(true, 3),
+        "restored user/assistant history already carries the resume context"
+    );
+    assert!(!should_build_session_resume_hydration_hint(false, 1));
+}
+
 #[tokio::test]
 async fn server_resume_hydration_failure_is_not_prompt_facing() {
     let service = test_service();


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Related to [matrixorigin/matrixflow#15570](https://github.com/matrixorigin/matrixflow/issues/15570).

Companion PR: [matrixorigin/matrixflow#15893](https://github.com/matrixorigin/matrixflow/pull/15893).

## What this PR does / why we need it

### Problem

In a resumed multi-turn conversation, a new English question could repeat the previous Chinese answer instead of following the current user language.

### Root cause

Astra restored canonical or CSL prompt history and then also appended a session-resume hydration summary to the current user tail. The summary duplicated the previous latest_user_input and assistant answer. With small models, that stale duplicate context could dominate the current user message.

### Fix

- Restore canonical or CSL prompt history as the primary conversation context.
- Build the session-resume hydration hint only when history restoration yields no prior prompt messages.
- Preserve plan resume hints independently from the session-resume fallback.
- Apply the same decision in both agentic lifecycle paths.
- Add a regression test for restored history, empty-history fallback, and disabled resume.

### Scope and compatibility

- API and wire contracts: unchanged.
- Database schema and persisted data: unchanged.
- Configuration and environment variables: unchanged.
- Permissions and authentication: unchanged.
- Runtime behavior: resumed conversations no longer receive duplicate stale prompt context.
- Performance: avoids unnecessary summary loading when history is already available.
- Rollback risk: low; reverting restores the previous eager hydration behavior.

## Architecture and complexity delta

- Canonical owner changed or extended: The agentic run lifecycle decides whether the session-resume fallback is necessary after prompt history restoration.
- Existing implementations/callers searched: Both lifecycle paths that call `session_resume_hydration_hint_for_session` were updated.
- Superseded code, states, tables, shims, and self-only tests removed: Eager duplicate resume-hint construction was removed from the primary lifecycle path.
- Net code/state/table delta: +40/-13 runtime lines and one focused regression test; no schema, table, or durable-state changes.
- If parallel implementations remain, the external boundary and retirement condition: Canonical or CSL prompt history remains authoritative; session-resume hydration remains only as an empty-history fallback.

## Production wiring and verification

- Public product entrypoint exercised: Local Matrixflow UI using Momo and `qwen2.5:0.5b`; Chinese to English passed in two fresh sessions, and English to Chinese passed in the same session.
- Unhappy paths exercised: Empty-history fallback and resume-disabled behavior are covered by the focused unit test.
- Database schema/query/transaction/migration verified against a real database, or `N/A` with reason: N/A, this change does not modify database contracts.

Verification:

- `cargo test -p astra-runtime resume_hydration --lib`: 6 passed.
- `cargo build -p astra-runtime --bin astra-server`: passed.
- Full local library run: 4526 passed, 54 ignored, and 3 environment-dependent failures; each failed test passed when rerun individually with `LC_ALL=C` and isolated temporary directories.
- GitHub Actions: static checks, `Test: astra-runtime`, core, CLI, online, SDK, and web jobs passed.
