### PR TITLE
ci: harden merge queue automation contract

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,5 +1,10 @@
 queue_rules:
   - name: main
+    # Keep checks in place so GitHub's strict up-to-date protection and the
+    # queue validate the same PR head. See docs/guides/repository-automation.md.
+    batch_size: 1
+    max_checks_retries: 0
+    update_method: merge
     merge_conditions: []
     checks_timeout: 4h
     merge_method: squash
@@ -30,11 +35,6 @@ pull_request_rules:
       queue:
         name: main
 
-  - name: Auto update branch
-    conditions:
-      - created-at>=00:10 ago
-    actions:
-      update:
-
 merge_queue:
+  mode: serial
   max_parallel_checks: 1

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,6 +5,7 @@ queue_rules:
     batch_size: 1
     max_checks_retries: 0
     update_method: merge
+    branch_protection_injection_mode: queue
     merge_conditions: []
     checks_timeout: 4h
     merge_method: squash

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ operators, and kernel contributors to the level of detail they need.
 | [Testing guide](guides/testing.md) | Offline, contract, online, and system test lanes |
 | [Makefile reference](reference/makefile-commands.md) | Build, validation, test, and development targets |
 | [Dependencies](reference/dependencies.md) | Required and optional development tools |
+| [Repository automation](guides/repository-automation.md) | Maintainer contract for Mergify, branch protection, and external-fork delivery |
 | [Release guide](guides/releasing.md) | Maintainer workflow for versioned CLI and container releases |
 | [System E2E matrix](testing/system-e2e-matrix.md) | Cross-surface runtime behavior and coverage obligations |
 | [Capability harness](testing/capability-harness.md) | Capability-provider and model/tool test contract |

--- a/docs/guides/repository-automation.md
+++ b/docs/guides/repository-automation.md
@@ -16,8 +16,8 @@ The queue settings are explicit rather than relying on service defaults:
 
 - `batch_size: 1`, `max_checks_retries: 0`, `mode: serial`, and
   `max_parallel_checks: 1` keep validation on the original pull request.
-- `update_method: merge` works for branches in forks without rewriting their
-  history.
+- `update_method: merge` updates eligible fork branches without rewriting
+  their history.
 - Branch-protection requirements are injected by Mergify, so the required
   check list remains owned by GitHub.
 
@@ -27,8 +27,10 @@ all stale branches creates avoidable CI runs and writes to contributor forks.
 
 ## Required GitHub App access
 
-The Mergify installation on `matrixorigin/Astra` must retain these repository
-permissions:
+Mergify requests a fixed permission set for its products. Do not trim that set
+to this table: these are the permissions most directly involved in Astra's
+queue path. The installation must include `matrixorigin/Astra` in its selected
+repository access and retain Mergify's requested permissions, including:
 
 | Permission | Access | Why |
 | --- | --- | --- |
@@ -37,6 +39,9 @@ permissions:
 | Checks | Read and write | Publish queue and rule results |
 | Workflows | Read and write | Update a Git ref when the incoming `main` commits include `.github/workflows/*` |
 | Administration | Read | Read branch-protection requirements |
