### PR TITLE
ci: request owner review on every pull request

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,16 +3,23 @@ queue_rules:
     merge_conditions: []
     checks_timeout: 4h
     merge_method: squash
-    commit_message_template: >
-      {{ title }} (#{{ number }})
-
-
-      {{ body | trim | get_section("## Summary") }}
-
-
-      Approved by: @{{ approved_reviews_by | join(', @') }}
+    commit_message_format:
+      title: pr-title
+      body: pr-body
+      trailers:
+        - approved-by
 
 pull_request_rules:
+  - name: Request XuPeng-SH review on every pull request
+    conditions:
+      - author!=XuPeng-SH
+      - -draft
+      - -approved-reviews-by=XuPeng-SH
+    actions:
+      request_reviews:
+        users:
+          - XuPeng-SH
+
   - name: Automatic queue on approval for main
     conditions:
       - "#changes-requested-reviews-by<=0"


### PR DESCRIPTION
## Summary

- explicitly request `XuPeng-SH` on every non-draft PR not authored by `XuPeng-SH`
- retain CODEOWNERS as the merge requirement while making pending ownership visible in the Reviewer field
- migrate the deprecated Mergify commit message template to `commit_message_format` before its removal deadline

## Verification

- YAML parsed successfully with Ruby Psych
- configuration uses the current documented Mergify `request_reviews` action and commit message format

## User and compatibility impact

Repository automation only; PRs authored by `XuPeng-SH` are excluded because GitHub does not allow authors to review their own PRs.