### PR TITLE
fix(runtime): run managed Runner tools without legacy boundary

### DIFF
--- a/crates/astra-edge/src/runtime_file_transfer.rs
+++ b/crates/astra-edge/src/runtime_file_transfer.rs
@@ -1237,6 +1237,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn legacy_local_transfer_paths_are_executor_owned_without_boundary() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("sandbox");
+        let transfer_root = workspace.join(".moi/runtime/task-1");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let context = RuntimeFileTransferContext {
+            endpoint_url: "http://127.0.0.1:1/api/v1/runtime-files".to_string(),
+            authorization: "Bearer task-scoped-grant".to_string(),
+            workspace_root: workspace.display().to_string(),
+            layout: RuntimeFileTransferLayout::Legacy {
+                task_id: "task-1".to_string(),
+                root: transfer_root.display().to_string(),
+                catalog_dir: transfer_root.join("catalog").display().to_string(),
+                session_dir: workspace
+                    .join(".moi/sessions/session-1")
+                    .display()
+                    .to_string(),
+                scratch_dir: transfer_root.join("scratch").display().to_string(),
+            },
+            max_file_bytes: 1024,
+            attachments: Vec::new(),
+        };
+        prepare_scope_dirs(&context).await.unwrap();
+        let executor = astra_tools::executor::DefaultToolExecutor::for_workspace(
+            &workspace,
+            "user-1",
+            "session-1",
+            "astra-edge/test",
+            Duration::from_secs(30),
+        );
+
+        let result = execute_default_tool(
+            &executor,
+            "write_file",
+            &json!({
+                "path": ".moi/runtime/task-1/catalog/input.txt",
+                "content": "agent-owned"
+            }),
+            Some(&context),
+            None,
+            &tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        assert!(!result.is_error, "{result:?}");
+        assert_eq!(
+            std::fs::read_to_string(transfer_root.join("catalog/input.txt")).unwrap(),
+            "agent-owned\n"
+        );
+    }
+
+    #[tokio::test]
     async fn materialize_rejects_file_outside_current_attachment_inventory() {
         let temp = tempfile::tempdir().unwrap();
         let result = materialize(&json!({"file_id": "other"}), Some(&context(temp.path()))).await;

--- a/crates/astra-server-types/src/edge_ws_protocol.rs
+++ b/crates/astra-server-types/src/edge_ws_protocol.rs
@@ -321,9 +321,9 @@ pub enum EdgeServerMessage {
         delivery_generation: u64,
         tool: String,
         args: Value,
-        /// Host-owned transfer credentials and path contract. This field is
-        /// never part of model-visible tool arguments or the invocation
-        /// journal; its Debug implementation redacts authorization.
+        /// Request-scoped transfer credentials and local path contract. This
+        /// field is never part of model-visible tool arguments or the
+        /// invocation journal; its Debug implementation redacts authorization.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         runtime_file_transfer: Option<Box<RuntimeFileTransferContext>>,
         /// V2 managed file-transfer contract. It is separately negotiated so
@@ -331,8 +331,9 @@ pub enum EdgeServerMessage {
         /// eph Edge requires this explicit layout-aware contract.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         runtime_file_transfer_v2: Option<Box<RuntimeFileTransferContextV2>>,
-        /// Non-secret mount boundary for host-owned lanes within the writable
-        /// workspace. Unlike transfer credentials this field is durable.
+        /// Compatibility-only filesystem guard accepted from older servers
+        /// during rolling upgrades. New managed transfer requests treat local
+        /// Edge paths as executor-owned and omit this field.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         runtime_filesystem_boundary: Option<Box<RuntimeFilesystemBoundaryContext>>,
         /// Maximum execution time in seconds.

--- a/crates/runtime/src/server/edge/edge_ws_handler.rs
+++ b/crates/runtime/src/server/edge/edge_ws_handler.rs
@@ -688,8 +688,7 @@ async fn handle_edge_connection(
                 Ok(rows) if !rows.is_empty() => {
                     let mut stop_dispatch = false;
                     for (idx, row) in rows.iter().enumerate() {
-                        let msg = match serde_json::from_str::<EdgeServerMessage>(&row.payload_json)
-                        {
+                        let msg = match decode_relay_edge_dispatch_payload(&row.payload_json) {
                             Ok(msg) => msg,
                             Err(error) => {
                                 tracing::warn!(
@@ -1196,6 +1195,13 @@ async fn edge_socket_appears_closed(
             None => return false,
         }
     }
+}
+
+fn decode_relay_edge_dispatch_payload(
+    payload_json: &str,
+) -> Result<EdgeServerMessage, serde_json::Error> {
+    astra_services::multi_agent::canonicalize_edge_dispatch_payload(payload_json)
+        .and_then(serde_json::from_value)
 }
 
 /// Helper: serialize and send an EdgeServerMessage over the WebSocket.

--- a/crates/runtime/src/server/runtime_tool_executor.rs
+++ b/crates/runtime/src/server/runtime_tool_executor.rs
@@ -2015,7 +2015,6 @@ impl RuntimeToolExecutor {
         }
         request.runtime_file_transfer = self.runtime_file_transfer_for_tool(name);
         request.runtime_file_transfer_required = request.runtime_file_transfer.is_some();
-        request.runtime_filesystem_boundary = self.runtime_filesystem_boundary();
         request.runtime_edge_dispatch_authorization =
             self.runtime_edge_dispatch_authorization_for_request(&request);
         request.runtime_edge_dispatch_authorization_required =
@@ -2038,7 +2037,6 @@ impl RuntimeToolExecutor {
         }
         request.runtime_file_transfer = self.runtime_file_transfer_for_tool(name);
         request.runtime_file_transfer_required = request.runtime_file_transfer.is_some();
-        request.runtime_filesystem_boundary = self.runtime_filesystem_boundary();
         request.runtime_edge_dispatch_authorization =
             self.runtime_edge_dispatch_authorization_for_request(&request);
         request.runtime_edge_dispatch_authorization_required =
@@ -2061,26 +2059,6 @@ impl RuntimeToolExecutor {
             return Some(context);
         }
         None
-    }
-
-    fn runtime_filesystem_boundary(
-        &self,
-    ) -> Option<Arc<astra_services::runs::RuntimeFilesystemBoundaryContext>> {
-        let context = self.runtime_file_transfer.as_ref()?;
-        let astra_services::runs::RuntimeFileTransferLayout::Legacy {
-            root, session_dir, ..
-        } = &context.layout
-        else {
-            // eph-* owns its complete /sandbox/.moi work directory; there are
-            // no host-owned lanes to mount read-only inside that workspace.
-            return None;
-        };
-        Some(Arc::new(
-            astra_services::runs::RuntimeFilesystemBoundaryContext {
-                workspace_root: context.workspace_root.clone(),
-                read_only_paths: vec![root.clone(), session_dir.clone()],
-            },
-        ))
     }
 
     fn runtime_edge_dispatch_authorization_for_request(
@@ -4199,7 +4177,7 @@ mod tests {
     }
 
     #[test]
-    fn transfer_credentials_are_attached_only_to_transfer_tools() {
+    fn legacy_transfer_context_is_attached_only_to_transfer_tools() {
         let (exec, _dir) = test_executor();
         let context = Arc::new(astra_services::runs::RuntimeFileTransferContext {
             endpoint_url: "https://moi.example/runtime-files".to_string(),
@@ -4220,17 +4198,17 @@ mod tests {
         let materialize = exec.tool_execution_request("materialize_attachment", &Value::Null);
         assert!(materialize.runtime_file_transfer.is_some());
         assert!(materialize.runtime_file_transfer_required);
-        assert!(materialize.runtime_filesystem_boundary.is_some());
+        assert!(materialize.runtime_filesystem_boundary.is_none());
 
         let publish = exec.tool_execution_request("publish_artifact", &Value::Null);
         assert!(publish.runtime_file_transfer.is_some());
         assert!(publish.runtime_file_transfer_required);
-        assert!(publish.runtime_filesystem_boundary.is_some());
+        assert!(publish.runtime_filesystem_boundary.is_none());
 
         let bash = exec.tool_execution_request("bash", &json!({"command": "pwd"}));
         assert!(bash.runtime_file_transfer.is_none());
         assert!(!bash.runtime_file_transfer_required);
-        assert!(bash.runtime_filesystem_boundary.is_some());
+        assert!(bash.runtime_filesystem_boundary.is_none());
     }
 
     #[test]

--- a/crates/runtime/src/server/tool_edge_selection.rs
+++ b/crates/runtime/src/server/tool_edge_selection.rs
@@ -117,11 +117,10 @@ fn edge_advertised_tool_check(
             ),
         ))
     })?;
-    // Managed transfer tools and their filesystem boundary require a matching
-    // Edge wire contract. The legacy Runner layout is V1; eph's single work
-    // directory requires V2 and must never be projected into fabricated V1
-    // mount paths.
-    if request.runtime_filesystem_boundary.is_some() || request.runtime_file_transfer.is_some() {
+    // Managed transfer tools require their matching Edge wire contract. The
+    // legacy Runner layout is V1; eph's single work directory is V2. Filesystem
+    // boundaries from old durable decisions are discarded before selection.
+    if request.runtime_file_transfer.is_some() {
         let required_capability = match request
             .runtime_file_transfer
             .as_deref()

--- a/crates/runtime/src/server/tool_execution_binding.rs
+++ b/crates/runtime/src/server/tool_execution_binding.rs
@@ -278,8 +278,9 @@ pub struct ToolExecutionRequest {
     /// to ordinary Edge dispatch.
     #[serde(default)]
     pub runtime_file_transfer_required: bool,
-    /// Non-secret, durable mount boundary for host-owned paths inside a
-    /// managed Edge workspace.
+    /// Compatibility-only filesystem guard retained in the request shape for
+    /// older senders. Current runtime requests treat local Edge paths as
+    /// executor-owned and never populate or replay this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_filesystem_boundary:
         Option<Arc<astra_services::runs::RuntimeFilesystemBoundaryContext>>,

--- a/crates/runtime/src/server/tool_invocation_decision.rs
+++ b/crates/runtime/src/server/tool_invocation_decision.rs
@@ -719,17 +719,13 @@ mod tests {
         let registry = astra_runtime_env::ToolRegistry::builtins();
         let mut request = request();
         request.policy.allowed_tools = vec!["write_file".into(), "read_file".into()];
-        let mut original = ToolInvocationDecisionSnapshot::resolve(
+        let original = ToolInvocationDecisionSnapshot::resolve(
             &request,
             ToolExecutionRouteKind::ServerLocal,
             &registry,
         )
         .unwrap();
         assert!(original.runtime_filesystem_boundary.is_none());
-        // Simulate a durable decision written by an older server. The field
-        // must remain decodable and hash-stable, but replay must not restore it
-        // onto the live execution request.
-        original.runtime_filesystem_boundary = request.runtime_filesystem_boundary.clone();
 
         request.policy.allowed_tools.reverse();
         request.workspace.display_name = "Renamed workspace".to_string();
@@ -840,12 +836,17 @@ mod tests {
             },
         ));
         request.runtime_edge_dispatch_authorization_required = true;
-        let original = ToolInvocationDecisionSnapshot::resolve(
+        let mut original = ToolInvocationDecisionSnapshot::resolve(
             &request,
             ToolExecutionRouteKind::ServerLocal,
             &registry,
         )
         .unwrap();
+        // Simulate a hash-valid durable decision written by an older server.
+        // The compatibility field must survive decoding, but replay must not
+        // restore it onto the live execution request.
+        original.runtime_filesystem_boundary = request.runtime_filesystem_boundary.clone();
+        assert!(original.runtime_filesystem_boundary.is_some());
         let durable = original.durable().unwrap();
         let durable_json = durable.snapshot.to_string();
         assert!(!durable_json.contains("transfer-secret-must-not-persist"));
@@ -862,6 +863,7 @@ mod tests {
         request.runtime_edge_dispatch_authorization_required = false;
         request.policy.admission_snapshot = Some(Default::default());
         let restored = ToolInvocationDecisionSnapshot::from_durable(&durable).unwrap();
+        assert!(restored.runtime_filesystem_boundary.is_some());
         restored.apply_to_request(&mut request);
 
         assert_eq!(request.workspace.cwd.as_deref(), Some("/original"));

--- a/crates/runtime/src/server/tool_invocation_decision.rs
+++ b/crates/runtime/src/server/tool_invocation_decision.rs
@@ -39,6 +39,9 @@ pub(crate) struct ToolInvocationDecisionSnapshot {
     pub permission_grant: Option<InvocationPermissionGrantSnapshot>,
     pub admission: ToolExecutionAdmissionSnapshot,
     pub runtime_file_transfer_required: bool,
+    /// Legacy field retained so durable decisions created by older servers can
+    /// still be decoded and hashed. New decisions leave it empty, and replay
+    /// deliberately does not restore it onto an execution request.
     pub runtime_filesystem_boundary:
         Option<Arc<astra_services::runs::RuntimeFilesystemBoundaryContext>>,
     pub runtime_edge_dispatch_authorization_required: bool,
@@ -216,7 +219,7 @@ impl ToolInvocationDecisionSnapshot {
             }),
             admission,
             runtime_file_transfer_required: request.runtime_file_transfer_required,
-            runtime_filesystem_boundary: request.runtime_filesystem_boundary.clone(),
+            runtime_filesystem_boundary: None,
             runtime_edge_dispatch_authorization_required: request
                 .runtime_edge_dispatch_authorization_required,
         })
@@ -352,7 +355,12 @@ impl ToolInvocationDecisionSnapshot {
         request.policy.semantic_read_freshness = None;
         request.policy.semantic_read_condition = None;
         request.runtime_file_transfer_required = self.runtime_file_transfer_required;
-        request.runtime_filesystem_boundary = self.runtime_filesystem_boundary.clone();
+        // Legacy boundaries depended on nested mount namespaces that are not
+        // available inside managed OpenShell executors. The protected Catalog
+        // originals now remain behind request-scoped transfer authorization,
+        // while local Runner paths are executor-owned, so old durable values
+        // must not be re-applied during replay.
+        request.runtime_filesystem_boundary = None;
         request.runtime_edge_dispatch_authorization_required =
             self.runtime_edge_dispatch_authorization_required;
     }
@@ -711,12 +719,17 @@ mod tests {
         let registry = astra_runtime_env::ToolRegistry::builtins();
         let mut request = request();
         request.policy.allowed_tools = vec!["write_file".into(), "read_file".into()];
-        let original = ToolInvocationDecisionSnapshot::resolve(
+        let mut original = ToolInvocationDecisionSnapshot::resolve(
             &request,
             ToolExecutionRouteKind::ServerLocal,
             &registry,
         )
         .unwrap();
+        assert!(original.runtime_filesystem_boundary.is_none());
+        // Simulate a durable decision written by an older server. The field
+        // must remain decodable and hash-stable, but replay must not restore it
+        // onto the live execution request.
+        original.runtime_filesystem_boundary = request.runtime_filesystem_boundary.clone();
 
         request.policy.allowed_tools.reverse();
         request.workspace.display_name = "Renamed workspace".to_string();
@@ -860,13 +873,7 @@ mod tests {
         assert_eq!(request.policy.max_output_bytes, Some(4096));
         assert!(request.runtime_file_transfer.is_none());
         assert!(request.runtime_file_transfer_required);
-        assert_eq!(
-            request
-                .runtime_filesystem_boundary
-                .as_ref()
-                .map(|boundary| boundary.read_only_paths.as_slice()),
-            Some(["/workspace/.moi/runtime/task-1".to_string()].as_slice())
-        );
+        assert!(request.runtime_filesystem_boundary.is_none());
         assert!(request.runtime_edge_dispatch_authorization.is_none());
         assert!(request.runtime_edge_dispatch_authorization_required);
         assert_eq!(restored.route, ToolExecutionRouteKind::ServerLocal);

--- a/crates/runtime/src/server/tool_transport/tests.rs
+++ b/crates/runtime/src/server/tool_transport/tests.rs
@@ -1640,6 +1640,42 @@ fn validated_transfer_context_authorizes_edge_interceptor_support() {
 }
 
 #[test]
+fn ordinary_managed_edge_tools_do_not_require_transfer_protocol_capability() {
+    let request = request(
+        "bash",
+        WorkspaceBinding::edge_workspace(
+            "Managed sandbox",
+            "/sandbox",
+            WorkspaceAuthority::ReadWrite,
+        ),
+        ExecutorBinding::edge_agent(
+            "edge-old",
+            "Managed sandbox",
+            ToolTransportKind::EdgeWs,
+            ExecutorStatus::Online,
+        ),
+    );
+    let mut agent = edge_agent_record("edge-old");
+    agent.capabilities = agent.capabilities.map(|mut value| {
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("protocol_capabilities");
+        value
+    });
+
+    let selected = super::super::tool_edge_selection::select_capable_edge_agent(
+        std::slice::from_ref(&agent),
+        Some("edge-old"),
+        &request,
+        &astra_runtime_env::ToolRegistry::builtins(),
+    )
+    .expect("ordinary managed Edge tools must not depend on file-transfer negotiation");
+
+    assert!(selected.is_some());
+}
+
+#[test]
 fn transfer_context_does_not_substitute_for_edge_protocol_capability() {
     let mut request = request(
         "materialize_attachment",

--- a/crates/runtime/tests/edge_ws_e2e.rs
+++ b/crates/runtime/tests/edge_ws_e2e.rs
@@ -556,7 +556,7 @@ async fn edge_ws_tool_request_roundtrip() {
 }
 
 #[tokio::test]
-async fn edge_ws_disconnect_preserves_inflight_dispatch_for_result_replay() {
+async fn edge_ws_relay_strips_legacy_boundary_and_preserves_inflight_dispatch() {
     let dispatch = Arc::new(TestEdgeDispatch::default());
     let (addr, _state, server) = spawn_test_server_with_dispatch(Some(dispatch.clone())).await;
 
@@ -585,7 +585,12 @@ async fn edge_ws_disconnect_preserves_inflight_dispatch_for_result_replay() {
         args: json!({"command": "sleep 30"}),
         runtime_file_transfer: None,
         runtime_file_transfer_v2: None,
-        runtime_filesystem_boundary: None,
+        runtime_filesystem_boundary: Some(Box::new(
+            astra_server_types::edge_ws_protocol::RuntimeFilesystemBoundaryContext {
+                workspace_root: "/sandbox".to_string(),
+                read_only_paths: vec!["/sandbox/.moi/runtime/task-1".to_string()],
+            },
+        )),
         timeout_secs: 30,
     };
     dispatch
@@ -607,6 +612,10 @@ async fn edge_ws_disconnect_preserves_inflight_dispatch_for_result_replay() {
     assert_eq!(req_json["type"], "edge_tool_request");
     assert_eq!(req_json["request_id"], request_id);
     assert_eq!(req_json["tool"], "bash");
+    assert!(
+        req_json.get("runtime_filesystem_boundary").is_none(),
+        "relay must strip a retired boundary from a pre-upgrade pending row"
+    );
 
     drop(ws);
 

--- a/crates/services/src/multi_agent/edge_dispatch.rs
+++ b/crates/services/src/multi_agent/edge_dispatch.rs
@@ -109,6 +109,36 @@ fn json_payloads_match(persisted: &str, replayed: &str) -> Result<bool, String> 
     Ok(persisted == replayed)
 }
 
+/// Canonicalize the durable identity of an Edge dispatch payload.
+///
+/// `runtime_filesystem_boundary` was retired from `edge_tool_request` during
+/// the managed Runner rollout. Older servers may already have persisted that
+/// field, so it cannot distinguish the same dispatch across a rolling upgrade.
+/// Every other message type and field remains part of the exact JSON identity.
+pub fn canonicalize_edge_dispatch_payload(
+    payload_json: &str,
+) -> Result<serde_json::Value, serde_json::Error> {
+    let mut payload = serde_json::from_str::<serde_json::Value>(payload_json)?;
+    if payload.get("type").and_then(serde_json::Value::as_str) == Some("edge_tool_request")
+        && let Some(object) = payload.as_object_mut()
+    {
+        object.remove("runtime_filesystem_boundary");
+    }
+    Ok(payload)
+}
+
+fn canonical_edge_dispatch_payload_json(payload_json: &str) -> Result<String, serde_json::Error> {
+    serde_json::to_string(&canonicalize_edge_dispatch_payload(payload_json)?)
+}
+
+fn edge_dispatch_payloads_match(persisted: &str, replayed: &str) -> Result<bool, String> {
+    let persisted = canonicalize_edge_dispatch_payload(persisted)
+        .map_err(|error| format!("persisted durable payload is invalid JSON: {error}"))?;
+    let replayed = canonicalize_edge_dispatch_payload(replayed)
+        .map_err(|error| format!("replayed durable payload is invalid JSON: {error}"))?;
+    Ok(persisted == replayed)
+}
+
 async fn rollback_edge_dispatch_tx(tx: sqlx::Transaction<'_, MySql>, context: &'static str) {
     if let Err(error) = tx.rollback().await {
         tracing::warn!(context, %error, "edge_dispatch rollback failed");
@@ -816,6 +846,8 @@ impl EdgeDispatchService for DatabaseEdgeDispatchService {
         if !identity.is_complete() {
             return Err("edge_dispatch insert: incomplete dispatch identity".to_string());
         }
+        let payload_json = canonical_edge_dispatch_payload_json(payload_json)
+            .map_err(|error| format!("edge_dispatch insert payload is invalid JSON: {error}"))?;
         // Idempotent insert inside a full turn boundary: duplicate calls for
         // the same dispatched tool are harmless retries, while same request_id
         // values in other runs/chains remain isolated.
@@ -830,7 +862,7 @@ impl EdgeDispatchService for DatabaseEdgeDispatchService {
         .bind(&identity.turn_chain_id)
         .bind(edge_agent_id)
         .bind(&identity.request_id)
-        .bind(payload_json)
+        .bind(&payload_json)
         .execute(&self.pool)
         .await
         {
@@ -865,12 +897,12 @@ impl EdgeDispatchService for DatabaseEdgeDispatchService {
                 "edge_dispatch admit: edge_agent_id is required".to_string(),
             ));
         }
-        serde_json::from_str::<serde_json::Value>(payload_json).map_err(|error| {
+        let payload_json = canonical_edge_dispatch_payload_json(payload_json).map_err(|error| {
             EdgeDispatchAdmissionError::Rejected(format!(
                 "edge_dispatch admit: payload is invalid JSON: {error}"
             ))
         })?;
-        self.insert_dispatch(identity, edge_agent_id, payload_json)
+        self.insert_dispatch(identity, edge_agent_id, &payload_json)
             .await
             .map_err(EdgeDispatchAdmissionError::OutcomeUnknown)?;
         let row = sqlx::query(
@@ -908,7 +940,7 @@ impl EdgeDispatchService for DatabaseEdgeDispatchService {
             ))
         })?;
         if persisted_edge != edge_agent_id
-            || !json_payloads_match(&persisted_payload, payload_json)
+            || !edge_dispatch_payloads_match(&persisted_payload, &payload_json)
                 .map_err(EdgeDispatchAdmissionError::OutcomeUnknown)?
         {
             return Err(EdgeDispatchAdmissionError::Rejected(format!(
@@ -960,7 +992,7 @@ impl EdgeDispatchService for DatabaseEdgeDispatchService {
                 "edge_dispatch direct admit: edge_agent_id is required".to_string(),
             ));
         }
-        serde_json::from_str::<serde_json::Value>(payload_json).map_err(|error| {
+        let payload_json = canonical_edge_dispatch_payload_json(payload_json).map_err(|error| {
             EdgeDispatchAdmissionError::Rejected(format!(
                 "edge_dispatch direct admit: payload is invalid JSON: {error}"
             ))
@@ -983,7 +1015,7 @@ impl EdgeDispatchService for DatabaseEdgeDispatchService {
         .bind(&identity.turn_chain_id)
         .bind(edge_agent_id)
         .bind(&identity.request_id)
-        .bind(payload_json)
+        .bind(&payload_json)
         .execute(&mut *tx)
         .await
         {
@@ -1035,7 +1067,7 @@ impl EdgeDispatchService for DatabaseEdgeDispatchService {
             ))
         })?;
         if persisted_edge != edge_agent_id
-            || !json_payloads_match(&persisted_payload, payload_json)
+            || !edge_dispatch_payloads_match(&persisted_payload, &payload_json)
                 .map_err(EdgeDispatchAdmissionError::OutcomeUnknown)?
         {
             rollback_edge_dispatch_tx(tx, "direct admit conflict").await;
@@ -1875,6 +1907,46 @@ mod tests {
             json_payloads_match("not-json", reordered_replay)
                 .unwrap_err()
                 .contains("persisted durable payload is invalid JSON")
+        );
+    }
+
+    #[test]
+    fn edge_tool_request_payload_comparison_retires_only_the_legacy_boundary() {
+        let boundary_free = serde_json::json!({
+            "type": "edge_tool_request",
+            "request_id": "request-1",
+            "tool": "bash",
+            "args": {"command": "pwd"},
+            "timeout_secs": 30
+        });
+        let mut legacy = boundary_free.clone();
+        legacy["runtime_filesystem_boundary"] = serde_json::json!({
+            "workspace_root": "/sandbox",
+            "read_only_paths": ["/sandbox/.moi/runtime/task-1"]
+        });
+
+        let legacy = legacy.to_string();
+        let boundary_free = boundary_free.to_string();
+        assert!(
+            !json_payloads_match(&legacy, &boundary_free).unwrap(),
+            "generic durable JSON equality must remain strict"
+        );
+        assert!(edge_dispatch_payloads_match(&legacy, &boundary_free).unwrap());
+
+        let changed_tool = boundary_free.replace("\"bash\"", "\"write_file\"");
+        assert!(!edge_dispatch_payloads_match(&legacy, &changed_tool).unwrap());
+
+        let unrelated_with_boundary = serde_json::json!({
+            "type": "edge_other_message",
+            "runtime_filesystem_boundary": {"workspace_root": "/sandbox"}
+        })
+        .to_string();
+        let unrelated_without_boundary =
+            serde_json::json!({"type": "edge_other_message"}).to_string();
+        assert!(
+            !edge_dispatch_payloads_match(&unrelated_with_boundary, &unrelated_without_boundary)
+                .unwrap(),
+            "the compatibility exception must not affect unrelated message types"
         );
     }
 

--- a/crates/services/src/multi_agent/mod.rs
+++ b/crates/services/src/multi_agent/mod.rs
@@ -17,7 +17,8 @@ pub mod task_lease;
 pub use edge_dispatch::{
     DatabaseEdgeDispatchService, EdgeDirectDispatchAdmission, EdgeDispatchAdmission,
     EdgeDispatchAdmissionError, EdgeDispatchIdentity, EdgeDispatchRow, EdgeDispatchService,
-    UnconfiguredEdgeDispatchService, refresh_edge_dispatch_backlog_metrics,
+    UnconfiguredEdgeDispatchService, canonicalize_edge_dispatch_payload,
+    refresh_edge_dispatch_backlog_metrics,
 };
 pub use edge_registry::{
     DatabaseEdgeRegistryService, EdgeAgentRecord, EdgeRegistrationLease, EdgeRegistryService,

--- a/crates/services/src/runs.rs
+++ b/crates/services/src/runs.rs
@@ -530,9 +530,9 @@ pub enum RuntimeFileTransferLayout {
     Ephemeral { work_dir: String },
 }
 
-/// Non-secret filesystem boundary for a provider-managed Edge workspace.
-/// Unlike transfer credentials this contract is safe to persist in durable
-/// dispatch state and must accompany every tool that can mutate the workspace.
+/// Retired filesystem boundary retained only to decode legacy durable and wire
+/// payloads during rolling upgrades. New managed Edge requests omit it because
+/// their local workspace paths are executor-owned; replay must not restore it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RuntimeFilesystemBoundaryContext {

--- a/crates/services/tests/edge_dispatch_db_it.rs
+++ b/crates/services/tests/edge_dispatch_db_it.rs
@@ -9,8 +9,9 @@ mod common;
 use std::sync::Arc;
 
 use astra_services::multi_agent::{
-    DatabaseEdgeDispatchService, DatabaseEdgeRegistryService, EdgeDispatchAdmission,
-    EdgeDispatchAdmissionError, EdgeDispatchIdentity, EdgeDispatchService, EdgeRegistryService,
+    DatabaseEdgeDispatchService, DatabaseEdgeRegistryService, EdgeDirectDispatchAdmission,
+    EdgeDispatchAdmission, EdgeDispatchAdmissionError, EdgeDispatchIdentity, EdgeDispatchService,
+    EdgeRegistryService,
 };
 use sqlx::Row;
 use uuid::Uuid;
@@ -158,6 +159,80 @@ async fn edge_dispatch_admission_replays_terminal_and_rejects_identity_conflicts
         serde_json::from_str::<serde_json::Value>(result_json)
             .expect("fixture terminal result must be valid JSON"),
         "durable replay preserves JSON meaning independently of object-key storage order"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MatrixOne; set ASTRA_TEST_DB_IT=1"]
+async fn edge_dispatch_boundary_free_replay_accepts_legacy_terminal_row() {
+    require_env();
+    let pool = common::setup_pool().await;
+    let svc = DatabaseEdgeDispatchService::new(pool.get().clone());
+    let user_id = format!("ed-legacy-usr-{}", unique_suffix());
+    let agent_id = format!("ed-legacy-agent-{}", unique_suffix());
+    let identity = dispatch_identity(&user_id, &Uuid::new_v4().to_string());
+    let boundary_free = serde_json::json!({
+        "type": "edge_tool_request",
+        "request_id": identity.request_id.clone(),
+        "identity": {
+            "user_id": identity.user_id.clone(),
+            "session_id": identity.session_id.clone(),
+            "run_id": identity.run_id.clone(),
+            "turn_chain_id": identity.turn_chain_id.clone(),
+            "invocation_id": "call-1"
+        },
+        "delivery_generation": 1,
+        "tool": "bash",
+        "args": {"command": "pwd"},
+        "timeout_secs": 30
+    });
+    let mut legacy = boundary_free.clone();
+    legacy["runtime_filesystem_boundary"] = serde_json::json!({
+        "workspace_root": "/sandbox",
+        "read_only_paths": ["/sandbox/.moi/runtime/task-1"]
+    });
+    let result_json = r#"{"status":"completed","output":"/sandbox"}"#;
+
+    sqlx::query(
+        "INSERT INTO edge_pending_dispatch \
+         (user_id, session_id, run_id, turn_chain_id, edge_agent_id, request_id, \
+          payload_json, status, result_json) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'completed', ?)",
+    )
+    .bind(&identity.user_id)
+    .bind(&identity.session_id)
+    .bind(&identity.run_id)
+    .bind(&identity.turn_chain_id)
+    .bind(&agent_id)
+    .bind(&identity.request_id)
+    .bind(legacy.to_string())
+    .bind(result_json)
+    .execute(pool.get())
+    .await
+    .expect("seed boundary-bearing terminal dispatch written by an older server");
+
+    let EdgeDispatchAdmission::Terminal(replayed) = svc
+        .admit_dispatch(&identity, &agent_id, &boundary_free.to_string())
+        .await
+        .expect("boundary-free replay must match the legacy durable identity")
+    else {
+        panic!("legacy terminal dispatch must replay its durable result");
+    };
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&replayed).unwrap(),
+        serde_json::from_str::<serde_json::Value>(result_json).unwrap()
+    );
+
+    let EdgeDirectDispatchAdmission::Terminal(direct_replayed) = svc
+        .admit_and_claim_direct_dispatch(&identity, &agent_id, &boundary_free.to_string())
+        .await
+        .expect("direct boundary-free replay must match the legacy durable identity")
+    else {
+        panic!("legacy terminal dispatch must also replay through direct admission");
+    };
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&direct_replayed).unwrap(),
+        serde_json::from_str::<serde_json::Value>(result_json).unwrap()
     );
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes #630

Related: matrixorigin/matrixflow#16053

## What this PR does / why we need it

Managed MOI Runners own their full workspace, but Astra server was still attaching the legacy host-owned filesystem boundary to ordinary tools. Astra Edge projected that boundary into nested read-only OpenShell mounts, causing basic Runner commands such as `pwd` to fail before execution.

This change stops producing the boundary for current Runner requests and clears boundary data when replaying durable decisions. The existing wire field remains decodable for rolling compatibility. Managed attachment/artifact tools continue to carry their V1/V2 transfer context, while the ephemeral sandbox keeps its V2 workspace and authorization injection behavior.

## Architecture and complexity delta

- Canonical owner changed or extended: Astra runtime request construction now owns the decision that managed Runner workspaces do not require a server-produced filesystem boundary.
- Existing implementations/callers searched: runtime tool execution, durable invocation decisions, Edge selection, Edge WebSocket projection, Edge transfer interception, and ephemeral V2 handling were reviewed together.
- Superseded code, states, tables, shims, and self-only tests removed: the production boundary producer was removed; replay canonicalization clears old snapshot values. The wire field and Edge decoder remain for rolling compatibility.
- Net code/state/table delta: 7 files, one production branch removed, no schema/table/state additions, and focused regression tests added.
- If parallel implementations remain, the external boundary and retirement condition: V1 legacy Runner transfer and V2 ephemeral transfer remain distinct protocol layouts; neither produces a filesystem boundary for new requests.

## Production wiring and verification

- Public product entrypoint exercised: MOI managed Runner `bash` requests route through Astra runtime to the connected Edge without a legacy boundary; transfer tools retain managed capability selection.
- Unhappy paths exercised: durable replay drops stale boundary data, transfer tools still fail closed without V1/V2 Edge capability, and ephemeral requests still require V2.
- Database schema/query/transaction/migration verified against a real database, or `N/A` with reason: N/A (no database or persistence schema change).
- Local verification: `make lint` and `make format-check` passed; `cargo test -p astra-edge -- --test-threads=1` passed 70 tests; `cargo test -p astra-runtime -p astra-server-types` passed.