+
+The current full permission set and its feature-level rationale are maintained
+in [Mergify's security reference](https://docs.mergify.com/security/#github-app-required-permissions).
 
 `Workflows: read and write` does not make workflow changes part of a
 documentation pull request. GitHub checks the complete ref update: if `main`
@@ -47,6 +52,13 @@ GitHub rejects that ref update unless the app has the Workflows permission.
 When Mergify requests new permissions, an organization owner must approve the
 installation update. Selecting the permission in the app UI is not sufficient
 until the organization installation reports the new effective access.
+
+For a pull request from a personal fork, the author must also select **Allow
+edits from maintainers**. GitHub labels this **Allow edits and access to secrets
+by maintainers** when the fork contains Actions workflows. This is the author's
+security choice; if it is disabled, ask the author to update the branch instead
+of bypassing protection. See [GitHub's fork collaboration
+guide](https://docs.github.com/en/pull-requests/how-tos/work-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
 
 ## Protection settings
 
@@ -80,9 +92,12 @@ before rerunning CI:
 
 1. A message naming `.github/workflows/...` and missing `workflows` permission
    is an installation-permission failure, not a test failure.
-2. A merge conflict requires the contributor or maintainer to resolve the
+2. A message saying the fork branch cannot be updated without a missing app
+   permission can mean maintainer edits are disabled; the author must update
+   the branch or opt in.
+3. A merge conflict requires the contributor or maintainer to resolve the
    branch; increasing app permissions does not help.
-3. A required check failure after Mergify updates the branch is a real CI
+4. A required check failure after Mergify updates the branch is a real CI
    result on the current `main` integration and should be debugged normally.
 
 This separation prevents permission failures from being treated as flaky CI

--- a/docs/guides/repository-automation.md
+++ b/docs/guides/repository-automation.md
@@ -9,8 +9,9 @@ for merge behavior.
 
 Astra uses a serial, in-place Mergify queue with GitHub's strict branch
 protection enabled. A pull request enters the queue only after the required
-checks and owner approval pass. Mergify then updates it with the current
-`main`, reruns the required checks on that exact head, and squash-merges it.
+checks and owner approval pass. If `main` advanced, Mergify updates the pull
+request and waits for the required checks on the resulting head. If it is
+already current, Mergify can reuse its passed checks before squash-merging it.
 
 The queue settings are explicit rather than relying on service defaults:
 
@@ -18,8 +19,9 @@ The queue settings are explicit rather than relying on service defaults:
   `max_parallel_checks: 1` keep validation on the original pull request.
 - `update_method: merge` updates eligible fork branches without rewriting
   their history.
-- Branch-protection requirements are injected by Mergify, so the required
-  check list remains owned by GitHub.
+- `branch_protection_injection_mode: queue` makes Mergify enforce GitHub's
+  branch-protection requirements when a pull request enters the queue and when
+  it merges, while the required check list remains owned by GitHub.
 
 Do not add a separate rule that automatically updates every open pull request.
 The queue already updates an approved pull request when necessary. Updating
@@ -30,7 +32,8 @@ all stale branches creates avoidable CI runs and writes to contributor forks.
 Mergify requests a fixed permission set for its products. Do not trim that set
 to this table: these are the permissions most directly involved in Astra's
 queue path. The installation must include `matrixorigin/Astra` in its selected
-repository access and retain Mergify's requested permissions, including:
+repository access—or cover all organization repositories—and retain Mergify's
+requested permissions, including:
 
 | Permission | Access | Why |
 | --- | --- | --- |
@@ -81,9 +84,10 @@ gh api repos/matrixorigin/Astra/branches/main/protection \
                     .permissions]}'
 ```
 
-The result must show `strict: true` and `workflows: "write"`. Requeue one
-approved, behind pull request after any permission change to exercise the same
-path external contributors use.
+The result must show `strict: true`; the Mergify permissions must include
+`administration: "read"` plus `checks`, `contents`, `pull_requests`, and
+`workflows` set to `"write"`. Requeue one approved, behind pull request after
+any permission change to exercise the same path external contributors use.
 
 ## Failure diagnosis
 

--- a/docs/guides/repository-automation.md
+++ b/docs/guides/repository-automation.md
@@ -1,0 +1,89 @@
+# Repository Automation
+
+This guide records the maintainer-owned GitHub settings that cannot be fully
+expressed in the repository. The versioned configuration in
+[`.github/mergify.yml`](../../.github/mergify.yml) remains the source of truth
+for merge behavior.
+
+## Merge queue contract
+
+Astra uses a serial, in-place Mergify queue with GitHub's strict branch
+protection enabled. A pull request enters the queue only after the required
+checks and owner approval pass. Mergify then updates it with the current
+`main`, reruns the required checks on that exact head, and squash-merges it.
+
+The queue settings are explicit rather than relying on service defaults:
+
+- `batch_size: 1`, `max_checks_retries: 0`, `mode: serial`, and
+  `max_parallel_checks: 1` keep validation on the original pull request.
+- `update_method: merge` works for branches in forks without rewriting their
+  history.
+- Branch-protection requirements are injected by Mergify, so the required
+  check list remains owned by GitHub.
+
+Do not add a separate rule that automatically updates every open pull request.
+The queue already updates an approved pull request when necessary. Updating
+all stale branches creates avoidable CI runs and writes to contributor forks.
+
+## Required GitHub App access
+
+The Mergify installation on `matrixorigin/Astra` must retain these repository
+permissions:
+
+| Permission | Access | Why |
+| --- | --- | --- |
+| Contents | Read and write | Update the queued branch and merge the pull request |
+| Pull requests | Read and write | Inspect approvals and manage queue state |
+| Checks | Read and write | Publish queue and rule results |
+| Workflows | Read and write | Update a Git ref when the incoming `main` commits include `.github/workflows/*` |
+| Administration | Read | Read branch-protection requirements |
+
+`Workflows: read and write` does not make workflow changes part of a
+documentation pull request. GitHub checks the complete ref update: if `main`
+advanced through a workflow change while a pull request was open, merging
+`main` into that pull request also carries the workflow commit into its head.
+GitHub rejects that ref update unless the app has the Workflows permission.
+
+When Mergify requests new permissions, an organization owner must approve the
+installation update. Selecting the permission in the app UI is not sufficient
+until the organization installation reports the new effective access.
+
+## Protection settings
+
+Keep the following `main` branch-protection invariants aligned with the queue:
+
+- pull requests and the configured approving review are required;
+- required status checks are enabled;
+- **Require branches to be up to date before merging** remains enabled;
+- direct pushes are restricted, with Mergify as the automation app allowed to
+  complete reviewed queue merges;
+- administrators do not use bypass as the normal delivery path.
+
+After changing the Mergify installation or branch protection, verify the
+effective state rather than relying on the settings form:
+
+```bash
+gh api repos/matrixorigin/Astra/branches/main/protection \
+  --jq '{strict: .required_status_checks.strict,
+         mergify: [.restrictions.apps[] | select(.slug == "mergify") |
+                    .permissions]}'
+```
+
+The result must show `strict: true` and `workflows: "write"`. Requeue one
+approved, behind pull request after any permission change to exercise the same
+path external contributors use.
+
+## Failure diagnosis
+
+If a queue entry says that the pull request cannot be updated, classify it
+before rerunning CI:
+
+1. A message naming `.github/workflows/...` and missing `workflows` permission
+   is an installation-permission failure, not a test failure.
+2. A merge conflict requires the contributor or maintainer to resolve the
+   branch; increasing app permissions does not help.
+3. A required check failure after Mergify updates the branch is a real CI
+   result on the current `main` integration and should be debugged normally.
+
+This separation prevents permission failures from being treated as flaky CI
+and keeps external-fork behavior part of the repository's delivery contract.


### PR DESCRIPTION
## What this PR does / why we need it

Makes Astra's merge-queue behavior and its GitHub App permission dependency explicit and reviewable.

The failure on #685 was not a test failure and the documentation PR did not modify a workflow. The PR was behind `main`; updating it therefore carried a newer `release-docker.yml` commit into the fork branch. GitHub rejected Mergify's ref update while the installation lacked effective `Workflows: read and write` access.

This change:

- pins the serial in-place queue parameters instead of relying on Mergify defaults;
- uses an explicit merge update method for fork compatibility without history rewrites;
- removes the redundant global auto-update rule, because the merge queue already updates approved PRs and reruns required checks;
- documents the Mergify permission, branch-protection, verification, and failure-classification contract.

It keeps strict up-to-date branch protection, required checks, owner approval, and squash merging unchanged.

## Validation

- `git diff --check`
- parsed `.github/mergify.yml` with Ruby's YAML parser
- `python3 scripts/ci/validate_repository.py`
