### PR TITLE
fix(runtime): preserve compacted user anchor at canonical commit

### DIFF
--- a/crates/astra-turn-core/src/prompt_facing.rs
+++ b/crates/astra-turn-core/src/prompt_facing.rs
@@ -168,12 +168,14 @@ pub fn sanitize_canonical_continuation_messages_with_turn_semantics(
         }
     }
 
-    // Compaction has already removed the compacted middle from this vector.
-    // The boundary marker separates that removed region from the retained
-    // tail; messages before it (notably the protected first user) are still
-    // canonical conversation content.
+    // A compaction boundary supersedes the earlier conversation only when its
+    // retained tail owns a newer user turn. Tiered compaction can otherwise
+    // place the marker after the protected first user while retaining only an
+    // assistant/tool tail; cutting there would orphan the entire turn.
+    let start = canonical_continuation_start(&messages);
     let messages = messages
         .into_iter()
+        .skip(start)
         .filter_map(|mut message| {
             let keep = message.get("_compact_boundary").and_then(Value::as_bool) != Some(true)
                 && !is_runtime_owned_message(&message);
@@ -498,6 +500,18 @@ fn latest_compaction_boundary_start(messages: &[Value]) -> Option<usize> {
     })
 }
 
+fn canonical_continuation_start(messages: &[Value]) -> usize {
+    let Some(boundary_index) = latest_compaction_boundary_start(messages) else {
+        return 0;
+    };
+    let tail_has_user = messages[boundary_index + 1..].iter().any(|message| {
+        !is_runtime_owned_message(message)
+            && message.get("role").and_then(Value::as_str) == Some("user")
+            && canonical_text_message(message, "user", false).is_some()
+    });
+    if tail_has_user { boundary_index } else { 0 }
+}
+
 fn prompt_facing_content_for_role(role: &str, content: &str) -> Option<String> {
     let _ = role;
     let content = content.trim().to_string();
@@ -782,9 +796,9 @@ mod tests {
     }
 
     #[test]
-    fn recovery_drops_corrupt_semantics_without_discarding_the_compacted_head() {
+    fn recovery_drops_only_corrupt_semantics_then_runs_the_full_sanitizer() {
         let messages = vec![
-            json!({"role": "user", "content": "protected objective"}),
+            json!({"role": "user", "content": "stale objective"}),
             json!({"role": "system", "content": "boundary", "_compact_boundary": true}),
             runtime_owned_message(
                 "system",
@@ -810,7 +824,6 @@ mod tests {
         assert_eq!(
             got,
             vec![
-                json!({"role": "user", "content": "protected objective"}),
                 json!({"role": "user", "content": "current objective"}),
                 json!({"role": "assistant", "content": "current answer"}),
             ]

--- a/crates/astra-turn-core/src/prompt_facing.rs
+++ b/crates/astra-turn-core/src/prompt_facing.rs
@@ -168,10 +168,12 @@ pub fn sanitize_canonical_continuation_messages_with_turn_semantics(
         }
     }
 
-    let start = latest_compaction_boundary_start(&messages).unwrap_or(0);
+    // Compaction has already removed the compacted middle from this vector.
+    // The boundary marker separates that removed region from the retained
+    // tail; messages before it (notably the protected first user) are still
+    // canonical conversation content.
     let messages = messages
         .into_iter()
-        .skip(start)
         .filter_map(|mut message| {
             let keep = message.get("_compact_boundary").and_then(Value::as_bool) != Some(true)
                 && !is_runtime_owned_message(&message);
@@ -780,9 +782,9 @@ mod tests {
     }
 
     #[test]
-    fn recovery_drops_only_corrupt_semantics_then_runs_the_full_sanitizer() {
+    fn recovery_drops_corrupt_semantics_without_discarding_the_compacted_head() {
         let messages = vec![
-            json!({"role": "user", "content": "stale objective"}),
+            json!({"role": "user", "content": "protected objective"}),
             json!({"role": "system", "content": "boundary", "_compact_boundary": true}),
             runtime_owned_message(
                 "system",
@@ -808,6 +810,7 @@ mod tests {
         assert_eq!(
             got,
             vec![
+                json!({"role": "user", "content": "protected objective"}),
                 json!({"role": "user", "content": "current objective"}),
                 json!({"role": "assistant", "content": "current answer"}),
             ]

--- a/crates/astra-turn-core/src/prompt_facing.rs
+++ b/crates/astra-turn-core/src/prompt_facing.rs
@@ -159,6 +159,23 @@ pub fn sanitize_prompt_facing_messages_with_state(
 pub fn sanitize_canonical_continuation_messages_with_turn_semantics(
     messages: Vec<Value>,
 ) -> Result<Vec<Value>, astra_turn_types::UserTurnSemanticsError> {
+    sanitize_canonical_continuation_messages_impl(messages, false)
+}
+
+/// Project an already-compacted current turn for canonical commit.
+///
+/// Only an explicit typed replacement in the retained tail supersedes the
+/// protected head. Other user messages retain the objective they depend on.
+pub fn sanitize_compacted_canonical_continuation_messages_with_turn_semantics(
+    messages: Vec<Value>,
+) -> Result<Vec<Value>, astra_turn_types::UserTurnSemanticsError> {
+    sanitize_canonical_continuation_messages_impl(messages, true)
+}
+
+fn sanitize_canonical_continuation_messages_impl(
+    messages: Vec<Value>,
+    preserve_compacted_head: bool,
+) -> Result<Vec<Value>, astra_turn_types::UserTurnSemanticsError> {
     for message in &messages {
         if message
             .get(astra_turn_types::USER_TURN_SEMANTICS_FIELD)
@@ -168,11 +185,11 @@ pub fn sanitize_canonical_continuation_messages_with_turn_semantics(
         }
     }
 
-    // A compaction boundary supersedes the earlier conversation only when its
-    // retained tail owns a newer user turn. Tiered compaction can otherwise
-    // place the marker after the protected first user while retaining only an
-    // assistant/tool tail; cutting there would orphan the entire turn.
-    let start = canonical_continuation_start(&messages);
+    let start = if preserve_compacted_head {
+        compacted_canonical_turn_start(&messages)?
+    } else {
+        latest_compaction_boundary_start(&messages).unwrap_or(0)
+    };
     let messages = messages
         .into_iter()
         .skip(start)
@@ -500,16 +517,24 @@ fn latest_compaction_boundary_start(messages: &[Value]) -> Option<usize> {
     })
 }
 
-fn canonical_continuation_start(messages: &[Value]) -> usize {
+fn compacted_canonical_turn_start(
+    messages: &[Value],
+) -> Result<usize, astra_turn_types::UserTurnSemanticsError> {
     let Some(boundary_index) = latest_compaction_boundary_start(messages) else {
-        return 0;
+        return Ok(0);
     };
-    let tail_has_user = messages[boundary_index + 1..].iter().any(|message| {
-        !is_runtime_owned_message(message)
+    for (index, message) in messages.iter().enumerate().skip(boundary_index + 1).rev() {
+        if !is_runtime_owned_message(message)
             && message.get("role").and_then(Value::as_str) == Some("user")
             && canonical_text_message(message, "user", false).is_some()
-    });
-    if tail_has_user { boundary_index } else { 0 }
+            && astra_turn_types::user_turn_semantics(message)?.is_some_and(|semantics| {
+                semantics.objective_relation == astra_turn_types::ObjectiveRelation::Replace
+            })
+        {
+            return Ok(index);
+        }
+    }
+    Ok(0)
 }
 
 fn prompt_facing_content_for_role(role: &str, content: &str) -> Option<String> {
@@ -670,6 +695,117 @@ mod tests {
             got.iter()
                 .all(|message| message["content"] != "retry this tool round"),
             "runtime-owned control messages must not cross a continuation boundary"
+        );
+    }
+
+    fn compacted_turn_projections(messages: Vec<Value>) -> Vec<Vec<Value>> {
+        vec![
+            super::sanitize_compacted_canonical_continuation_messages_with_turn_semantics(messages)
+                .expect("valid compacted turn"),
+        ]
+    }
+
+    fn typed_user(content: &str, relation: astra_turn_types::ObjectiveRelation) -> Value {
+        let mut message = json!({"role": "user", "content": content});
+        astra_turn_types::mark_user_turn_semantics(
+            &mut message,
+            astra_turn_types::UserTurnSemantics::new(relation, None),
+        );
+        message
+    }
+
+    #[test]
+    fn compacted_current_turn_preserves_objective_until_typed_replacement() {
+        use astra_turn_types::ObjectiveRelation;
+        for relation in [
+            None,
+            Some(ObjectiveRelation::Unknown),
+            Some(ObjectiveRelation::Acknowledge),
+            Some(ObjectiveRelation::Continue),
+            Some(ObjectiveRelation::Refine),
+            Some(ObjectiveRelation::Correct),
+            Some(ObjectiveRelation::Replace),
+        ] {
+            let head = typed_user("initial objective", ObjectiveRelation::Replace);
+            // Identical text deliberately cannot tell the projection what to do.
+            let tail = relation.map_or_else(
+                || json!({"role": "user", "content": "follow-up input"}),
+                |relation| typed_user("follow-up input", relation),
+            );
+            let answer = json!({"role": "assistant", "content": "done"});
+            let messages = vec![
+                head.clone(),
+                json!({"role": "system", "content": "boundary", "_compact_boundary": true}),
+                tail.clone(),
+                answer.clone(),
+            ];
+            let mut expected = vec![tail, answer];
+            if relation != Some(ObjectiveRelation::Replace) {
+                expected.insert(0, head);
+            }
+            for projected in compacted_turn_projections(messages) {
+                assert_eq!(projected, expected, "relation: {relation:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn compacted_current_turn_starts_at_last_explicit_replacement() {
+        use astra_turn_types::ObjectiveRelation;
+        let replacement = typed_user("replacement objective", ObjectiveRelation::Replace);
+        let refinement = typed_user("additional constraint", ObjectiveRelation::Refine);
+        let messages = vec![
+            typed_user("obsolete head", ObjectiveRelation::Replace),
+            json!({"role": "system", "content": "boundary", "_compact_boundary": true}),
+            typed_user("obsolete refinement", ObjectiveRelation::Refine),
+            typed_user("superseded replacement", ObjectiveRelation::Replace),
+            json!({"role": "assistant", "content": "obsolete answer"}),
+            replacement.clone(),
+            refinement.clone(),
+        ];
+        for projected in compacted_turn_projections(messages) {
+            assert_eq!(projected, vec![replacement.clone(), refinement.clone()]);
+        }
+    }
+
+    #[test]
+    fn compacted_current_turn_ignores_runtime_owned_replacement() {
+        use astra_turn_types::ObjectiveRelation;
+        let head = typed_user("initial objective", ObjectiveRelation::Replace);
+        let mut control =
+            runtime_owned_message("user", "control", RuntimeMessageDelivery::EphemeralControl);
+        astra_turn_types::mark_user_turn_semantics(
+            &mut control,
+            astra_turn_types::UserTurnSemantics::new(ObjectiveRelation::Replace, None),
+        );
+        let messages = vec![
+            head.clone(),
+            json!({"role": "system", "content": "boundary", "_compact_boundary": true}),
+            control,
+            typed_user("  ", ObjectiveRelation::Replace),
+        ];
+        for projected in compacted_turn_projections(messages) {
+            assert_eq!(projected, vec![head.clone()]);
+        }
+    }
+
+    #[test]
+    fn compacted_current_turn_rejects_corrupt_semantics() {
+        let messages = vec![
+            json!({"role": "user", "content": "objective"}),
+            json!({"role": "system", "content": "boundary", "_compact_boundary": true}),
+            json!({
+                "role": "user", "content": "input",
+                (astra_turn_types::USER_TURN_SEMANTICS_FIELD): {
+                    "schema_version": 1, "objective_relation": "invalid",
+                },
+            }),
+        ];
+        assert!(
+            super::sanitize_compacted_canonical_continuation_messages_with_turn_semantics(
+                messages.clone()
+            )
+            .is_err()
         );
     }
 

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -293,9 +293,8 @@ fn typed_objective_relations_survive_real_tiered_compaction() {
             assert_eq!(users, expected_users, "relation: {relation:?}");
             assert_eq!(committed.first(), expected_users.first());
             assert_eq!(committed.last().unwrap()["content"], "done");
-            assert_eq!(
+            assert!(
                 committed.iter().any(|message| message["role"] == "tool"),
-                true,
                 "retained execution evidence follows the commit contract",
             );
 

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -197,84 +197,117 @@ fn single_user_tool_turn_remains_committable_after_real_tiered_compaction() {
 }
 
 #[test]
-fn newer_user_supersedes_compacted_head_after_real_tiered_compaction() {
-    let mut messages = vec![json!({"role": "user", "content": "review everything"})];
-    for index in 0..6 {
+fn typed_objective_relations_survive_real_tiered_compaction() {
+    use astra_turn_core::resume_hydration::objective_context_from_messages;
+    use astra_turn_types::{ObjectiveRelation, UserTurnSemantics, mark_user_turn_semantics};
+
+    for relation in [
+        None,
+        Some(ObjectiveRelation::Unknown),
+        Some(ObjectiveRelation::Acknowledge),
+        Some(ObjectiveRelation::Continue),
+        Some(ObjectiveRelation::Refine),
+        Some(ObjectiveRelation::Correct),
+        Some(ObjectiveRelation::Replace),
+    ] {
+        let mut head = json!({"role": "user", "content": "initial objective"});
+        mark_user_turn_semantics(
+            &mut head,
+            UserTurnSemantics::new(ObjectiveRelation::Replace, None),
+        );
+        let mut messages = vec![head.clone()];
+        for index in 0..6 {
+            messages.push(json!({
+                "role": "assistant", "content": null,
+                "tool_calls": [{
+                    "id": format!("call-{index}"), "type": "function",
+                    "function": {"name": "bash", "arguments": "{}"},
+                }],
+            }));
+            messages.push(json!({
+                "role": "tool", "tool_call_id": format!("call-{index}"),
+                "content": format!("result {index}"),
+            }));
+        }
+        let mut tail = json!({"role": "user", "content": "follow-up input"});
+        if let Some(relation) = relation {
+            mark_user_turn_semantics(&mut tail, UserTurnSemantics::new(relation, None));
+        }
+        messages.push(tail.clone());
         messages.push(json!({
-            "role": "assistant",
-            "content": null,
+            "role": "assistant", "content": null,
             "tool_calls": [{
-                "id": format!("call-{index}"),
-                "type": "function",
-                "function": {
-                    "name": "bash",
-                    "arguments": format!(r#"{{"chunk":{index}}}"#),
-                },
+                "id": "tail-call", "type": "function",
+                "function": {"name": "bash", "arguments": "{}"},
             }],
         }));
-        messages.push(json!({
-            "role": "tool",
-            "tool_call_id": format!("call-{index}"),
-            "content": format!("reviewed chunk {index}"),
-        }));
+        messages
+            .push(json!({"role": "tool", "tool_call_id": "tail-call", "content": "tail result"}));
+        messages.push(json!({"role": "assistant", "content": "done"}));
+        let expected_objective = objective_context_from_messages(&messages).unwrap();
+
+        // Admit an actual prefix, then prove the real compaction rewrites it.
+        let prior = messages[..7].to_vec();
+        let manifest_root = "a".repeat(64);
+        let mut proof =
+            CanonicalRewriteProof::from_materialized_admission(&prior, &manifest_root, 0);
+        let permit = proof.begin(&messages);
+        let mut engine = crate::turn::CompactionEngine::new();
+        engine.add_layer(Box::new(crate::turn::cloud::TieredCompaction::new(2, 0.0)));
+        let outcome = engine.compress_if_needed(
+            &mut messages,
+            &crate::turn::TokenBudget {
+                max_prompt_tokens: 64_000,
+                last_measured_tokens: 100_000,
+                current_round_index: None,
+                now_secs: 10_000_000,
+            },
+        );
+        proof.finish(permit, &messages);
+
+        assert!(outcome.total_tokens_freed > 0, "real compaction must run");
+        assert_eq!(
+            messages[0], head,
+            "the compactor retains the protected head"
+        );
+        assert_eq!(messages[1]["_compact_boundary"], true);
+        assert_eq!(messages[2], tail, "typed tail survives real compaction");
+
+        {
+            let (mode, packs) =
+                canonical_commit_delta(&prior, true, &messages, Some(&proof), false)
+                    .expect("verified compacted turn")
+                    .expect("nonempty canonical delta");
+            assert_eq!(mode, astra_turn_types::CanonicalDeltaModeV1::Replace);
+            let committed = packs.concat();
+            let users = committed
+                .iter()
+                .filter(|message| message["role"] == "user")
+                .cloned()
+                .collect::<Vec<_>>();
+            let expected_users = if relation == Some(ObjectiveRelation::Replace) {
+                vec![tail.clone()]
+            } else {
+                vec![head.clone(), tail.clone()]
+            };
+            assert_eq!(users, expected_users, "relation: {relation:?}");
+            assert_eq!(committed.first(), expected_users.first());
+            assert_eq!(committed.last().unwrap()["content"], "done");
+            assert_eq!(
+                committed.iter().any(|message| message["role"] == "tool"),
+                true,
+                "retained execution evidence follows the commit contract",
+            );
+
+            let serialized = serde_json::to_string(&committed).unwrap();
+            let restored: Vec<Value> = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(
+                objective_context_from_messages(&restored).unwrap(),
+                expected_objective,
+                "commit/restore must preserve typed objective semantics: {relation:?}",
+            );
+        }
     }
-    messages.push(json!({
-        "role": "user",
-        "content": "do not review; translate instead",
-    }));
-    messages.push(json!({"role": "assistant", "content": "translation complete"}));
-
-    let mut engine = crate::turn::CompactionEngine::new();
-    engine.add_layer(Box::new(crate::turn::cloud::TieredCompaction::new(2, 0.0)));
-    let outcome = engine.compress_if_needed(
-        &mut messages,
-        &crate::turn::TokenBudget {
-            max_prompt_tokens: 64_000,
-            last_measured_tokens: 100_000,
-            current_round_index: None,
-            now_secs: 10_000_000,
-        },
-    );
-
-    assert!(
-        outcome.total_tokens_freed > 0,
-        "the real pipeline must compact"
-    );
-    let boundary_index = messages
-        .iter()
-        .position(|message| message["_compact_boundary"].as_bool() == Some(true))
-        .expect("tiered compaction must leave its canonical boundary marker");
-    assert_eq!(
-        boundary_index, 1,
-        "the obsolete protected user precedes the boundary"
-    );
-    assert!(
-        messages[boundary_index + 1..].iter().any(|message| {
-            message["role"] == "user" && message["content"] == "do not review; translate instead"
-        }),
-        "the newer user goal must survive in the retained tail"
-    );
-
-    let (mode, packs) = canonical_commit_delta(&[], false, &messages, None, false)
-        .expect("a compacted multi-user turn must remain committable")
-        .expect("the turn must produce a canonical delta");
-    let committed = packs.concat();
-
-    assert_eq!(mode, astra_turn_types::CanonicalDeltaModeV1::Append);
-    assert_eq!(
-        committed,
-        vec![
-            json!({
-                "role": "user",
-                "content": "do not review; translate instead",
-            }),
-            json!({
-                "role": "assistant",
-                "content": "translation complete",
-            }),
-        ],
-        "the newer user must replace the obsolete pre-boundary anchor"
-    );
 }
 
 #[test]

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -197,6 +197,87 @@ fn single_user_tool_turn_remains_committable_after_real_tiered_compaction() {
 }
 
 #[test]
+fn newer_user_supersedes_compacted_head_after_real_tiered_compaction() {
+    let mut messages = vec![json!({"role": "user", "content": "review everything"})];
+    for index in 0..6 {
+        messages.push(json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": format!("call-{index}"),
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "arguments": format!(r#"{{"chunk":{index}}}"#),
+                },
+            }],
+        }));
+        messages.push(json!({
+            "role": "tool",
+            "tool_call_id": format!("call-{index}"),
+            "content": format!("reviewed chunk {index}"),
+        }));
+    }
+    messages.push(json!({
+        "role": "user",
+        "content": "do not review; translate instead",
+    }));
+    messages.push(json!({"role": "assistant", "content": "translation complete"}));
+
+    let mut engine = crate::turn::CompactionEngine::new();
+    engine.add_layer(Box::new(crate::turn::cloud::TieredCompaction::new(2, 0.0)));
+    let outcome = engine.compress_if_needed(
+        &mut messages,
+        &crate::turn::TokenBudget {
+            max_prompt_tokens: 64_000,
+            last_measured_tokens: 100_000,
+            current_round_index: None,
+            now_secs: 10_000_000,
+        },
+    );
+
+    assert!(
+        outcome.total_tokens_freed > 0,
+        "the real pipeline must compact"
+    );
+    let boundary_index = messages
+        .iter()
+        .position(|message| message["_compact_boundary"].as_bool() == Some(true))
+        .expect("tiered compaction must leave its canonical boundary marker");
+    assert_eq!(
+        boundary_index, 1,
+        "the obsolete protected user precedes the boundary"
+    );
+    assert!(
+        messages[boundary_index + 1..].iter().any(|message| {
+            message["role"] == "user" && message["content"] == "do not review; translate instead"
+        }),
+        "the newer user goal must survive in the retained tail"
+    );
+
+    let (mode, packs) = canonical_commit_delta(&[], false, &messages, None, false)
+        .expect("a compacted multi-user turn must remain committable")
+        .expect("the turn must produce a canonical delta");
+    let committed = packs.concat();
+
+    assert_eq!(mode, astra_turn_types::CanonicalDeltaModeV1::Append);
+    assert_eq!(
+        committed,
+        vec![
+            json!({
+                "role": "user",
+                "content": "do not review; translate instead",
+            }),
+            json!({
+                "role": "assistant",
+                "content": "translation complete",
+            }),
+        ],
+        "the newer user must replace the obsolete pre-boundary anchor"
+    );
+}
+
+#[test]
 fn unexplained_canonical_prefix_shrink_remains_rejected() {
     let prior = vec![json!({"role": "user", "content": "committed"})];
     let shortened = vec![json!({"role": "user", "content": "unexpected tail"})];

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -114,6 +114,89 @@ fn compaction_commits_the_complete_replacement_projection() {
 }
 
 #[test]
+fn single_user_tool_turn_remains_committable_after_real_tiered_compaction() {
+    let mut messages = vec![json!({"role": "user", "content": "translate the document"})];
+    for index in 0..6 {
+        messages.push(json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": format!("call-{index}"),
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "arguments": format!(r#"{{"chunk":{index}}}"#),
+                },
+            }],
+        }));
+        messages.push(json!({
+            "role": "tool",
+            "tool_call_id": format!("call-{index}"),
+            "content": format!("translated chunk {index}"),
+        }));
+    }
+    messages.push(json!({"role": "assistant", "content": "translation complete"}));
+
+    let mut engine = crate::turn::CompactionEngine::new();
+    engine.add_layer(Box::new(crate::turn::cloud::TieredCompaction::new(2, 0.0)));
+    let outcome = engine.compress_if_needed(
+        &mut messages,
+        &crate::turn::TokenBudget {
+            max_prompt_tokens: 64_000,
+            last_measured_tokens: 100_000,
+            current_round_index: None,
+            now_secs: 10_000_000,
+        },
+    );
+
+    assert!(
+        outcome.total_tokens_freed > 0,
+        "the real pipeline must compact"
+    );
+    let boundary_index = messages
+        .iter()
+        .position(|message| message["_compact_boundary"].as_bool() == Some(true))
+        .expect("tiered compaction must leave its canonical boundary marker");
+    assert_eq!(
+        boundary_index, 1,
+        "the protected first user precedes the boundary"
+    );
+    assert!(
+        messages[boundary_index + 1..]
+            .iter()
+            .all(|message| message["role"] != "user"),
+        "one agentic turn has no second user anchor after compaction"
+    );
+
+    let (mode, packs) = canonical_commit_delta(&[], false, &messages, None, false)
+        .expect("a compacted single-user turn must remain committable")
+        .expect("a completed turn must produce a canonical delta");
+    let committed = packs.concat();
+
+    assert_eq!(mode, astra_turn_types::CanonicalDeltaModeV1::Append);
+    assert_eq!(
+        committed.first(),
+        Some(&json!({
+            "role": "user",
+            "content": "translate the document",
+        }))
+    );
+    assert_eq!(
+        committed.last(),
+        Some(&json!({
+            "role": "assistant",
+            "content": "translation complete",
+        }))
+    );
+    assert!(
+        committed
+            .iter()
+            .all(|message| message.get("_compact_boundary").is_none()),
+        "the marker is runtime state, not canonical conversation content"
+    );
+}
+
+#[test]
 fn unexplained_canonical_prefix_shrink_remains_rejected() {
     let prior = vec![json!({"role": "user", "content": "committed"})];
     let shortened = vec![json!({"role": "user", "content": "unexpected tail"})];

--- a/crates/runtime/src/turn/canonical_commit.rs
+++ b/crates/runtime/src/turn/canonical_commit.rs
@@ -101,7 +101,7 @@ pub(crate) fn canonical_commit_delta(
         &messages[prior_messages.len()..]
     };
     let canonical_changed =
-        astra_turn_core::prompt_facing::sanitize_canonical_continuation_messages_with_turn_semantics(
+        astra_turn_core::prompt_facing::sanitize_compacted_canonical_continuation_messages_with_turn_semantics(
             changed_messages.to_vec(),
         )
         .map_err(|error| {


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

N/A — diagnosed from a production MOI run that ended with `canonical turn produced no committable messages` after a long, tool-heavy turn.

## What this PR does / why we need it

Tiered compaction physically removes the compacted middle of the runtime message vector while deliberately preserving the first user message before its `_compact_boundary` marker. The canonical continuation projection incorrectly treated that marker as another truncation point. For a single-user, tool-heavy turn with no later user message, it discarded the only user anchor and then dropped every assistant/tool message as orphaned, so terminal canonical commit failed.

This change makes the current-turn canonical commit projection honor producer-owned `UserTurnSemantics`:

- only a visible tail user explicitly marked `ObjectiveRelation::Replace` authorizes dropping earlier retained messages; projection starts at the last such replacement message, not at the boundary marker;
- `Refine`, `Correct`, `Continue`, `Acknowledge`, `Unknown`, and absent semantics do not authorize dropping the existing objective;
- runtime-owned or empty messages cannot replace the objective, and malformed semantics remain errors.

Session/CLI continuation recovery keeps its pre-existing latest-boundary contract through a separate entrypoint backed by the shared sanitizer. No lifecycle decision is inferred from message text.

The real regression matrix runs `CompactionEngine + TieredCompaction`, authorizes the rewrite with `CanonicalRewriteProof`, exercises a canonical `Replace` commit, serializes/restores the result, and compares typed objective context before and after. It covers all six objective relations plus absent metadata. The original single-user, tool-heavy production regression remains covered.

## Architecture and complexity delta

- Canonical owner changed or extended: `astra-turn-core` current-turn commit projections, using existing `astra-turn-types::ObjectiveRelation` authority.
- Existing implementations/callers searched: tiered compaction layers and engine, runtime lifecycle terminal commit, canonical delta construction, recovery projection, and prompt-facing projection tests.
- Superseded code, states, tables, shims, and self-only tests removed: replaced the any-tail-user truncation predicate and untyped replacement fixture with typed authorization and regression matrices.
- Net code/state/table delta: three existing Rust files; one explicit cross-crate current-turn projection entrypoint; no schema, state, configuration, fallback, or compatibility layer.
- If parallel implementations remain, the external boundary and retirement condition: N/A. Display/provider projection and canonical continuation projection intentionally have different contracts and retain their existing owners.

## Production wiring and verification

- Public product entrypoint exercised: Astra server run lifecycle terminal canonical commit used by MOI.
- Unhappy paths exercised: single-user anchor loss, non-replacing follow-ups, multiple typed replacements, runtime-owned/empty replacement messages, and corrupt semantics. Real compaction/commit/restore checks preserve typed objective context.
- Database schema/query/transaction/migration verified against a real database, or `N/A` with reason: N/A; this change is an in-memory message projection correction and does not touch persistence schema or queries.

Verification:

- `cargo fmt --all -- --check`
- `cargo test -p astra-runtime --lib single_user_tool_turn_remains_committable_after_real_tiered_compaction -- --nocapture`
- `cargo test -p astra-runtime --lib typed_objective_relations_survive_real_tiered_compaction -- --nocapture`
- Five focused `astra-cli` nextest cases for stale-goal, corrupt-semantics, session-continuation, and CSL projection behavior — rerun after this review fix, 5 passed.
- `cargo test -p astra-turn-core --lib` — 3634 passed
- `cargo check --workspace --all-targets`
- `cargo test -p astra-turn-core --lib compacted_current_turn -- --nocapture` — 4 passed

- CI lint follow-up: use the equivalent `assert!(condition)` in the typed compaction regression; no behavior or expectation change.
- `cargo clippy -p astra-runtime --all-targets -- -D warnings` — passed after the assertion fix.
- `typed_objective_relations_survive_real_tiered_compaction` — rerun after the assertion fix, passed (all six typed relations plus absent metadata).
