### PR TITLE
ci: route checks by changed paths

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -18,38 +18,73 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
+  scope:
+    name: Determine static-check scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      rust: ${{ steps.scope.outputs.rust }}
+      sdk: ${{ steps.scope.outputs.sdk }}
+      web: ${{ steps.scope.outputs.web }}
+      harness: ${{ steps.scope.outputs.harness }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # A PR merge commit plus both parents is enough for the path diff.
+          # Detection falls back to all scopes if a longer push range is absent.
+          fetch-depth: 2
+          persist-credentials: false
+      - name: Classify changed paths
+        id: scope
+        run: python3 scripts/ci/ci_scope.py
+
   check:
+    needs: scope
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Validate repository metadata and documentation
+        run: python3 scripts/ci/validate_repository.py
+      - name: Test CI scope routing
+        run: python3 scripts/ci/test_ci_scope.py
       - name: Validate Terminal-Bench harness contracts
+        if: ${{ needs.scope.result != 'success' || needs.scope.outputs.harness == 'true' }}
         run: |
           bash -n scripts/harness/local_gateway_contract.sh scripts/harness/test_local_gateway_contract.sh scripts/harness/run_terminal_bench_current.sh
           bash scripts/harness/test_local_gateway_contract.sh
       - uses: ./.github/actions/rust-setup
+        if: ${{ needs.scope.result != 'success' || needs.scope.outputs.rust == 'true' }}
         with:
           shared-key: ci-check
           save-cache: ${{ github.event_name == 'push' }}
           install-nextest: false
       - name: Run clippy
+        if: ${{ needs.scope.result != 'success' || needs.scope.outputs.rust == 'true' }}
         run: make lint
       - name: Check formatting
+        if: ${{ needs.scope.result != 'success' || needs.scope.outputs.rust == 'true' }}
         run: make format-check
       - uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2
+        if: ${{ needs.scope.result != 'success' || needs.scope.outputs.rust == 'true' }}
         with:
           tool: cargo-audit@0.22.1
       - name: Fetch RustSec advisory DB
+        if: ${{ needs.scope.result != 'success' || needs.scope.outputs.rust == 'true' }}
         run: |
           rm -rf "$HOME/.cargo/advisory-db"
           git clone --depth 1 https://github.com/RustSec/advisory-db "$HOME/.cargo/advisory-db"
       - name: cargo audit (RustSec advisory DB)
+        if: ${{ needs.scope.result != 'success' || needs.scope.outputs.rust == 'true' }}
         run: make audit
 
   sdk:
     name: "@astra/sdk (typecheck, test+coverage, build)"
+    needs: scope
+    if: ${{ always() && (needs.scope.result != 'success' || needs.scope.outputs.sdk == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -71,6 +106,8 @@ jobs:
 
   web:
     name: "web (typecheck, test, build)"
+    needs: scope
+    if: ${{ always() && (needs.scope.result != 'success' || needs.scope.outputs.web == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,28 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
+  scope:
+    name: Determine test scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      test_cli: ${{ steps.scope.outputs.test_cli }}
+      test_runtime: ${{ steps.scope.outputs.test_runtime }}
+      test_services: ${{ steps.scope.outputs.test_services }}
+      test_core: ${{ steps.scope.outputs.test_core }}
+      online_core: ${{ steps.scope.outputs.online_core }}
+      online_integration: ${{ steps.scope.outputs.online_integration }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # A PR merge commit plus both parents is enough for the path diff.
+          # Detection falls back to all scopes if a longer push range is absent.
+          fetch-depth: 2
+          persist-credentials: false
+      - name: Classify changed paths
+        id: scope
+        run: python3 scripts/ci/ci_scope.py
+
   # All shards start immediately. A previous compile-only job added a ~20 minute
   # barrier, but rust-cache intentionally removes workspace binaries before
   # saving, so the shards still had to compile and link their own test targets.
@@ -40,8 +62,12 @@ jobs:
 
   shard-a:
     name: "Test: astra-cli (${{ matrix.segment }})"
+    needs: scope
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      RUN_TESTS: ${{ needs.scope.result != 'success' || needs.scope.outputs.test_cli == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -63,17 +89,23 @@ jobs:
             command_timeout: 25m
 
     steps:
+      - name: Skip unaffected test segment
+        if: env.RUN_TESTS != 'true'
+        run: echo "No astra-cli test impact detected."
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: env.RUN_TESTS == 'true'
         with:
           persist-credentials: false
       - uses: ./.github/actions/rust-setup
+        if: env.RUN_TESTS == 'true'
         with:
           shared-key: ci-test
           save-cache: ${{ github.event_name == 'push' && matrix.segment == 'non-edge' }}
       - name: Prebuild mock MCP server
-        if: matrix.segment == 'non-edge'
+        if: env.RUN_TESTS == 'true' && matrix.segment == 'non-edge'
         run: cargo build --manifest-path Cargo.toml -p astra-cli --bin mock_mcp_server
       - name: "Test astra-cli (${{ matrix.segment }})"
+        if: env.RUN_TESTS == 'true'
         env:
           NEXTEST_FILTER: ${{ matrix.filter }}
         run: >-
@@ -81,18 +113,20 @@ jobs:
           --manifest-path Cargo.toml -p astra-cli
           --profile ci --lib --bins -E "$NEXTEST_FILTER"
       - name: Test astra-cli runtime profile guardrail
-        if: matrix.segment == 'non-edge'
+        if: env.RUN_TESTS == 'true' && matrix.segment == 'non-edge'
         run: >-
           timeout ${{ matrix.command_timeout }} cargo nextest run
           --manifest-path Cargo.toml -p astra-cli
           --profile ci --lib
           -E 'test(/local_cli_catalog_exposes_the_root_work_lifecycle/)'
       - name: Dump processes on failure
-        if: failure()
+        if: failure() && env.RUN_TESTS == 'true'
         run: ps -ef | grep -E 'cargo|nextest|astra|bash|sleep' || true
 
   shard-b:
     name: "Test: astra-runtime"
+    needs: scope
+    if: ${{ always() && (needs.scope.result != 'success' || needs.scope.outputs.test_runtime == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -122,6 +156,8 @@ jobs:
 
   shard-c:
     name: "Test: turn-core + services + plan"
+    needs: scope
+    if: ${{ always() && (needs.scope.result != 'success' || needs.scope.outputs.test_services == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -140,6 +176,8 @@ jobs:
 
   shard-d:
     name: "Test: core crates + bridge hooks"
+    needs: scope
+    if: ${{ always() && (needs.scope.result != 'success' || needs.scope.outputs.test_core == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -170,6 +208,8 @@ jobs:
   # two jobs share test-binary link and live-DB work more evenly.
   test-online:
     name: "Test: online (${{ matrix.lane }})"
+    needs: scope
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -177,6 +217,10 @@ jobs:
       matrix:
         lane: [core, integration]
     env:
+      RUN_TESTS: >-
+        ${{ needs.scope.result != 'success' ||
+            (matrix.lane == 'core' && needs.scope.outputs.online_core == 'true') ||
+            (matrix.lane == 'integration' && needs.scope.outputs.online_integration == 'true') }}
       MATRIXONE_HOST: localhost
       MATRIXONE_PORT: "6001"
       MATRIXONE_USER: root
@@ -195,10 +239,15 @@ jobs:
       MEMORIA_EMBEDDING_DIM: ${{ vars.EMBEDDING_DIM || '1024' }}
       ASTRA_ONLINE_LANE: ${{ matrix.lane }}
     steps:
+      - name: Skip unaffected online lane
+        if: env.RUN_TESTS != 'true'
+        run: echo "No online-test impact detected."
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: env.RUN_TESTS == 'true'
         with:
           persist-credentials: false
       - name: Prepare dependency env
+        if: env.RUN_TESTS == 'true'
         run: |
           cp .env.example .env
           {
@@ -210,20 +259,24 @@ jobs:
             echo "MEMORIA_EMBEDDING_DIM=${MEMORIA_EMBEDDING_DIM}"
           } >> .env
       - name: Start dependencies
+        if: env.RUN_TESTS == 'true'
         run: make dev-deps-up
       - uses: ./.github/actions/rust-setup
+        if: env.RUN_TESTS == 'true'
         with:
           shared-key: ci-test
       - name: Wait for dependencies
+        if: env.RUN_TESTS == 'true'
         run: make dev-deps-wait
       - name: Run online tests
+        if: env.RUN_TESTS == 'true'
         env:
           ASTRA_TEST_DB_IT: "1"
           ASTRA_TEST_DB_IT_TEST_THREADS: "1"
         run: make test-online NEXTEST_ONLINE_PROFILE=strict-online-ci
       - name: Dump dependency logs
-        if: failure()
+        if: failure() && env.RUN_TESTS == 'true'
         run: make dev-deps-logs-once
       - name: Stop dependencies
-        if: always()
+        if: always() && env.RUN_TESTS == 'true'
         run: make dev-deps-down

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,21 @@ for the correct lane. Pull requests from forks must remain testable without
 repository secrets, so live-provider coverage must have a deterministic
 offline path or stay in an explicitly optional lane.
 
+CI routes required checks by the files changed in a pull request:
+
+| Change area | Heavy checks selected |
+| --- | --- |
+| Documentation and repository governance | Lightweight repository contracts only |
+| Rust crates | Workspace static checks plus affected offline shards; shared runtime paths also select online tests |
+| `packages/sdk/` | SDK and Web (the local SDK consumer) |
+| `web/` | Web |
+| Terminal-Bench harness scripts | Harness contracts |
+| CI routing, workflows, or an unavailable diff | All checks (fail-safe) |
+
+Required check names remain present when their heavy work is skipped, so this
+routing is compatible with branch protection and the merge queue. The routing
+contract and its tests live in [`scripts/ci/`](scripts/ci/).
+
 ## Open a pull request
 
 1. Rebase the feature branch on the current `main` branch.

--- a/scripts/ci/ci_scope.py
+++ b/scripts/ci/ci_scope.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Classify changed paths into Astra CI execution scopes.
+
+The classifier is deliberately conservative: an unknown diff or a change to CI
+itself enables every scope. Documentation and repository-governance changes are
+handled by the always-on lightweight repository checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+SCOPES = (
+    "rust",
+    "sdk",
+    "web",
+    "harness",
+    "test_cli",
+    "test_runtime",
+    "test_services",
+    "test_core",
+    "online_core",
+    "online_integration",
+)
+RUST_SCOPES = (
+    "rust",
+    "test_cli",
+    "test_runtime",
+    "test_services",
+    "test_core",
+    "online_core",
+    "online_integration",
+)
+SERVICE_CRATES = {"services", "astra-turn-core", "astra-plan", "astra-prompts"}
+LIGHTWEIGHT_ROOT_FILES = {
+    ".dockerignore",
+    ".editorconfig",
+    ".gitattributes",
+    ".gitignore",
+    "CITATION.cff",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "README.md",
+    "SUPPORT.md",
+}
+
+
+def _scopes(*enabled: str) -> dict[str, bool]:
+    return {scope: scope in enabled for scope in SCOPES}
+
+
+def _enable(result: dict[str, bool], *scopes: str) -> None:
+    for scope in scopes:
+        result[scope] = True
+
+
+def _normalize(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def _is_lightweight(path: str) -> bool:
+    return (
+        path in LIGHTWEIGHT_ROOT_FILES
+        or path.endswith((".md", ".mdc"))
+        or path.startswith(
+            (
+                ".agent/",
+                ".claude/",
+                ".cursor/",
+                ".github/CODEOWNERS",
+                ".github/ISSUE_TEMPLATE/",
+                ".github/PULL_REQUEST_TEMPLATE.md",
+                ".github/dependabot.yml",
+                ".github/mergify.yml",
+                ".github/release.yml",
+                ".kiro/",
+                "deployment/",
+                "docs/",
+                "monitoring/",
+                "plans/",
+                "scripts/",
+            )
+        )
+    )
+
+
+def _rust_scope_for(path: str, result: dict[str, bool]) -> None:
+    _enable(result, "rust")
+    parts = path.split("/")
+    crate = parts[1] if len(parts) > 1 else ""
+    is_test_only = "/tests/" in path or path.endswith(("/tests.rs", "/test.rs"))
+
+    if crate == "astra-cli":
+        _enable(result, "test_cli")
+        return
+    if crate == "runtime":
+        _enable(result, "test_runtime")
+        if is_test_only:
+            online_lane = "online_integration" if "/tests/" in path else "online_core"
+            _enable(result, online_lane)
+        else:
+            # Runtime is consumed by the CLI and the bridge-hook tests in shard D.
+            _enable(result, "test_cli", "test_core", "online_core", "online_integration")
+        return
+    if crate in SERVICE_CRATES:
+        _enable(result, "test_services")
+        if crate == "services":
+            _enable(result, "online_core")
+        elif crate == "astra-plan":
+            _enable(result, "online_integration")
+        elif crate == "astra-turn-core" and not is_test_only:
+            _enable(result, "online_core")
+        if not is_test_only:
+            # These crates feed both runtime orchestration and CLI execution.
+            _enable(result, "test_runtime", "test_cli")
+        return
+
+    _enable(result, "test_core")
+    if not is_test_only:
+        # Core crates are shared broadly. Keep their downstream behavioral gates
+        # conservative; workspace clippy also compiles every downstream target.
+        _enable(
+            result,
+            "test_services",
+            "test_runtime",
+            "test_cli",
+            "online_core",
+            "online_integration",
+        )
+
+
+def classify(paths: list[str]) -> dict[str, bool]:
+    normalized = {_normalize(path) for path in paths if _normalize(path)}
+    if not normalized:
+        return _scopes(*SCOPES)
+
+    result = _scopes()
+    for path in normalized:
+        # Changes to routing or workflow behavior must exercise every route.
+        if path.startswith((".github/workflows/", ".github/actions/", "scripts/ci/")) or path == "Makefile":
+            return _scopes(*SCOPES)
+
+        if (
+            path in {"Cargo.toml", "Cargo.lock", "rust-toolchain.toml"}
+            or path.startswith((".cargo/", ".config/nextest"))
+        ):
+            _enable(result, *RUST_SCOPES)
+            continue
+        if path == ".nvmrc":
+            _enable(result, "sdk", "web")
+            continue
+        if path.startswith("packages/sdk/"):
+            # The web workspace consumes the local SDK package.
+            _enable(result, "sdk", "web")
+            continue
+        if path.startswith("web/"):
+            _enable(result, "web")
+            continue
+        if path.startswith("scripts/harness/"):
+            _enable(result, "harness")
+            continue
+        if path.startswith("config/") or path in {".env.example", ".env.production.example"}:
+            _enable(
+                result,
+                "rust",
+                "test_core",
+                "test_runtime",
+                "online_core",
+                "online_integration",
+            )
+            continue
+        if path == "Dockerfile":
+            # make lint verifies its Rust version remains aligned with the toolchain.
+            _enable(result, "rust")
+            continue
+        if path.startswith("crates/"):
+            _rust_scope_for(path, result)
+            continue
+        if _is_lightweight(path):
+            continue
+
+        # A new or unclassified area must not silently bypass its relevant gate.
+        return _scopes(*SCOPES)
+
+    return result
+
+
+def changed_paths_from_event() -> list[str]:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        raise RuntimeError("GITHUB_EVENT_PATH is not set")
+    event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    if "pull_request" in event:
+        base = event["pull_request"]["base"]["sha"]
+        head = event["pull_request"]["head"]["sha"]
+    else:
+        base = event.get("before")
+        head = event.get("after") or os.environ.get("GITHUB_SHA")
+    if not base or not head or set(base) == {"0"}:
+        return []
+    output = subprocess.check_output(
+        ["git", "diff", "--name-only", "-z", base, head], stderr=subprocess.STDOUT
+    )
+    return [item.decode("utf-8") for item in output.split(b"\0") if item]
+
+
+def emit(scopes: dict[str, bool], paths: list[str], *, fallback: str | None = None) -> None:
+    if fallback:
+        print(f"::warning::{fallback}; enabling every CI scope", file=sys.stderr)
+    for scope in SCOPES:
+        print(f"{scope}={'true' if scopes[scope] else 'false'}")
+    print("changed_paths=" + (", ".join(sorted(paths)) or "<unknown; full fallback>"))
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a", encoding="utf-8") as output:
+            for scope in SCOPES:
+                output.write(f"{scope}={'true' if scopes[scope] else 'false'}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*", help="explicit changed paths; omit in GitHub Actions")
+    args = parser.parse_args()
+    try:
+        paths = args.paths or changed_paths_from_event()
+        emit(classify(paths), paths)
+    except (
+        OSError,
+        RuntimeError,
+        subprocess.CalledProcessError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as error:
+        # Scope detection is an optimization, never a reason to omit validation.
+        emit(_scopes(*SCOPES), [], fallback=f"CI scope detection failed: {error}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_ci_scope.py
+++ b/scripts/ci/test_ci_scope.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from unittest.mock import patch
+
+from ci_scope import classify, main
+
+
+class CiScopeTests(unittest.TestCase):
+    def test_documentation_and_governance_use_no_heavy_scope(self) -> None:
+        scopes = classify(
+            ["README.md", "docs/guides/testing.md", "CITATION.cff", ".github/CODEOWNERS"]
+        )
+        self.assertFalse(any(scopes.values()))
+
+    def test_dot_prefixed_paths_are_not_corrupted(self) -> None:
+        scopes = classify(["./.agent/skills/verify_task/SKILL.md"])
+        self.assertFalse(any(scopes.values()))
+
+    def test_sdk_change_also_validates_web_consumer(self) -> None:
+        scopes = classify(["packages/sdk/src/client.ts"])
+        self.assertTrue(scopes["sdk"])
+        self.assertTrue(scopes["web"])
+        self.assertFalse(scopes["rust"])
+
+    def test_web_change_does_not_run_sdk_or_rust(self) -> None:
+        scopes = classify(["web/app/page.tsx"])
+        self.assertTrue(scopes["web"])
+        self.assertFalse(scopes["sdk"])
+        self.assertFalse(scopes["rust"])
+
+    def test_cli_source_only_selects_cli_tests(self) -> None:
+        scopes = classify(["crates/astra-cli/src/main.rs"])
+        self.assertTrue(scopes["rust"])
+        self.assertTrue(scopes["test_cli"])
+        self.assertFalse(scopes["test_runtime"])
+        self.assertFalse(scopes["online_core"])
+        self.assertFalse(scopes["online_integration"])
+
+    def test_test_only_rust_change_selects_owning_shard(self) -> None:
+        scopes = classify(["crates/core/tests/repo_layout_contract.rs"])
+        self.assertTrue(scopes["rust"])
+        self.assertTrue(scopes["test_core"])
+        self.assertFalse(scopes["test_cli"])
+        self.assertFalse(scopes["online_core"])
+        self.assertFalse(scopes["online_integration"])
+
+    def test_shared_core_source_selects_downstream_lanes(self) -> None:
+        scopes = classify(["crates/astra-text-utils/src/lib.rs"])
+        for name in (
+            "rust",
+            "test_cli",
+            "test_runtime",
+            "test_services",
+            "test_core",
+            "online_core",
+            "online_integration",
+        ):
+            self.assertTrue(scopes[name])
+
+    def test_runtime_integration_test_selects_only_its_online_lane(self) -> None:
+        scopes = classify(["crates/runtime/tests/http_contract.rs"])
+        self.assertTrue(scopes["test_runtime"])
+        self.assertFalse(scopes["test_cli"])
+        self.assertFalse(scopes["online_core"])
+        self.assertTrue(scopes["online_integration"])
+
+    def test_services_test_selects_online_core_lane(self) -> None:
+        scopes = classify(["crates/services/tests/work_repository_db_it.rs"])
+        self.assertTrue(scopes["test_services"])
+        self.assertTrue(scopes["online_core"])
+        self.assertFalse(scopes["online_integration"])
+
+    def test_harness_change_uses_targeted_contract_scope(self) -> None:
+        scopes = classify(["scripts/harness/local_gateway_contract.sh"])
+        self.assertTrue(scopes["harness"])
+        self.assertFalse(scopes["rust"])
+
+    def test_cargo_lock_runs_rust_but_not_node(self) -> None:
+        scopes = classify(["Cargo.lock"])
+        self.assertTrue(
+            all(scopes[name] for name in ("rust", "test_cli", "online_core", "online_integration"))
+        )
+        self.assertFalse(scopes["sdk"])
+        self.assertFalse(scopes["web"])
+
+    def test_ci_classifier_change_falls_back_to_every_scope(self) -> None:
+        self.assertTrue(all(classify(["scripts/ci/ci_scope.py"]).values()))
+
+    def test_known_governance_change_uses_only_lightweight_checks(self) -> None:
+        self.assertFalse(any(classify(["LICENSE"]).values()))
+
+    def test_unknown_change_falls_back_to_every_scope(self) -> None:
+        self.assertTrue(all(classify(["unexpected/build.graph"]).values()))
+
+    def test_missing_diff_falls_back_to_every_scope(self) -> None:
+        self.assertTrue(all(classify([]).values()))
+
+    def test_detection_error_exits_successfully_with_full_fallback(self) -> None:
+        stdout = StringIO()
+        stderr = StringIO()
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("sys.argv", ["ci_scope.py"]),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            self.assertEqual(main(), 0)
+        self.assertIn("rust=true", stdout.getvalue())
+        self.assertIn("online_integration=true", stdout.getvalue())
+        self.assertIn("enabling every CI scope", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/validate_repository.py
+++ b/scripts/ci/validate_repository.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Dependency-free repository metadata and documentation checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import re
+import subprocess
+
+
+def tracked_files() -> list[Path]:
+    output = subprocess.check_output(["git", "ls-files", "-z"])
+    return [Path(item.decode("utf-8")) for item in output.split(b"\0") if item]
+
+
+def skill_body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        raise AssertionError(f"{path}: missing YAML frontmatter")
+    _, separator, body = text[4:].partition("\n---\n")
+    if not separator:
+        raise AssertionError(f"{path}: unterminated YAML frontmatter")
+    return body
+
+
+def main() -> None:
+    files = [path for path in tracked_files() if path.exists()]
+    errors: list[str] = []
+
+    markdown = [path for path in files if path.suffix in {".md", ".mdc"}]
+    link_pattern = re.compile(r"(?<!!)\[[^]]*\]\(([^)\s]+)(?:\s+[\"'][^\"']*[\"'])?\)")
+    for source in markdown:
+        text = source.read_text(encoding="utf-8", errors="replace")
+        for target in link_pattern.findall(text):
+            target = target.strip("<>")
+            if target.startswith(("http://", "https://", "#", "mailto:", "data:")):
+                continue
+            relative = target.split("#", 1)[0]
+            if relative and not (source.parent / relative).resolve().exists():
+                errors.append(f"{source}: broken local link {target}")
+
+    for source in [path for path in files if path.suffix == ".json"]:
+        try:
+            json.loads(source.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            errors.append(f"{source}: invalid JSON ({error})")
+
+    shell_scripts = [path for path in files if path.suffix == ".sh"]
+    for source in shell_scripts:
+        result = subprocess.run(
+            ["bash", "-n", str(source)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode:
+            errors.append(f"{source}: invalid shell syntax ({result.stderr.strip()})")
+
+    workflow_files = [
+        *Path(".github/workflows").glob("*.yml"),
+        *Path(".github/workflows").glob("*.yaml"),
+        *Path(".github/actions").glob("*/action.yml"),
+        *Path(".github/actions").glob("*/action.yaml"),
+    ]
+    uses_pattern = re.compile(r"^\s*-?\s*uses:\s*([^\s#]+)", re.MULTILINE)
+    pinned_action = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+    for source in workflow_files:
+        text = source.read_text(encoding="utf-8")
+        for action in uses_pattern.findall(text):
+            if action.startswith(("./", "docker://")):
+                continue
+            if not pinned_action.fullmatch(action):
+                errors.append(f"{source}: action must be pinned to a full commit SHA ({action})")
+
+    design_index = Path("docs/design/README.md").read_text(encoding="utf-8")
+    for design in Path("docs/design").glob("*.md"):
+        if design.name != "README.md" and f"]({design.name})" not in design_index:
+            errors.append(f"{design}: missing from docs/design/README.md")
+
+    for adapter in [
+        Path("CLAUDE.md"),
+        Path(".claude/CLAUDE.md"),
+        Path(".cursor/rules/project-rules.mdc"),
+        Path(".kiro/steering/project-rules.md"),
+    ]:
+        text = adapter.read_text(encoding="utf-8")
+        if "AGENTS.md" not in text or "canonical" not in text:
+            errors.append(f"{adapter}: must delegate to canonical AGENTS.md")
+
+    agent_root = Path(".agent/skills")
+    claude_root = Path(".claude/skills")
+    agent_names = {path.parent.name for path in agent_root.glob("*/SKILL.md")}
+    claude_names = {path.parent.name for path in claude_root.glob("*/SKILL.md")}
+    if agent_names != claude_names:
+        errors.append(".agent/skills and .claude/skills expose different skill sets")
+    for name in sorted(agent_names & claude_names):
+        if skill_body(agent_root / name / "SKILL.md") != skill_body(claude_root / name / "SKILL.md"):
+            errors.append(f"{name}: .agent and .claude instruction bodies differ")
+
+    stale_suffixes = {".bak", ".disabled", ".orig", ".rej"}
+    for path in files:
+        if path.suffix in stale_suffixes:
+            errors.append(f"{path}: tracked stale/disabled artifact")
+
+    if errors:
+        raise SystemExit("\n".join(errors))
+    print(
+        f"repository metadata: ok ({len(markdown)} Markdown/rule files, "
+        f"{len(shell_scripts)} shell scripts, {len(agent_names)} mirrored skills)"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a fail-safe changed-path classifier for Rust shards, online core/integration lanes, SDK, Web, and harness checks
- keep required check contexts stable while avoiding expensive work for unaffected areas
- add always-on lightweight validation for local documentation links, design-index coverage, mirrored agent instructions, JSON, shell syntax, stale artifacts, and pinned Actions
- document the routing contract for contributors

## Safety properties

- CI/workflow/router changes, unknown paths, empty diffs, and detection errors run every scope
- SDK changes also test the Web consumer
- shared Rust changes fan out conservatively; test-only changes use their owning shard
- matrix jobs still materialize every protected check name when their heavy steps are skipped
- fork PRs retain the existing mock/real embedding behavior

## Validation

- 16 classifier unit tests
- repository metadata validator
- workflow YAML parse
- git diff whitespace check

This PR intentionally changes CI routing, so its own run selects the full suite.