### PR TITLE
ci: configure Mergify merge queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,33 @@
+queue_rules:
+  - name: main
+    merge_conditions: []
+    checks_timeout: 4h
+    merge_method: squash
+    commit_message_template: >
+      {{ title }} (#{{ number }})
+
+
+      {{ body | trim | get_section("## Summary") }}
+
+
+      Approved by: @{{ approved_reviews_by | join(', @') }}
+
+pull_request_rules:
+  - name: Automatic queue on approval for main
+    conditions:
+      - "#changes-requested-reviews-by<=0"
+      - label!=do-not-merge/wip
+      - base=main
+      - approved-reviews-by=XuPeng-SH
+    actions:
+      queue:
+        name: main
+
+  - name: Auto update branch
+    conditions:
+      - created-at>=00:10 ago
+    actions:
+      update:
+
+merge_queue:
+  max_parallel_checks: 1


### PR DESCRIPTION
## Summary

- add a Mergify queue for `main` using squash merges
- enqueue PRs after approval by `XuPeng-SH` when no change request or WIP label blocks them
- keep PR branches current automatically and serialize speculative queue checks
- adapt the squash commit body to Astra’s `## Summary` PR template

## Verification

- YAML parsed successfully with Ruby Psych
- configuration follows MatrixOne’s active `main` queue policy without copying obsolete release-branch queues

## User and compatibility impact

Repository automation only; no runtime or API behavior changes.