### PR TITLE
docs: carry the Docker quick start through to a first agent response

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,15 +146,16 @@ ties Pi, finishes one task behind Hermes, and one ahead of DSH.
 
 ## Quick start
 
-Two supported paths. Start with **Docker** to evaluate Astra without a Rust or
-Node toolchain; **build from source** when you want the `astra` CLI/TUI, the Web
-dashboard, or to change Astra itself. For production topologies, use the
+Two supported paths, both ending at a working agent response. Start with
+**Docker** to evaluate Astra without a Rust or Node toolchain; **build from
+source** when you want the Web dashboard, CLI-local Runner capacity, or to
+change Astra itself. For production topologies, use the
 [getting-started guide](docs/quickstart/README.md).
 
 | Path | What you get | Additional prerequisites |
 | --- | --- | --- |
-| [Docker](#docker) | MatrixOne, Memoria, and `astra-server` from published images — the HTTP API | Docker Compose and OpenSSL |
-| [From source](#build-from-source) | The same backbone plus the `astra` CLI/TUI, the Web dashboard, and CLI-local Runner capacity | Rust 1.97 and Node.js 24, both pinned in the repository |
+| [Docker](#docker) | MatrixOne, Memoria, and `astra-server` from published images, plus the prebuilt `astra` CLI | Docker Compose and OpenSSL |
+| [From source](#build-from-source) | The same backbone built locally, plus the Web dashboard and CLI-local Runner capacity | Rust 1.97 and Node.js 24, both pinned in the repository |
 
 Both paths need Git, Make, and at least one supported LLM endpoint. Semantic
 memory needs an embedding API; deterministic mock embeddings are also available
@@ -162,9 +163,14 @@ for local evaluation and tests.
 
 ### Docker
 
+No Rust or Node toolchain. These steps run all the way to a real agent
+response, not just a healthy port.
+
+#### 1. Start the stack
+
 ```bash
-git clone https://github.com/matrixorigin/astra.git
-cd astra
+git clone https://github.com/matrixorigin/Astra.git
+cd Astra
 
 make stack-env
 ```
@@ -187,13 +193,63 @@ curl http://localhost:17001/health
 | HTTP API | <http://localhost:17001> |
 | Health check | <http://localhost:17001/health> |
 
+#### 2. Install the CLI
+
+The stack ships `astra-server`, not the CLI. Install the prebuilt `astra`
+binary to drive it — Linux and macOS, `amd64` and `arm64`:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/matrixorigin/astra-suite/main/scripts/install-astra.sh | sh
+astra health
+```
+
+The CLI defaults to `http://127.0.0.1:17001`, which is where the stack binds,
+so no extra configuration is needed. If you remapped `ASTRA_API_PORT`, set
+`ASTRA_API_URL` or pass `--api-url` to each command. Pass `-v <version>` to the
+installer, and set `ASTRA_IMAGE` before `make stack-up`, when you need a pinned
+CLI and server pair.
+
+#### 3. Bootstrap the admin account
+
+```bash
+astra admin register --username admin --password '<password>'
+```
+
+On a fresh data volume this performs the initial admin bootstrap, prints
+`registered and logged in (initial admin)`, and stores the credentials in the
+local CLI profile.
+
+#### 4. Register a model
+
+```bash
+astra admin model add MODEL_NAME openai \
+  --api-key "$LLM_API_KEY" --base-url https://your-endpoint/v1
+astra admin model check MODEL_NAME
+```
+
+`model check` probes the endpoint and reports `is_active` and `connectivity`.
+A model reaches `is_active: true` only when the probe succeeds, so this is the
+step that tells you routing will work. For more than one model, write a
+`.models.yaml` and run
+`astra admin model load .models.yaml --update-existing`.
+
+#### 5. First agent response
+
+```bash
+astra chat -m "Explain what you can and cannot do in this deployment"
+astra session list
+```
+
+You are through the loop when the request returns a model response and
+`session list` shows the durable session it created.
+
 This stack is Server-only by design. Server-side agent turns, memory, planning,
 MCP, and introspection are available, while file, shell, Git, build/test, and
-private-network tools stay unavailable until a Runner connects. Operate it with
-`make stack-status`, `make stack-logs SERVICE=api`, and `make stack-down`. The
-[all-in-one guide](deployment/all-in-one/README.md) covers admin bootstrap,
-model loading, and the server+edge profile; the
-[Docker quick start](docs/quickstart/docker.md) covers ports and
+private-network tools stay unavailable until a Runner connects — which is what
+the answer above should tell you. Operate it with `make stack-status`,
+`make stack-logs SERVICE=api`, and `make stack-down`. The
+[all-in-one guide](deployment/all-in-one/README.md) covers the server+edge
+profile; the [Docker quick start](docs/quickstart/docker.md) covers ports and
 troubleshooting.
 
 ### Build from source

--- a/deployment/all-in-one/README.md
+++ b/deployment/all-in-one/README.md
@@ -77,14 +77,25 @@ Use `astra admin register` to create an administrator account. On a fresh Matrix
 data volume this performs the initial admin bootstrap. After an admin exists,
 `astra admin register` must be run while logged in as an existing admin.
 
+This stack ships `astra-server` but not the `astra` CLI binary. Install the
+prebuilt CLI if you are not building from source:
+
 ```bash
-./target/debug/astra admin --api-url http://127.0.0.1:17001 register \
+curl -sSL https://raw.githubusercontent.com/matrixorigin/astra-suite/main/scripts/install-astra.sh | sh
+```
+
+```bash
+astra admin --api-url http://127.0.0.1:17001 register \
   --username admin \
   --email admin@example.com \
   --password '<password>'
 
-./target/debug/astra admin --api-url http://127.0.0.1:17001 model load .models.yaml --update-existing
+astra admin --api-url http://127.0.0.1:17001 model load .models.yaml --update-existing
 ```
+
+When building from source, use `./target/debug/astra` (or
+`./target/release/astra`) in place of `astra` above. `--api-url` can be omitted
+whenever the server listens on the default `http://127.0.0.1:17001`.
 
 `astra admin register` stores the returned admin credentials locally. It prints
 `registered and logged in (initial admin)` for the first admin, and

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -22,7 +22,23 @@ make stack-up
 
 # 4. Verify
 curl http://localhost:17001/health
+
+# 5. Install the prebuilt CLI (no Rust toolchain needed)
+curl -sSL https://raw.githubusercontent.com/matrixorigin/astra-suite/main/scripts/install-astra.sh | sh
+
+# 6. Bootstrap the admin account and register a model
+astra admin register --username admin --password '<password>'
+astra admin model add MODEL_NAME openai --api-key "$LLM_API_KEY" --base-url https://your-endpoint/v1
+astra admin model check MODEL_NAME
+
+# 7. First agent response
+astra chat -m "Explain what you can and cannot do in this deployment"
 ```
+
+Steps 1-4 prove the services are up; steps 5-7 prove Astra is usable. The CLI
+defaults to `http://127.0.0.1:17001`; set `ASTRA_API_URL` or pass `--api-url`
+if you remapped `ASTRA_API_PORT`. `model check` reports `is_active` and
+`connectivity`, and a model becomes active only when the probe succeeds.
 
 ## Compose Stack
 


### PR DESCRIPTION
Follow-up to #659. That PR put Docker first; this one makes the Docker path actually finish.

## Problem

The Docker path is advertised as the way to evaluate Astra with no Rust or Node toolchain, but it stopped here:

```bash
make stack-up
curl http://localhost:17001/health
```

That proves a port is open. It does not prove anyone can *use* Astra. Everything that turns a running stack into a working agent — account bootstrap, model import, first request — was deferred to `deployment/all-in-one/README.md`, which invokes `./target/debug/astra`.

That is a binary a Docker-only user has never built. **The "no toolchain needed" path dead-ended on a command that requires the toolchain.** A reader following the recommended route hits a wall with no in-document way past it.

The missing piece was already in this repository. `scripts/README.md` documents a public installer that ships prebuilt `astra` CLI binaries from `matrixorigin/astra-suite`, and the top-level README never referenced it.

## Change

The Docker path now runs to a real agent response:

| Step | Command | How you know it worked |
| --- | --- | --- |
| 1 | `make stack-env` / `make stack-up` | `curl /health` |
| 2 | install the prebuilt `astra` CLI | `astra health` |
| 3 | `astra admin register` | prints `registered and logged in (initial admin)` |
| 4 | `astra admin model add` + `model check` | reports `is_active: true` / `connectivity` |
| 5 | `astra chat -m ...` + `astra session list` | a model response, and the durable session it created |

Every step names its success signal, so a reader can tell whether it worked rather than discovering three steps later that it did not. Step 4 matters most: a model only reaches `is_active: true` when the connectivity probe actually succeeds, so that is the step that confirms routing will work.

The suggested first prompt — *"Explain what you can and cannot do in this deployment"* — makes the answer double as the explanation of why this stack is Server-only and what connecting a Runner would add.

### Same gap closed downstream

- **`docs/quickstart/docker.md`** — its Quick Start also stopped at `curl /health`. Now continues through install, bootstrap and first request.
- **`deployment/all-in-one/README.md`** — now leads with the installed `astra` binary and keeps `./target/debug/astra` as the explicitly labelled from-source variant. This was the exact trap.

### One unrelated line

The Docker clone command said `matrixorigin/astra.git`. That line entered `main` through #659 after the casing pass in #661 had already run, so it was the only lowercase GitHub reference left in the README. Restored to `Astra` along with its `cd`.

## Verification

- **Dry-ran the installer on this machine.** It resolves `astra-cli-v0.0.5` for `darwin-arm64` and points at a real release asset that returns `200`. Published targets are linux/darwin × amd64/arm64, all checksummed.
- **`DEFAULT_API_URL` is `http://127.0.0.1:17001`** (`crates/core/src/config.rs`), matching the stack's default bind — so no `--api-url` is needed for a default setup. Confirmed in source rather than assumed.
- **The quoted output strings are real**, not invented: `registered and logged in (initial admin)` and the `is_active` / `connectivity` lines are all in `crates/astra-cli/src/admin_cli/mod.rs`.
- All relative links in the three touched files resolve.
- Rebased onto current `main`, so it keeps the `MEMORIA_EMBEDDING_PROVIDER=mock` wording from #681 — which is worth noting, because mock embeddings mean this whole loop can now be run with an LLM endpoint alone.
- I could not run the stack end to end; that needs a live LLM endpoint.

## One thing to confirm before merge

**Version skew.** The published CLI is `astra-cli-v0.0.5` (2026-07-09) while `matrixorigin/astra:latest` tracks `main`. This PR makes that pairing the recommended first-run experience, so it deserves one end-to-end run to confirm a July CLI still bootstraps and chats against a current server image.

If it does not, the fix is a fresh `astra-cli-v*` release rather than a documentation change — but you would want to know before this lands, because a broken step 2 is worse than the current dead end. The docs mention `-v <version>` and `ASTRA_IMAGE` for anyone needing a pinned pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
