### PR TITLE
fix: build on macOS and clear Rust 1.98 clippy lints

### DIFF
--- a/crates/astra-sandbox/src/process_isolation.rs
+++ b/crates/astra-sandbox/src/process_isolation.rs
@@ -22,8 +22,10 @@ use std::fs::File;
 use std::io::{Read, Write};
 #[cfg(target_os = "linux")]
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 #[cfg(target_os = "linux")]
-use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::os::unix::process::ExitStatusExt;
 
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio_util::sync::CancellationToken;

--- a/crates/astra-tools/src/git_gix.rs
+++ b/crates/astra-tools/src/git_gix.rs
@@ -1307,7 +1307,8 @@ pub fn blame(project_root: &Path, args: &Value) -> String {
         let Ok(end) = u32::try_from(end) else {
             return "Error: 'end_line' exceeds the supported line range".to_string();
         };
-        match gix::blame::BlameRanges::from_one_based_inclusive_ranges(vec![start..=end]) {
+        let line_range = start..=end;
+        match gix::blame::BlameRanges::from_one_based_inclusive_ranges(vec![line_range]) {
             Ok(ranges) => options.ranges = ranges,
             Err(e) => return format!("Error: invalid line range: {e}"),
         }

--- a/crates/astra-tools/src/shell_ops.rs
+++ b/crates/astra-tools/src/shell_ops.rs
@@ -6761,9 +6761,7 @@ printf 'probe.txt:1:needle\n'
         let result = execute_bash(
             &ctx,
             &serde_json::json!({
-                "command": format!(
-                    "echo line_1; touch .cancel_sentinel; sleep 0.1; echo line_2; sleep 10"
-                )
+                "command": "echo line_1; touch .cancel_sentinel; sleep 0.1; echo line_2; sleep 10"
             }),
         )
         .await;

--- a/crates/astra-tools/src/workspace_observation.rs
+++ b/crates/astra-tools/src/workspace_observation.rs
@@ -505,7 +505,7 @@ impl GenerationTamperWatch {
         }
         #[cfg(not(target_os = "linux"))]
         {
-            let _ = (lock_paths, binding_paths);
+            let _ = (lock_paths, binding_paths, cancel_token);
             Err(std::io::Error::new(
                 std::io::ErrorKind::Unsupported,
                 "workspace generation tamper watch is unavailable",
@@ -1219,7 +1219,7 @@ impl WorkspacePathIdentity {
                 path,
                 device: metadata.dev(),
                 inode: metadata.ino(),
-                file_type: metadata.mode() & libc::S_IFMT,
+                file_type: metadata.mode() & (libc::S_IFMT as u32),
             })
         }
         #[cfg(not(unix))]
@@ -1238,7 +1238,7 @@ impl WorkspacePathIdentity {
             use std::os::unix::fs::MetadataExt;
             metadata.dev() == self.device
                 && metadata.ino() == self.inode
-                && metadata.mode() & libc::S_IFMT == self.file_type
+                && metadata.mode() & (libc::S_IFMT as u32) == self.file_type
         }
         #[cfg(not(unix))]
         {

--- a/crates/astra-tools/src/workspace_observation.rs
+++ b/crates/astra-tools/src/workspace_observation.rs
@@ -1209,6 +1209,13 @@ struct WorkspacePathIdentity {
     file_type: u32,
 }
 
+/// File-type bits of `st_mode`. `libc::S_IFMT` is `u16` on macOS/BSD and
+/// `u32` on Linux, while `MetadataExt::mode` is always `u32`, so the cast is
+/// required on some targets and a no-op on others.
+#[cfg(unix)]
+#[allow(clippy::unnecessary_cast)]
+const FILE_TYPE_MASK: u32 = libc::S_IFMT as u32;
+
 impl WorkspacePathIdentity {
     fn capture(path: PathBuf) -> Option<Self> {
         let metadata = fs::symlink_metadata(&path).ok()?;
@@ -1219,7 +1226,7 @@ impl WorkspacePathIdentity {
                 path,
                 device: metadata.dev(),
                 inode: metadata.ino(),
-                file_type: metadata.mode() & (libc::S_IFMT as u32),
+                file_type: metadata.mode() & FILE_TYPE_MASK,
             })
         }
         #[cfg(not(unix))]
@@ -1238,7 +1245,7 @@ impl WorkspacePathIdentity {
             use std::os::unix::fs::MetadataExt;
             metadata.dev() == self.device
                 && metadata.ino() == self.inode
-                && metadata.mode() & (libc::S_IFMT as u32) == self.file_type
+                && metadata.mode() & FILE_TYPE_MASK == self.file_type
         }
         #[cfg(not(unix))]
         {

--- a/crates/astra-turn-core/src/parallel_tool_exec.rs
+++ b/crates/astra-turn-core/src/parallel_tool_exec.rs
@@ -73,9 +73,17 @@ pub fn shared_tool_semaphore() -> Arc<Semaphore> {
         .clone()
 }
 
+/// Failure to obtain a slot from the process-wide tool execution budget.
+#[derive(Debug, thiserror::Error)]
+pub enum ToolPermitError {
+    /// The shared semaphore was closed, so no further tool admissions are possible.
+    #[error("global tool execution admission is closed")]
+    AdmissionClosed,
+}
+
 /// Acquire one slot from the process-wide tool execution budget while
 /// preserving the same wait/closed metrics across all runtime frontends.
-pub async fn acquire_shared_tool_permit() -> Result<OwnedSemaphorePermit, ()> {
+pub async fn acquire_shared_tool_permit() -> Result<OwnedSemaphorePermit, ToolPermitError> {
     let start = Instant::now();
     match shared_tool_semaphore().acquire_owned().await {
         Ok(permit) => {
@@ -84,7 +92,7 @@ pub async fn acquire_shared_tool_permit() -> Result<OwnedSemaphorePermit, ()> {
         }
         Err(_closed) => {
             record_tool_admission("closed", start.elapsed());
-            Err(())
+            Err(ToolPermitError::AdmissionClosed)
         }
     }
 }

--- a/crates/astra-turn-core/src/stall.rs
+++ b/crates/astra-turn-core/src/stall.rs
@@ -486,7 +486,7 @@ impl StallReflection {
     /// Format as a nudge message for injection into the conversation.
     pub fn to_nudge_message(&self) -> String {
         let mut parts = vec![
-            format!("⚠ REFLECTION — Agent appears stuck.\n"),
+            "⚠ REFLECTION — Agent appears stuck.\n".to_string(),
             format!("What happened: {}\n", self.what_happened),
             format!("Why: {}\n", self.why),
             format!("What to try: {}", self.what_to_try),

--- a/crates/services/src/session_journal.rs
+++ b/crates/services/src/session_journal.rs
@@ -2046,6 +2046,9 @@ impl SessionExecutionLease {
                 }
             })?;
         let lock_path = execution_lease_path(&journal_path, session_id);
+        // On Linux this binds a kernel-held guard that must live for the whole
+        // lease; the non-Linux fallback returns unit, which trips the lint.
+        #[allow(clippy::let_unit_value)]
         let _kernel_authority =
             acquire_execution_kernel_authority(&owner_scope, &journal_path, session_id)?;
         let created_parent_dirs = journal_path


### PR DESCRIPTION
## Summary

`make build` failed on macOS after #639 because two crates assumed Linux. This PR fixes the build and clears the clippy errors that Rust 1.98 raises under `-D warnings` in the same crates.

**Build fixes**
- `astra-sandbox`: `CommandExt` was imported only on Linux while `process_group` is called under `cfg(unix)`. The import is now `cfg(unix)`.
- `astra-tools`: `metadata.mode()` is `u32` but `libc::S_IFMT` is `u16` on macOS. Cast to `u32` at both call sites; discard `cancel_token` on the non-Linux fallback.

**Clippy fixes (Rust 1.98)**
- `services`: allow `let_unit_value` on the kernel-authority guard binding. On Linux it holds a socket that must live for the whole lease; on other platforms it is unit.
- `astra-tools`: single-range `vec!` in git blame, no-arg `format!` in a shell test.
- `astra-turn-core`: `acquire_shared_tool_permit` now returns a `thiserror` `ToolPermitError` instead of `Result<_, ()>`. The only caller matches on `Ok`, so it is unchanged. Removed a no-arg `format!` in the stall nudge.

## Verification
- `make build` (release) finishes clean on macOS.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass on the four edited crates.
- Lib tests pass for `astra-sandbox` (156) and `astra-turn-core` (3725).

## Known pre-existing macOS issues not addressed
- `make lint` still fails in `astra-runtime` with seven `result_large_err` lints on existing types (`StreamCollectError`, `InflightEdgeDispatch`, bedrock transport).
- The workspace mutation lease requires the Linux-only inotify tamper watch, which returns `Unsupported` on macOS. As a result `bash` and `write_file` tool calls refuse to run, and most `astra-tools` executor tests plus five `astra-services` lease tests fail on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01No3sQw9ftrXZGNNzVVk1dc
