### PR TITLE
ci(release): harden publication and user upgrade flow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,115 +1,27 @@
-name: Release Astra Client Binaries
+name: Build Astra Client Release Candidates
 
 permissions:
   contents: read
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
-  workflow_dispatch:
+  workflow_call:
     inputs:
       version:
-        description: "Release version to publish, e.g. 0.1.0 or v0.1.0"
+        description: Release version without the leading v
+        required: true
+        type: string
+      source_sha:
+        description: Immutable source commit selected by the release controller
         required: true
         type: string
 
-concurrency:
-  group: release-binaries
-  # Never cancel a run that may already be publishing immutable artifacts.
-  cancel-in-progress: false
-
 env:
-  CROSS_REVISION: 8c1a8aa4b661711f4b7b6ac07c2e8929ce2f7d27 # upstream main, 2026-08-19
+  RELEASE_VERSION: ${{ inputs.version }}
+  RELEASE_SOURCE_SHA: ${{ inputs.source_sha }}
 
 jobs:
-  version:
-    name: Resolve Version
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    outputs:
-      value: ${{ steps.resolve.outputs.value }}
-      source_tag: ${{ steps.resolve.outputs.source_tag }}
-      source_sha: ${{ steps.source.outputs.source_sha }}
-      tag_object: ${{ steps.source.outputs.tag_object }}
-      prerelease: ${{ steps.resolve.outputs.prerelease }}
-    steps:
-      - name: Resolve release version
-        id: resolve
-        shell: bash
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            version="${INPUT_VERSION}"
-          else
-            version="${GITHUB_REF_NAME}"
-          fi
-
-          if [[ ! "${version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Invalid release version: ${version}" >&2
-            echo "Expected format: 0.1.0, v0.1.0, or 0.1.0-rc.1" >&2
-            exit 1
-          fi
-
-          value="${version#v}"
-          prerelease=false
-          if [[ "${value}" == *-* ]]; then
-            prerelease=true
-          fi
-
-          echo "value=${value}" >> "${GITHUB_OUTPUT}"
-          echo "source_tag=v${value}" >> "${GITHUB_OUTPUT}"
-          echo "prerelease=${prerelease}" >> "${GITHUB_OUTPUT}"
-
-      - name: Check out release source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-          ref: ${{ steps.resolve.outputs.source_tag }}
-
-      - name: Validate manifest version
-        run: scripts/validate-release-version.sh "${{ steps.resolve.outputs.value }}"
-
-      - name: Validate immutable release source
-        id: source
-        shell: bash
-        env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          EVENT_SOURCE_SHA: ${{ github.event.after }}
-          SOURCE_TAG: ${{ steps.resolve.outputs.source_tag }}
-        run: |
-          set -euo pipefail
-          tag_object="$(git rev-parse "refs/tags/${SOURCE_TAG}")"
-          if [ "$(git cat-file -t "refs/tags/${SOURCE_TAG}")" != "tag" ]; then
-            echo "Release tag ${SOURCE_TAG} must be annotated." >&2
-            exit 1
-          fi
-          source_sha="$(git rev-list -n 1 "refs/tags/${SOURCE_TAG}")"
-          if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${source_sha}" != "${EVENT_SOURCE_SHA}" ]; then
-            echo "Release tag ${SOURCE_TAG} no longer points to the commit that triggered this workflow." >&2
-            exit 1
-          fi
-          if [ "$(git rev-parse HEAD)" != "${source_sha}" ]; then
-            echo "Checked-out source does not match ${SOURCE_TAG}." >&2
-            exit 1
-          fi
-          git fetch --no-tags origin \
-            "refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
-          if ! git merge-base --is-ancestor "${source_sha}" "origin/${DEFAULT_BRANCH}"; then
-            echo "Release tag ${{ steps.resolve.outputs.source_tag }} is not reachable from ${DEFAULT_BRANCH}." >&2
-            echo "Merge the release commit before publishing its tag." >&2
-            exit 1
-          fi
-          echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
-          echo "tag_object=${tag_object}" >> "${GITHUB_OUTPUT}"
-
   build:
     name: Build ${{ matrix.target }}
-    needs: version
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
     strategy:
@@ -119,92 +31,85 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             suffix: linux-amd64
-            use-cross: false
             features: astra-cli/release-vendored-openssl
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             suffix: linux-arm64
-            use-cross: true
             features: astra-cli/release-vendored-openssl
           - os: macos-15-intel
             target: x86_64-apple-darwin
             suffix: darwin-amd64
-            use-cross: false
             features: ""
           - os: macos-15
             target: aarch64-apple-darwin
             suffix: darwin-arm64
-            use-cross: false
             features: ""
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-          ref: ${{ needs.version.outputs.source_sha }}
+          ref: ${{ env.RELEASE_SOURCE_SHA }}
 
-      - name: Cache cargo registry
+      - name: Cache Cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry/cache
             ~/.cargo/registry/index
             ~/.cargo/git/db
-          key: cargo-registry-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
+          key: release-cargo-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            cargo-registry-${{ runner.os }}-${{ matrix.target }}-
+            release-cargo-${{ runner.os }}-${{ matrix.target }}-
 
-      - name: Install pinned Rust toolchain and target
+      - name: Install pinned Rust target
         shell: bash
         run: |
+          set -euo pipefail
           rustc --version
           rustup target add "${{ matrix.target }}"
 
-      - name: Install musl build deps
-        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+      - name: Install musl build dependencies
+        if: ${{ contains(matrix.target, 'unknown-linux-musl') }}
+        shell: bash
         run: |
+          set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends musl-tools
 
-      - name: Install cross
-        if: ${{ matrix.use-cross }}
-        run: >-
-          cargo install cross
-          --git https://github.com/cross-rs/cross
-          --rev "${CROSS_REVISION}"
-          --locked
-
-      - name: Build with cross
-        if: ${{ matrix.use-cross }}
+      - name: Build client candidates
+        shell: bash
         env:
           RELEASE_FEATURES: ${{ matrix.features }}
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
         run: |
           set -euo pipefail
           feature_args=()
           if [ -n "${RELEASE_FEATURES}" ]; then
             feature_args=(--features "${RELEASE_FEATURES}")
           fi
-          cross build --release --no-default-features "${feature_args[@]}" \
+          cargo build --release --locked --no-default-features "${feature_args[@]}" \
             --manifest-path Cargo.toml --target "${{ matrix.target }}" \
             -p astra-cli --bin astra \
             -p astra-edge --bin astra-edge
 
-      - name: Build native
-        if: ${{ !matrix.use-cross }}
-        env:
-          RELEASE_FEATURES: ${{ matrix.features }}
+      - name: Execute client candidates
+        shell: bash
         run: |
           set -euo pipefail
-          feature_args=()
-          if [ -n "${RELEASE_FEATURES}" ]; then
-            feature_args=(--features "${RELEASE_FEATURES}")
-          fi
-          cargo build --release --no-default-features "${feature_args[@]}" \
-            --manifest-path Cargo.toml --target "${{ matrix.target }}" \
-            -p astra-cli --bin astra \
-            -p astra-edge --bin astra-edge
+          for binary in astra astra-edge; do
+            candidate="target/${{ matrix.target }}/release/${binary}"
+            reported_version="$("${candidate}" --version)"
+            expected_version="${binary} ${RELEASE_VERSION}"
+            if [ "${reported_version}" != "${expected_version}" ]; then
+              echo "${binary} reports '${reported_version}', expected '${expected_version}'" >&2
+              exit 1
+            fi
+            "${candidate}" --help >/dev/null
+          done
 
-      - name: Package archive
+      - name: Package client archive
         shell: bash
         run: |
           set -euo pipefail
@@ -226,69 +131,57 @@ jobs:
               "${package_dir}/${binary}"
           done
           install -m 0644 LICENSE "${package_dir}/LICENSE"
-          archive="astra-v${{ needs.version.outputs.value }}-${{ matrix.suffix }}.tar.gz"
+          archive="astra-v${RELEASE_VERSION}-${{ matrix.suffix }}.tar.gz"
           tar -czf "dist/${archive}" -C "${package_dir}" astra astra-edge LICENSE
-          (cd dist && checksum_file "${archive}" | tee "${archive}.sha256" > /dev/null)
+          (cd dist && checksum_file "${archive}" > "${archive}.sha256")
 
-      - name: Upload artifact
+      - name: Upload client candidate
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: bins-${{ matrix.suffix }}
+          name: client-${{ matrix.suffix }}
           path: dist/
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 3
 
-  release:
-    name: Create Release
-    needs:
-      - version
-      - build
+  verify:
+    name: Verify Complete Client Set
+    needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: write
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-          ref: ${{ needs.version.outputs.source_sha }}
+          ref: ${{ env.RELEASE_SOURCE_SHA }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          pattern: bins-*
+          pattern: client-*
           path: dist
           merge-multiple: true
 
-      - name: Verify release artifacts and create checksum manifest
+      - name: Verify archives and create aggregate checksums
         shell: bash
-        run: scripts/verify-release-artifacts.sh "${{ needs.version.outputs.value }}" dist
+        run: scripts/verify-release-artifacts.sh "${RELEASE_VERSION}" dist
 
-      - name: Require the original immutable release tag
+      - name: Write client candidate summary
         shell: bash
-        env:
-          EXPECTED_TAG_OBJECT: ${{ needs.version.outputs.tag_object }}
-          SOURCE_TAG: ${{ needs.version.outputs.source_tag }}
         run: |
-          set -euo pipefail
-          remote_tag_object="$(
-            git ls-remote origin "refs/tags/${SOURCE_TAG}" |
-              awk 'NR == 1 { print $1 }'
-          )"
-          if [ -z "${remote_tag_object}" ] || [ "${remote_tag_object}" != "${EXPECTED_TAG_OBJECT}" ]; then
-            echo "Release tag ${SOURCE_TAG} was deleted or moved during the build." >&2
-            exit 1
-          fi
+          {
+            echo "## Verified Astra client candidates"
+            echo
+            echo "Source: \`${RELEASE_SOURCE_SHA}\`"
+            echo
+            echo '```text'
+            cat dist/checksums.txt
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+      - name: Upload verified client release set
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          token: ${{ github.token }}
-          name: Astra v${{ needs.version.outputs.value }}
-          tag_name: ${{ needs.version.outputs.source_tag }}
-          draft: false
-          prerelease: ${{ needs.version.outputs.prerelease }}
-          generate_release_notes: true
-          make_latest: ${{ needs.version.outputs.prerelease == 'false' }}
-          files: dist/*
-          fail_on_unmatched_files: true
+          name: release-client-assets
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release-container-candidates.yml
+++ b/.github/workflows/release-container-candidates.yml
@@ -1,0 +1,181 @@
+name: Build Astra Container Release Candidates
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      image_version:
+        description: Candidate image version used for OCI metadata
+        required: true
+        type: string
+      source_sha:
+        description: Immutable source commit selected by the caller
+        required: true
+        type: string
+      matrix_json:
+        description: JSON platform build matrix
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+env:
+  IMAGE_NAME: matrixorigin/astra
+  RELEASE_SOURCE_SHA: ${{ inputs.source_sha }}
+  RELEASE_IMAGE_VERSION: ${{ inputs.image_version }}
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }} Candidate
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.matrix_json) }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ env.RELEASE_SOURCE_SHA }}
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        id: build
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.version=${{ env.RELEASE_IMAGE_VERSION }}
+            org.opencontainers.image.revision=${{ env.RELEASE_SOURCE_SHA }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          build-args: |
+            IMAGE_VERSION=${{ env.RELEASE_IMAGE_VERSION }}
+            IMAGE_REVISION=${{ env.RELEASE_SOURCE_SHA }}
+            IMAGE_SOURCE_DIRTY=false
+            IMAGE_BRANCH=${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache-${{ matrix.slug }}
+          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache-${{ matrix.slug }},mode=max
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          provenance: mode=max
+          sbom: true
+
+      - name: Export immutable digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Build returned an invalid image digest: ${digest:-<empty>}" >&2
+            exit 1
+          fi
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload candidate digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-digest-${{ matrix.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 7
+
+  smoke:
+    name: Verify ${{ matrix.platform }} Candidate
+    needs: build
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.matrix_json) }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ env.RELEASE_SOURCE_SHA }}
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-digest-${{ matrix.slug }}
+          path: /tmp/digest
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start candidate through the released all-in-one path
+        shell: bash
+        env:
+          DOCKERHUB_IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          digest_files=(/tmp/digest/*)
+          if [ "${#digest_files[@]}" -ne 1 ]; then
+            echo "Expected one candidate digest for ${{ matrix.platform }}, found ${#digest_files[@]}" >&2
+            exit 1
+          fi
+          digest="$(basename "${digest_files[0]}")"
+          if [[ ! "${digest}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Candidate artifact contains an invalid image digest: ${digest}" >&2
+            exit 1
+          fi
+          release_image="${DOCKERHUB_IMAGE_NAME}@sha256:${digest}"
+
+          make stack-env
+          sed -i "s|^ASTRA_IMAGE=.*|ASTRA_IMAGE=${release_image}|" deployment/all-in-one/.env
+          sed -i 's|^MEMORIA_EMBEDDING_PROVIDER=.*|MEMORIA_EMBEDDING_PROVIDER=mock|' deployment/all-in-one/.env
+          make stack-up
+
+          revision="$(docker image inspect "${release_image}" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+          if [ "${revision}" != "${RELEASE_SOURCE_SHA}" ]; then
+            echo "Candidate image revision ${revision:-<missing>} does not match ${RELEASE_SOURCE_SHA}" >&2
+            exit 1
+          fi
+
+      - name: Verify health and exact memory round trip
+        run: make stack-verify
+
+      - name: Write container candidate summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          digest_files=(/tmp/digest/*)
+          if [ "${#digest_files[@]}" -ne 1 ]; then
+            echo "Expected one verified candidate digest, found ${#digest_files[@]}" >&2
+            exit 1
+          fi
+          digest="$(basename "${digest_files[0]}")"
+          {
+            echo "## Verified Astra Server candidate"
+            echo
+            echo "- Platform: \`${{ matrix.platform }}\`"
+            echo "- Source: \`${RELEASE_SOURCE_SHA}\`"
+            echo "- Image: \`${IMAGE_NAME}@sha256:${digest}\`"
+            echo "- Runtime proof: all-in-one readiness and exact memory round trip"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Show service logs after failure
+        if: ${{ failure() }}
+        working-directory: deployment/all-in-one
+        run: docker compose --env-file .env logs --no-color --tail=200 api memoria matrixone || true
+
+      - name: Remove candidate smoke stack
+        if: ${{ always() }}
+        run: make stack-clean || true

--- a/.github/workflows/release-container-candidates.yml
+++ b/.github/workflows/release-container-candidates.yml
@@ -147,6 +147,11 @@ jobs:
             echo "Candidate image revision ${revision:-<missing>} does not match ${RELEASE_SOURCE_SHA}" >&2
             exit 1
           fi
+          image_version="$(docker image inspect "${release_image}" --format '{{ index .Config.Labels "org.opencontainers.image.version" }}')"
+          if [ "${image_version}" != "${RELEASE_IMAGE_VERSION}" ]; then
+            echo "Candidate image version ${image_version:-<missing>} does not match ${RELEASE_IMAGE_VERSION}" >&2
+            exit 1
+          fi
 
       - name: Verify health and exact memory round trip
         run: make stack-verify

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -103,6 +103,10 @@ jobs:
             fi
           }
           validate_tag "${image_version}"
+          if [[ ! "${image_version}" =~ ^snapshot-[0-9A-Za-z_][0-9A-Za-z_.-]*$ ]]; then
+            echo "Snapshot tags must start with snapshot-: ${image_version}" >&2
+            exit 1
+          fi
           if [[ "${image_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "Semantic versions are owned by the unified Release workflow." >&2
             exit 1
@@ -120,6 +124,10 @@ jobs:
 
           case "${INPUT_ARCHITECTURE}" in
             all)
+              if [[ "${image_version}" == *-amd64 || "${image_version}" == *-arm64 ]]; then
+                echo "Multi-platform snapshot tag ${image_version} must not use a single-architecture suffix." >&2
+                exit 1
+              fi
               matrix='{"include":[{"platform":"linux/amd64","runner":"ubuntu-latest","slug":"linux-amd64"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm","slug":"linux-arm64"}]}'
               ;;
             amd64)

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,21 +1,18 @@
-name: Release Docker Image
+name: Publish Astra Docker Snapshot
 
 permissions:
   contents: read
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Snapshot Docker tag (defaults to <YYYYMMDD>-<short-commit>; semver requires a Git tag)'
+      snapshot_tag:
+        description: Optional immutable tag (defaults to snapshot-<UTC date>-<short SHA>)
         required: false
-        default: ''
+        default: ""
         type: string
       architecture:
-        description: 'Architecture to build (single-architecture tags get an architecture suffix)'
+        description: Architecture to build
         required: true
         default: all
         type: choice
@@ -25,315 +22,171 @@ on:
           - arm64
 
 concurrency:
-  group: release-docker
-  # Never cancel a run that may already have pushed a platform image.
+  group: release-docker-snapshot
   cancel-in-progress: false
 
-env:
-  IMAGE_NAME: matrixorigin/astra
-
 jobs:
-  version:
-    name: Resolve Image Settings
+  settings:
+    name: Validate Snapshot Source
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     outputs:
-      image_version: ${{ steps.release.outputs.image_version }}
-      rolling_version: ${{ steps.release.outputs.rolling_version }}
-      latest: ${{ steps.release.outputs.latest }}
-      matrix: ${{ steps.release.outputs.matrix }}
+      image_version: ${{ steps.resolve.outputs.image_version }}
+      matrix: ${{ steps.resolve.outputs.matrix }}
       source_sha: ${{ steps.source.outputs.source_sha }}
-      tag_object: ${{ steps.source.outputs.tag_object }}
 
     steps:
-      - name: Resolve image tag and build matrix
-        id: release
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require Docker publication credentials
         shell: bash
         env:
-          INPUT_VERSION: ${{ inputs.version }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${DOCKERHUB_USERNAME}" ] || missing+=(DOCKERHUB_USERNAME)
+          [ -n "${DOCKERHUB_TOKEN}" ] || missing+=(DOCKERHUB_TOKEN)
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "Missing repository or organization Actions secrets: ${missing[*]}" >&2
+            echo "Configure the Docker Hub publisher credentials before building snapshot candidates." >&2
+            exit 1
+          fi
+
+      - name: Require the protected default-branch source
+        id: source
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+            echo "Select ${DEFAULT_BRANCH} in the Run workflow dialog." >&2
+            echo "Official Docker snapshots cannot publish unreviewed feature-branch source." >&2
+            exit 1
+          fi
+          git fetch --no-tags origin \
+            "refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          source_sha="$(git rev-parse HEAD)"
+          default_sha="$(git rev-parse "origin/${DEFAULT_BRANCH}")"
+          if [ "${source_sha}" != "${default_sha}" ]; then
+            echo "Selected source ${source_sha} is not the current ${DEFAULT_BRANCH} head ${default_sha}." >&2
+            echo "Refresh the workflow page and start a new run." >&2
+            exit 1
+          fi
+          echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Resolve immutable snapshot tag and platform matrix
+        id: resolve
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.snapshot_tag }}
           INPUT_ARCHITECTURE: ${{ inputs.architecture }}
         run: |
           set -euo pipefail
-
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            if [ -n "${INPUT_VERSION}" ]; then
-              image_version="${INPUT_VERSION}"
-            else
-              image_version="$(date -u +%Y%m%d)-${GITHUB_SHA::7}"
-            fi
-            architecture="${INPUT_ARCHITECTURE:-all}"
-
-            if [[ "${image_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-              echo "Semantic-version Docker tags are release-only." >&2
-              echo "Push the matching Git tag so source and manifest versions are validated." >&2
-              exit 1
-            fi
+          if [ -n "${INPUT_TAG}" ]; then
+            image_version="${INPUT_TAG}"
           else
-            image_version="${GITHUB_REF_NAME#v}"
-            architecture=all
-          fi
-
-          # Keep the previous behavior for semantic versions while preserving
-          # a leading "v" on non-semver custom tags.
-          if [[ "${image_version}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?)$ ]]; then
-            image_version="${BASH_REMATCH[1]}"
+            image_version="snapshot-$(date -u +%Y%m%d)-${GITHUB_SHA::7}"
           fi
 
           validate_tag() {
             local tag="$1"
             if [[ ! "${tag}" =~ ^[0-9A-Za-z_][0-9A-Za-z_.-]{0,127}$ ]]; then
-              echo "Invalid Docker tag: ${tag}" >&2
-              echo "A tag must start with a letter, digit, or underscore; contain only letters, digits, underscores, periods, and dashes; and be at most 128 characters." >&2
+              echo "Invalid Docker snapshot tag: ${tag}" >&2
+              echo "Tags must be at most 128 characters and use Docker tag characters." >&2
               exit 1
             fi
           }
           validate_tag "${image_version}"
-
+          if [[ "${image_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Semantic versions are owned by the unified Release workflow." >&2
+            exit 1
+          fi
           case "${image_version}" in
-            latest|buildcache|buildcache-*)
+            latest|buildcache|buildcache-*|snapshot)
               echo "Reserved Docker tag: ${image_version}" >&2
               exit 1
               ;;
           esac
           if [[ "${image_version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
-            echo "Reserved rolling-version tag: ${image_version}" >&2
+            echo "Rolling release tags are reserved: ${image_version}" >&2
             exit 1
           fi
 
-          rolling_version=""
-          latest=false
-
-          case "${architecture}" in
+          case "${INPUT_ARCHITECTURE}" in
             all)
               matrix='{"include":[{"platform":"linux/amd64","runner":"ubuntu-latest","slug":"linux-amd64"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm","slug":"linux-arm64"}]}'
-              if [[ "${image_version}" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
-                rolling_version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-                latest=true
-              fi
               ;;
             amd64)
-              if [[ "${image_version}" != *-amd64 ]]; then
-                image_version="${image_version}-amd64"
+              if [[ "${image_version}" == *-arm64 ]]; then
+                echo "Snapshot tag ${image_version} conflicts with the requested AMD64 architecture." >&2
+                exit 1
               fi
-              validate_tag "${image_version}"
+              [[ "${image_version}" == *-amd64 ]] || image_version="${image_version}-amd64"
               matrix='{"include":[{"platform":"linux/amd64","runner":"ubuntu-latest","slug":"linux-amd64"}]}'
               ;;
             arm64)
-              if [[ "${image_version}" != *-arm64 ]]; then
-                image_version="${image_version}-arm64"
+              if [[ "${image_version}" == *-amd64 ]]; then
+                echo "Snapshot tag ${image_version} conflicts with the requested ARM64 architecture." >&2
+                exit 1
               fi
-              validate_tag "${image_version}"
+              [[ "${image_version}" == *-arm64 ]] || image_version="${image_version}-arm64"
               matrix='{"include":[{"platform":"linux/arm64","runner":"ubuntu-24.04-arm","slug":"linux-arm64"}]}'
               ;;
             *)
-              echo "Unsupported architecture: ${architecture}" >&2
+              echo "Unsupported architecture: ${INPUT_ARCHITECTURE}" >&2
               exit 1
               ;;
           esac
-
+          validate_tag "${image_version}"
           echo "image_version=${image_version}" >> "${GITHUB_OUTPUT}"
-          echo "rolling_version=${rolling_version}" >> "${GITHUB_OUTPUT}"
-          echo "latest=${latest}" >> "${GITHUB_OUTPUT}"
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
 
-      - name: Check out release source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-          ref: ${{ github.event_name == 'push' && github.ref_name || github.sha }}
+  candidates:
+    name: Build and Verify Snapshot Candidates
+    needs: settings
+    uses: ./.github/workflows/release-container-candidates.yml
+    with:
+      image_version: ${{ needs.settings.outputs.image_version }}
+      source_sha: ${{ needs.settings.outputs.source_sha }}
+      matrix_json: ${{ needs.settings.outputs.matrix }}
+    secrets: inherit
 
-      - name: Validate manifest version
-        if: ${{ github.event_name == 'push' }}
-        run: scripts/validate-release-version.sh "${{ steps.release.outputs.image_version }}"
-
-      - name: Resolve and validate immutable source
-        id: source
-        shell: bash
-        env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          EVENT_SOURCE_SHA: ${{ github.event.after }}
-        run: |
-          set -euo pipefail
-          source_sha="$(git rev-parse HEAD)"
-          tag_object=""
-          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
-            tag_object="$(git rev-parse "refs/tags/${GITHUB_REF_NAME}")"
-            if [ "$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}")" != "tag" ]; then
-              echo "Release tag ${GITHUB_REF_NAME} must be annotated." >&2
-              exit 1
-            fi
-            source_sha="$(git rev-list -n 1 "refs/tags/${GITHUB_REF_NAME}")"
-            if [ "${source_sha}" != "${EVENT_SOURCE_SHA}" ]; then
-              echo "Release tag ${GITHUB_REF_NAME} no longer points to the commit that triggered this workflow." >&2
-              exit 1
-            fi
-          fi
-          git fetch --no-tags origin \
-            "refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
-          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
-            if ! git merge-base --is-ancestor "${source_sha}" "origin/${DEFAULT_BRANCH}"; then
-              echo "Release tag ${GITHUB_REF_NAME} is not reachable from ${DEFAULT_BRANCH}." >&2
-              echo "Merge the release commit before publishing its tag." >&2
-              exit 1
-            fi
-          fi
-          echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
-          echo "tag_object=${tag_object}" >> "${GITHUB_OUTPUT}"
-
-  build:
-    name: Build ${{ matrix.platform }}
-    needs: version
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.version.outputs.matrix) }}
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-          ref: ${{ needs.version.outputs.source_sha }}
-
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        id: meta
-        with:
-          images: ${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            type=raw,value=${{ needs.version.outputs.image_version }}
-
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        id: build
-        with:
-          context: .
-          file: Dockerfile
-          platforms: ${{ matrix.platform }}
-          tags: ${{ env.IMAGE_NAME }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            IMAGE_VERSION=${{ needs.version.outputs.image_version }}
-            IMAGE_REVISION=${{ needs.version.outputs.source_sha }}
-            IMAGE_SOURCE_DIRTY=false
-            IMAGE_BRANCH=${{ github.ref_name }}
-          # Registry caches are shared across release tags/branches and do not
-          # compete with Rust/sccache for the repository's Actions cache quota.
-          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache-${{ matrix.slug }}
-          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache-${{ matrix.slug }},mode=max
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          provenance: mode=max
-          sbom: true
-
-      - name: Export digest
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "Build returned an invalid image digest: ${digest:-<empty>}" >&2
-            exit 1
-          fi
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: digests-${{ matrix.slug }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  smoke:
-    name: Verify ${{ matrix.platform }} Candidate
+  publish:
+    name: Publish Immutable Snapshot Manifest
     needs:
-      - version
-      - build
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.version.outputs.matrix) }}
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-          ref: ${{ needs.version.outputs.source_sha }}
-
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: digests-${{ matrix.slug }}
-          path: /tmp/digest
-
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Start candidate digest through the documented all-in-one path
-        shell: bash
-        env:
-          DOCKERHUB_IMAGE_NAME: ${{ env.IMAGE_NAME }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          digest_files=(/tmp/digest/*)
-          if [ "${#digest_files[@]}" -ne 1 ]; then
-            echo "Expected one candidate digest for ${{ matrix.platform }}, found ${#digest_files[@]}" >&2
-            exit 1
-          fi
-          digest="$(basename "${digest_files[0]}")"
-          if [[ ! "${digest}" =~ ^[0-9a-f]{64}$ ]]; then
-            echo "Candidate artifact contains an invalid image digest: ${digest}" >&2
-            exit 1
-          fi
-          release_image="${DOCKERHUB_IMAGE_NAME}@sha256:${digest}"
-
-          make stack-env
-          sed -i "s|^ASTRA_IMAGE=.*|ASTRA_IMAGE=${release_image}|" deployment/all-in-one/.env
-          sed -i 's|^MEMORIA_EMBEDDING_PROVIDER=.*|MEMORIA_EMBEDDING_PROVIDER=mock|' deployment/all-in-one/.env
-          make stack-up
-
-          revision="$(docker image inspect "${release_image}" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
-          if [ "${revision}" != "${{ needs.version.outputs.source_sha }}" ]; then
-            echo "Candidate image revision ${revision:-<missing>} does not match ${{ needs.version.outputs.source_sha }}" >&2
-            exit 1
-          fi
-
-      - name: Verify health and memory round trip
-        run: make stack-verify
-
-      - name: Show service logs after failure
-        if: ${{ failure() }}
-        working-directory: deployment/all-in-one
-        run: docker compose --env-file .env logs --no-color --tail=200 api memoria matrixone || true
-
-      - name: Remove release smoke stack
-        if: ${{ always() }}
-        run: make stack-clean || true
-
-  merge:
-    name: Publish Verified DockerHub Manifest
-    needs:
-      - version
-      - build
-      - smoke
+      - settings
+      - candidates
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    environment: release-snapshot
+    timeout-minutes: 20
 
     steps:
+      - name: Require the configured snapshot environment
+        shell: bash
+        env:
+          SNAPSHOT_ENVIRONMENT_GUARD: ${{ secrets.ASTRA_SNAPSHOT_ENVIRONMENT_GUARD }}
+        run: |
+          set -euo pipefail
+          if [ "${SNAPSHOT_ENVIRONMENT_GUARD}" != "configured" ]; then
+            echo "The release-snapshot Environment is missing ASTRA_SNAPSHOT_ENVIRONMENT_GUARD=configured." >&2
+            echo "Snapshot publication fails closed when the protected Environment has not been configured." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ needs.settings.outputs.source_sha }}
+
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          pattern: digests-*
+          pattern: release-digest-*
           path: /tmp/digests
           merge-multiple: true
 
@@ -344,199 +197,28 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        id: meta
-        with:
-          images: ${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            type=raw,value=${{ needs.version.outputs.image_version }}
-
-      - name: Create verified DockerHub manifest list
-        shell: bash
-        working-directory: /tmp/digests
-        env:
-          DOCKERHUB_IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          DOCKERHUB_METADATA_JSON: ${{ steps.meta.outputs.json }}
-          BUILD_MATRIX_JSON: ${{ needs.version.outputs.matrix }}
-          EVENT_NAME: ${{ github.event_name }}
-          EXPECTED_TAG_OBJECT: ${{ needs.version.outputs.tag_object }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          mapfile -t tag_args < <(jq -r '.tags[] | "-t", .' <<< "${DOCKERHUB_METADATA_JSON}")
-          if [ "${#tag_args[@]}" -eq 0 ]; then
-            echo "No DockerHub tags were generated" >&2
-            exit 1
-          fi
-
-          sources=()
-          for digest in *; do
-            if [[ ! "${digest}" =~ ^[0-9a-f]{64}$ ]]; then
-              echo "Digest artifact has an invalid filename: ${digest}" >&2
-              exit 1
-            fi
-            sources+=("${DOCKERHUB_IMAGE_NAME}@sha256:${digest}")
-          done
-          if [ "${#sources[@]}" -eq 0 ]; then
-            echo "No platform image digests were downloaded" >&2
-            exit 1
-          fi
-          expected_sources="$(jq -r '.include | length' <<< "${BUILD_MATRIX_JSON}")"
-          if [ "${#sources[@]}" -ne "${expected_sources}" ]; then
-            echo "Expected ${expected_sources} platform digests, found ${#sources[@]}" >&2
-            exit 1
-          fi
-
-          expected_platforms="$(jq -r '.include[].platform' <<< "${BUILD_MATRIX_JSON}" | sort)"
-          image_platform_set() {
-            docker buildx imagetools inspect "$1" --format '{{json .Image}}' |
-              jq -r '
-                if .os? == "linux" and (.architecture? | type) == "string" then
-                  "\(.os)/\(.architecture)"
-                else
-                  to_entries[]
-                  | select(.value.os == "linux" and (.value.architecture | type) == "string")
-                  | "\(.value.os)/\(.value.architecture)"
-                end
-              ' |
-              sort -u
-          }
-          actual_platforms="$(
-            for source in "${sources[@]}"; do
-              image_platform_set "${source}"
-            done | sort -u
-          )"
-          if [ "${actual_platforms}" != "${expected_platforms}" ]; then
-            echo "Candidate platform set does not match the release build matrix" >&2
-            diff <(printf '%s\n' "${expected_platforms}") <(printf '%s\n' "${actual_platforms}") || true
-            exit 1
-          fi
-
-          if [ "${EVENT_NAME}" = "push" ]; then
-            remote_tag_object="$(
-              git ls-remote "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" "refs/tags/${GITHUB_REF_NAME}" |
-                awk 'NR == 1 { print $1 }'
-            )"
-            if [ -z "${remote_tag_object}" ] || [ "${remote_tag_object}" != "${EXPECTED_TAG_OBJECT}" ]; then
-              echo "Release tag ${GITHUB_REF_NAME} was deleted or moved during the build." >&2
-              exit 1
-            fi
-          fi
-
-          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
-
-  promote:
-    name: Promote Verified Release Tags
-    needs:
-      - version
-      - merge
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    steps:
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Promote stable release after smoke verification
+      - name: Publish or verify the immutable snapshot manifest
         shell: bash
         env:
-          IMAGE_VERSION: ${{ needs.version.outputs.image_version }}
-          ROLLING_VERSION: ${{ needs.version.outputs.rolling_version }}
-          PUBLISH_LATEST: ${{ needs.version.outputs.latest }}
+          IMAGE_NAME: matrixorigin/astra
+          IMAGE_VERSION: ${{ needs.settings.outputs.image_version }}
+          BUILD_MATRIX_JSON: ${{ needs.settings.outputs.matrix }}
         run: |
           set -euo pipefail
-          if [ "${PUBLISH_LATEST}" != "true" ]; then
-            echo "Snapshot or prerelease verified; latest remains unchanged."
-            exit 0
-          fi
-          docker buildx imagetools create \
-            --tag "${IMAGE_NAME}:${ROLLING_VERSION}" \
-            --tag "${IMAGE_NAME}:latest" \
-            "${IMAGE_NAME}:${IMAGE_VERSION}"
+          scripts/reconcile-docker-manifest.sh \
+            "${IMAGE_NAME}" "${IMAGE_VERSION}" "${BUILD_MATRIX_JSON}" \
+            /tmp/digests verify
 
-          platform_manifest_set() {
-            docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' |
-              jq -r '.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64")) | "\(.platform.os)/\(.platform.architecture)=\(.digest)"' |
-              sort
-          }
-          expected_platforms="$(platform_manifest_set "${IMAGE_NAME}:${IMAGE_VERSION}")"
-          if [ -z "${expected_platforms}" ]; then
-            echo "Verified version manifest has no Linux AMD64/ARM64 images" >&2
-            exit 1
-          fi
-          for target in "${ROLLING_VERSION}" latest; do
-            actual_platforms="$(platform_manifest_set "${IMAGE_NAME}:${target}")"
-            if [ "${actual_platforms}" != "${expected_platforms}" ]; then
-              echo "Promoted tag ${target} does not match ${IMAGE_VERSION}" >&2
-              diff <(printf '%s\n' "${expected_platforms}") <(printf '%s\n' "${actual_platforms}") || true
-              exit 1
-            fi
-          done
-
-  registry-mirror:
-    name: Publish Registry Mirror
-    if: >-
-      vars.CONTAINER_MIRROR_REGISTRY != '' &&
-      vars.CONTAINER_MIRROR_IMAGE != ''
-    needs:
-      - version
-      - promote
-    runs-on: ${{ vars.CONTAINER_MIRROR_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 45
-    env:
-      http_proxy: ${{ vars.CONTAINER_MIRROR_HTTP_PROXY || '' }}
-      https_proxy: ${{ vars.CONTAINER_MIRROR_HTTPS_PROXY || '' }}
-      no_proxy: ${{ vars.CONTAINER_MIRROR_NO_PROXY || '' }}
-
-    steps:
-      - name: Install crane
+      - name: Write snapshot summary
         shell: bash
         env:
-          CRANE_VERSION: v0.20.6
-          CRANE_LINUX_X86_64_SHA256: c1d593d01551f2c9a3df5ca0a0be4385a839bd9b86d4a76e18d7b17d16559127
+          IMAGE: matrixorigin/astra:${{ needs.settings.outputs.image_version }}
+          SOURCE_SHA: ${{ needs.settings.outputs.source_sha }}
         run: |
-          set -euo pipefail
-          mkdir -p "${RUNNER_TEMP}/bin"
-          curl -fsSL \
-            -o "${RUNNER_TEMP}/go-containerregistry.tar.gz" \
-            "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz"
-          echo "${CRANE_LINUX_X86_64_SHA256}  ${RUNNER_TEMP}/go-containerregistry.tar.gz" \
-            | sha256sum --check --strict
-          tar -xzf "${RUNNER_TEMP}/go-containerregistry.tar.gz" -C "${RUNNER_TEMP}/bin" crane
-          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
-          "${RUNNER_TEMP}/bin/crane" version
-
-      - name: Copy DockerHub manifest to IDC
-        shell: bash
-        env:
-          IMAGE_VERSION: ${{ needs.version.outputs.image_version }}
-          ROLLING_VERSION: ${{ needs.version.outputs.rolling_version }}
-          PUBLISH_LATEST: ${{ needs.version.outputs.latest }}
-          SOURCE_IMAGE: ${{ env.IMAGE_NAME }}
-          MIRROR_REGISTRY: ${{ vars.CONTAINER_MIRROR_REGISTRY }}
-          TARGET_IMAGE: ${{ vars.CONTAINER_MIRROR_IMAGE }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          MIRROR_USERNAME: ${{ secrets.IDC_REGISTRY_USERNAME }}
-          MIRROR_PASSWORD: ${{ secrets.IDC_REGISTRY_PASSWORD }}
-        run: |
-          set -euo pipefail
-          printf '%s' "${DOCKERHUB_TOKEN}" | crane auth login index.docker.io -u "${DOCKERHUB_USERNAME}" --password-stdin
-          printf '%s' "${MIRROR_PASSWORD}" | crane auth login "${MIRROR_REGISTRY}" -u "${MIRROR_USERNAME}" --password-stdin
-
-          tags=("${IMAGE_VERSION}")
-          if [ "${PUBLISH_LATEST}" = "true" ]; then
-            tags+=("${ROLLING_VERSION}" "latest")
-          fi
-          for tag in "${tags[@]}"; do
-            crane copy --platform=all --jobs 2 \
-              "docker.io/${SOURCE_IMAGE}:${IMAGE_VERSION}" \
-              "${TARGET_IMAGE}:${tag}"
-          done
-          crane manifest "${TARGET_IMAGE}:${IMAGE_VERSION}" >/dev/null
+          {
+            echo "## Docker snapshot published"
+            echo
+            echo "- Image: \`${IMAGE}\`"
+            echo "- Source: \`${SOURCE_SHA}\`"
+            echo "- This immutable snapshot did not update a semantic version or \`latest\`."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
           fi
 
           version="${INPUT_VERSION#v}"
+          scripts/validate-release-version.sh "${version}" --syntax-only
           source_tag="v${version}"
           git fetch --no-tags origin \
             "refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
@@ -166,14 +167,16 @@ jobs:
           fi
           matrix='{"include":[{"platform":"linux/amd64","runner":"ubuntu-latest","slug":"linux-amd64"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm","slug":"linux-arm64"}]}'
 
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "source_tag=${source_tag}" >> "${GITHUB_OUTPUT}"
-          echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
-          echo "tag_object=${tag_object}" >> "${GITHUB_OUTPUT}"
-          echo "prerelease=${prerelease}" >> "${GITHUB_OUTPUT}"
-          echo "rolling_version=${rolling_version}" >> "${GITHUB_OUTPUT}"
-          echo "publish_latest=${publish_latest}" >> "${GITHUB_OUTPUT}"
-          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "version=${version}"
+            echo "source_tag=${source_tag}"
+            echo "source_sha=${source_sha}"
+            echo "tag_object=${tag_object}"
+            echo "prerelease=${prerelease}"
+            echo "rolling_version=${rolling_version}"
+            echo "publish_latest=${publish_latest}"
+            echo "matrix=${matrix}"
+          } >> "${GITHUB_OUTPUT}"
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         if: ${{ inputs.recover_existing_tag != true }}
@@ -185,9 +188,15 @@ jobs:
           IMAGE: matrixorigin/astra:${{ steps.resolve.outputs.version }}
         run: |
           set -euo pipefail
-          if docker buildx imagetools inspect "${IMAGE}" >/dev/null 2>&1; then
+          if inspect_output="$(docker buildx imagetools inspect "${IMAGE}" 2>&1)"; then
             echo "Docker version ${IMAGE} already exists." >&2
             echo "Choose a new version; normal publication never adopts or overwrites an existing tag." >&2
+            exit 1
+          elif ! grep -Eqi '(: not found|manifest unknown|name unknown|HTTP 404|status[^0-9]*404)' \
+            <<< "${inspect_output}"; then
+            echo "Could not safely determine whether Docker version ${IMAGE} exists:" >&2
+            printf '%s\n' "${inspect_output}" >&2
+            echo "Resolve the registry or authentication failure before building candidates." >&2
             exit 1
           fi
 
@@ -299,8 +308,10 @@ jobs:
             tag_source="$(printf '%s' "${tag_json}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["object"]["sha"])')"
             tag_message="$(printf '%s' "${tag_json}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["message"])')"
             run_marker="Release-Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            mapfile -t run_markers < <(grep -F 'Release-Run: ' <<< "${tag_message}" || true)
             if [ "${tag_source}" != "${SOURCE_SHA}" ] \
-              || ! grep -Fxq "${run_marker}" <<< "${tag_message}"; then
+              || [ "${#run_markers[@]}" -ne 1 ] \
+              || [ "${run_markers[0]}" != "${run_marker}" ]; then
               echo "Release tag ${SOURCE_TAG} appeared during candidate verification and is not owned by this run." >&2
               exit 1
             fi
@@ -320,9 +331,15 @@ jobs:
         run: |
           set -euo pipefail
           state=none
-          if release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${SOURCE_TAG}" 2>/dev/null)"; then
+          lookup_error="${RUNNER_TEMP}/release-lookup-error"
+          if release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${SOURCE_TAG}" 2>"${lookup_error}")"; then
             state="$(printf '%s' "${release_json}" | python3 -c 'import json,sys; print("draft" if json.load(sys.stdin)["draft"] else "published")')"
+          elif ! grep -Eq 'HTTP 404' "${lookup_error}"; then
+            echo "Could not safely determine whether GitHub Release ${SOURCE_TAG} exists:" >&2
+            cat "${lookup_error}" >&2
+            exit 1
           fi
+          rm -f "${lookup_error}"
           if [ "${RECOVER_EXISTING_TAG}" != "true" ] \
             && [ "${SAME_RUN}" != "true" ] \
             && [ "${state}" != "none" ]; then
@@ -340,9 +357,14 @@ jobs:
           IMAGE: matrixorigin/astra:${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
-          if docker buildx imagetools inspect "${IMAGE}" >/dev/null 2>&1; then
+          if inspect_output="$(docker buildx imagetools inspect "${IMAGE}" 2>&1)"; then
             echo "Docker version ${IMAGE} already exists." >&2
             echo "Choose a new version; normal publication never adopts or overwrites an existing tag." >&2
+            exit 1
+          elif ! grep -Eqi '(: not found|manifest unknown|name unknown|HTTP 404|status[^0-9]*404)' \
+            <<< "${inspect_output}"; then
+            echo "Could not safely determine whether Docker version ${IMAGE} exists:" >&2
+            printf '%s\n' "${inspect_output}" >&2
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,588 @@
+name: Release Astra
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Semantic version to release, for example 0.1.0 or 0.1.0-rc.1
+        required: true
+        type: string
+      recover_existing_tag:
+        description: Resume a failed publication from an existing immutable tag
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: release-astra
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Resolve and Validate Release Source
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      source_tag: ${{ steps.resolve.outputs.source_tag }}
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
+      tag_object: ${{ steps.resolve.outputs.tag_object }}
+      prerelease: ${{ steps.resolve.outputs.prerelease }}
+      rolling_version: ${{ steps.resolve.outputs.rolling_version }}
+      publish_latest: ${{ steps.resolve.outputs.publish_latest }}
+      matrix: ${{ steps.resolve.outputs.matrix }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require Docker publication credentials
+        shell: bash
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${DOCKERHUB_USERNAME}" ] || missing+=(DOCKERHUB_USERNAME)
+          [ -n "${DOCKERHUB_TOKEN}" ] || missing+=(DOCKERHUB_TOKEN)
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "Missing repository or organization Actions secrets: ${missing[*]}" >&2
+            echo "Configure the Docker Hub publisher credentials before building release candidates." >&2
+            exit 1
+          fi
+
+      - name: Select protected source and recovery mode
+        id: resolve
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          INPUT_VERSION: ${{ inputs.version }}
+          RECOVER_EXISTING_TAG: ${{ inputs.recover_existing_tag }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+            echo "Select ${DEFAULT_BRANCH} in the Run workflow dialog." >&2
+            echo "The release control plane must execute from the protected default branch." >&2
+            exit 1
+          fi
+
+          version="${INPUT_VERSION#v}"
+          source_tag="v${version}"
+          git fetch --no-tags origin \
+            "refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          default_sha="$(git rev-parse "origin/${DEFAULT_BRANCH}")"
+          selected_sha="$(git rev-parse HEAD)"
+          remote_tag_object="$(
+            git ls-remote origin "refs/tags/${source_tag}" |
+              awk 'NR == 1 { print $1 }'
+          )"
+
+          if [ "${RECOVER_EXISTING_TAG}" = "true" ]; then
+            if [ -z "${remote_tag_object}" ]; then
+              echo "Recovery requested, but ${source_tag} does not exist." >&2
+              echo "Start a normal release run instead." >&2
+              exit 1
+            fi
+            git fetch --force origin \
+              "refs/tags/${source_tag}:refs/tags/${source_tag}"
+            if [ "$(git cat-file -t "refs/tags/${source_tag}")" != "tag" ]; then
+              echo "Release tag ${source_tag} must be annotated." >&2
+              exit 1
+            fi
+            source_sha="$(git rev-list -n 1 "refs/tags/${source_tag}")"
+            tag_message="$(git for-each-ref --format='%(contents)' "refs/tags/${source_tag}")"
+            run_marker_prefix="Release-Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/"
+            mapfile -t run_markers < <(grep -F 'Release-Run: ' <<< "${tag_message}" || true)
+            marker_run_id=""
+            if [ "${#run_markers[@]}" -eq 1 ] \
+              && [[ "${run_markers[0]}" == "${run_marker_prefix}"* ]]; then
+              marker_run_id="${run_markers[0]#"${run_marker_prefix}"}"
+            fi
+            if [[ ! "${marker_run_id}" =~ ^[0-9]+$ ]]; then
+              echo "Release tag ${source_tag} was not created by the unified Release Astra workflow." >&2
+              echo "Recovery cannot adopt manual or legacy tags." >&2
+              exit 1
+            fi
+            owner_run_json="$(
+              gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${marker_run_id}"
+            )" || {
+              echo "The Actions run recorded by ${source_tag} no longer exists or is not readable." >&2
+              echo "Recovery will not trust an unverifiable release owner." >&2
+              exit 1
+            }
+            mapfile -t owner_run < <(
+              printf '%s' "${owner_run_json}" | python3 -c 'import json, sys; run = json.load(sys.stdin); print(run.get("path", "")); print(run.get("event", "")); print(run.get("head_branch", "")); print(run.get("head_sha", ""))'
+            )
+            if [ "${#owner_run[@]}" -ne 4 ] \
+              || [ "${owner_run[0]}" != ".github/workflows/release.yml" ] \
+              || [ "${owner_run[1]}" != "workflow_dispatch" ] \
+              || [ "${owner_run[2]}" != "${DEFAULT_BRANCH}" ] \
+              || [ "${owner_run[3]}" != "${source_sha}" ]; then
+              echo "Release tag ${source_tag} names an Actions run that does not own this source." >&2
+              echo "Expected Release Astra on ${DEFAULT_BRANCH} at ${source_sha}." >&2
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "${source_sha}" "${default_sha}"; then
+              echo "Release tag ${source_tag} is not reachable from ${DEFAULT_BRANCH}." >&2
+              exit 1
+            fi
+            tag_object="${remote_tag_object}"
+          else
+            if [ -n "${remote_tag_object}" ]; then
+              echo "Release tag ${source_tag} already exists." >&2
+              echo "Use recovery mode only to resume its original publication." >&2
+              exit 1
+            fi
+            if [ "${selected_sha}" != "${default_sha}" ]; then
+              echo "Selected source ${selected_sha} is not the current ${DEFAULT_BRANCH} head ${default_sha}." >&2
+              echo "Refresh the workflow page and start a new run." >&2
+              exit 1
+            fi
+            source_sha="${selected_sha}"
+            tag_object=""
+          fi
+
+          git checkout --detach "${source_sha}"
+          scripts/validate-release-version.sh "${version}"
+          python3 scripts/ci/validate_repository.py
+
+          prerelease=false
+          publish_latest=true
+          rolling_version="${version%.*}"
+          if [[ "${version}" == *-* ]]; then
+            prerelease=true
+            publish_latest=false
+            rolling_version=""
+          fi
+          matrix='{"include":[{"platform":"linux/amd64","runner":"ubuntu-latest","slug":"linux-amd64"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm","slug":"linux-arm64"}]}'
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "source_tag=${source_tag}" >> "${GITHUB_OUTPUT}"
+          echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
+          echo "tag_object=${tag_object}" >> "${GITHUB_OUTPUT}"
+          echo "prerelease=${prerelease}" >> "${GITHUB_OUTPUT}"
+          echo "rolling_version=${rolling_version}" >> "${GITHUB_OUTPUT}"
+          echo "publish_latest=${publish_latest}" >> "${GITHUB_OUTPUT}"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        if: ${{ inputs.recover_existing_tag != true }}
+
+      - name: Reject an existing Docker version before candidate builds
+        if: ${{ inputs.recover_existing_tag != true }}
+        shell: bash
+        env:
+          IMAGE: matrixorigin/astra:${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          if docker buildx imagetools inspect "${IMAGE}" >/dev/null 2>&1; then
+            echo "Docker version ${IMAGE} already exists." >&2
+            echo "Choose a new version; normal publication never adopts or overwrites an existing tag." >&2
+            exit 1
+          fi
+
+      - name: Write preflight summary
+        shell: bash
+        run: |
+          {
+            echo "## Release preflight"
+            echo
+            echo "- Version: \`${{ steps.resolve.outputs.source_tag }}\`"
+            echo "- Source: \`${{ steps.resolve.outputs.source_sha }}\`"
+            echo "- Recovery: \`${{ inputs.recover_existing_tag }}\`"
+            echo "- Client targets: Linux and macOS, AMD64 and ARM64"
+            echo "- Server targets: Linux AMD64 and ARM64"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  clients:
+    name: Build and Verify Client Candidates
+    needs: preflight
+    uses: ./.github/workflows/release-binaries.yml
+    with:
+      version: ${{ needs.preflight.outputs.version }}
+      source_sha: ${{ needs.preflight.outputs.source_sha }}
+
+  containers:
+    name: Build and Verify Server Candidates
+    needs: preflight
+    uses: ./.github/workflows/release-container-candidates.yml
+    with:
+      image_version: ${{ needs.preflight.outputs.version }}
+      source_sha: ${{ needs.preflight.outputs.source_sha }}
+      matrix_json: ${{ needs.preflight.outputs.matrix }}
+    secrets: inherit
+
+  publish:
+    name: Publish Verified Release
+    needs:
+      - preflight
+      - clients
+      - containers
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 30
+    permissions:
+      contents: write
+
+    steps:
+      - name: Require the configured release environment
+        shell: bash
+        env:
+          RELEASE_ENVIRONMENT_GUARD: ${{ secrets.ASTRA_RELEASE_ENVIRONMENT_GUARD }}
+        run: |
+          set -euo pipefail
+          if [ "${RELEASE_ENVIRONMENT_GUARD}" != "configured" ]; then
+            echo "The release Environment is missing ASTRA_RELEASE_ENVIRONMENT_GUARD=configured." >&2
+            echo "Publication fails closed when the protected Environment has not been configured." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.source_sha }}
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-client-assets
+          path: dist
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: release-digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Revalidate client assets at the publication boundary
+        shell: bash
+        run: scripts/verify-release-artifacts.sh "${{ needs.preflight.outputs.version }}" dist
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve publication continuation state
+        id: publication_state
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RECOVER_EXISTING_TAG: ${{ inputs.recover_existing_tag }}
+          SOURCE_SHA: ${{ needs.preflight.outputs.source_sha }}
+          SOURCE_TAG: ${{ needs.preflight.outputs.source_tag }}
+        run: |
+          set -euo pipefail
+          same_run=false
+          tag_object="$(
+            git ls-remote origin "refs/tags/${SOURCE_TAG}" |
+              awk 'NR == 1 { print $1 }'
+          )"
+          if [ -n "${tag_object}" ] && [ "${RECOVER_EXISTING_TAG}" != "true" ]; then
+            tag_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_object}")" \
+              || {
+                echo "Existing ${SOURCE_TAG} is not a release tag owned by this run." >&2
+                exit 1
+              }
+            tag_source="$(printf '%s' "${tag_json}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["object"]["sha"])')"
+            tag_message="$(printf '%s' "${tag_json}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["message"])')"
+            run_marker="Release-Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            if [ "${tag_source}" != "${SOURCE_SHA}" ] \
+              || ! grep -Fxq "${run_marker}" <<< "${tag_message}"; then
+              echo "Release tag ${SOURCE_TAG} appeared during candidate verification and is not owned by this run." >&2
+              exit 1
+            fi
+            same_run=true
+          fi
+          echo "same_run=${same_run}" >> "${GITHUB_OUTPUT}"
+          echo "tag_object=${tag_object}" >> "${GITHUB_OUTPUT}"
+
+      - name: Detect existing GitHub Release
+        id: existing_release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_TAG: ${{ needs.preflight.outputs.source_tag }}
+          RECOVER_EXISTING_TAG: ${{ inputs.recover_existing_tag }}
+          SAME_RUN: ${{ steps.publication_state.outputs.same_run }}
+        run: |
+          set -euo pipefail
+          state=none
+          if release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${SOURCE_TAG}" 2>/dev/null)"; then
+            state="$(printf '%s' "${release_json}" | python3 -c 'import json,sys; print("draft" if json.load(sys.stdin)["draft"] else "published")')"
+          fi
+          if [ "${RECOVER_EXISTING_TAG}" != "true" ] \
+            && [ "${SAME_RUN}" != "true" ] \
+            && [ "${state}" != "none" ]; then
+            echo "GitHub Release ${SOURCE_TAG} already exists; normal publication will not mutate it." >&2
+            exit 1
+          fi
+          echo "state=${state}" >> "${GITHUB_OUTPUT}"
+
+      - name: Reject conflicting Docker version before creating the tag
+        if: >-
+          inputs.recover_existing_tag != true &&
+          steps.publication_state.outputs.same_run != 'true'
+        shell: bash
+        env:
+          IMAGE: matrixorigin/astra:${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          if docker buildx imagetools inspect "${IMAGE}" >/dev/null 2>&1; then
+            echo "Docker version ${IMAGE} already exists." >&2
+            echo "Choose a new version; normal publication never adopts or overwrites an existing tag." >&2
+            exit 1
+          fi
+
+      - name: Create or validate the immutable release tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RECOVER_EXISTING_TAG: ${{ inputs.recover_existing_tag }}
+          SOURCE_SHA: ${{ needs.preflight.outputs.source_sha }}
+          SOURCE_TAG: ${{ needs.preflight.outputs.source_tag }}
+          EXPECTED_TAG_OBJECT: ${{ needs.preflight.outputs.tag_object }}
+          SAME_RUN: ${{ steps.publication_state.outputs.same_run }}
+          CURRENT_TAG_OBJECT: ${{ steps.publication_state.outputs.tag_object }}
+        run: |
+          set -euo pipefail
+          remote_tag_object="$(
+            git ls-remote origin "refs/tags/${SOURCE_TAG}" |
+              awk 'NR == 1 { print $1 }'
+          )"
+          if [ -z "${remote_tag_object}" ]; then
+            if [ "${RECOVER_EXISTING_TAG}" = "true" ]; then
+              echo "Release tag ${SOURCE_TAG} disappeared after preflight." >&2
+              exit 1
+            fi
+            tag_message="$(printf 'Astra %s\n\nRelease-Run: %s/%s/actions/runs/%s' \
+              "${SOURCE_TAG}" "${GITHUB_SERVER_URL}" "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}")"
+            tag_object="$(
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/git/tags" \
+                -f tag="${SOURCE_TAG}" \
+                -f message="${tag_message}" \
+                -f object="${SOURCE_SHA}" \
+                -f type=commit \
+                --jq .sha
+            )"
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${SOURCE_TAG}" \
+              -f sha="${tag_object}" >/dev/null
+            remote_tag_object="${tag_object}"
+          else
+            if [ "${RECOVER_EXISTING_TAG}" = "true" ]; then
+              if [ "${remote_tag_object}" != "${EXPECTED_TAG_OBJECT}" ]; then
+                echo "Release tag ${SOURCE_TAG} changed after preflight." >&2
+                exit 1
+              fi
+            elif [ "${SAME_RUN}" != "true" ] \
+              || [ "${remote_tag_object}" != "${CURRENT_TAG_OBJECT}" ]; then
+              echo "Release tag ${SOURCE_TAG} appeared or changed during publication." >&2
+              exit 1
+            fi
+          fi
+
+          git fetch --force origin \
+            "refs/tags/${SOURCE_TAG}:refs/tags/${SOURCE_TAG}"
+          if [ "$(git cat-file -t "refs/tags/${SOURCE_TAG}")" != "tag" ]; then
+            echo "Release tag ${SOURCE_TAG} is not annotated." >&2
+            exit 1
+          fi
+          peeled_sha="$(git rev-list -n 1 "refs/tags/${SOURCE_TAG}")"
+          if [ "${peeled_sha}" != "${SOURCE_SHA}" ]; then
+            echo "Release tag ${SOURCE_TAG} points to ${peeled_sha}, expected ${SOURCE_SHA}." >&2
+            exit 1
+          fi
+
+      - name: Create or verify the immutable Docker version manifest
+        shell: bash
+        env:
+          IMAGE_NAME: matrixorigin/astra
+          IMAGE_VERSION: ${{ needs.preflight.outputs.version }}
+          BUILD_MATRIX_JSON: ${{ needs.preflight.outputs.matrix }}
+          RECOVER_EXISTING_TAG: ${{ inputs.recover_existing_tag }}
+          SAME_RUN: ${{ steps.publication_state.outputs.same_run }}
+        run: |
+          set -euo pipefail
+          existing_policy=reject
+          if [ "${RECOVER_EXISTING_TAG}" = "true" ] || [ "${SAME_RUN}" = "true" ]; then
+            existing_policy=verify
+          fi
+          scripts/reconcile-docker-manifest.sh \
+            "${IMAGE_NAME}" "${IMAGE_VERSION}" "${BUILD_MATRIX_JSON}" \
+            /tmp/digests "${existing_policy}"
+
+      - name: Verify already-published release during recovery
+        if: ${{ steps.existing_release.outputs.state == 'published' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_TAG: ${{ needs.preflight.outputs.source_tag }}
+        run: |
+          set -euo pipefail
+          existing_dir="${RUNNER_TEMP}/existing-release"
+          published_manifests="${RUNNER_TEMP}/published-manifests"
+          mkdir -p "${existing_dir}"
+          mkdir -p "${published_manifests}"
+          gh release download "${SOURCE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --dir "${existing_dir}"
+          cp "${existing_dir}/checksums.txt" "${published_manifests}/checksums.txt"
+          cp "${existing_dir}/checksums.txt.sha256" "${published_manifests}/checksums.txt.sha256"
+          scripts/verify-release-artifacts.sh \
+            "${{ needs.preflight.outputs.version }}" "${existing_dir}"
+          cmp "${published_manifests}/checksums.txt" "${existing_dir}/checksums.txt"
+          cmp "${published_manifests}/checksums.txt.sha256" "${existing_dir}/checksums.txt.sha256"
+          cmp dist/checksums.txt "${existing_dir}/checksums.txt"
+          cmp dist/checksums.txt.sha256 "${existing_dir}/checksums.txt.sha256"
+
+      - name: Stage GitHub Release and verified assets
+        if: ${{ steps.existing_release.outputs.state != 'published' }}
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          token: ${{ github.token }}
+          name: Astra v${{ needs.preflight.outputs.version }}
+          tag_name: ${{ needs.preflight.outputs.source_tag }}
+          draft: true
+          prerelease: ${{ needs.preflight.outputs.prerelease }}
+          generate_release_notes: true
+          make_latest: false
+          files: dist/*
+          fail_on_unmatched_files: true
+
+      - name: Publish GitHub Release
+        if: ${{ steps.existing_release.outputs.state != 'published' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_TAG: ${{ needs.preflight.outputs.source_tag }}
+          PRERELEASE: ${{ needs.preflight.outputs.prerelease }}
+          PUBLISH_LATEST: ${{ needs.preflight.outputs.publish_latest }}
+        run: |
+          set -euo pipefail
+          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${SOURCE_TAG}" --jq .id)"
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+            -F draft=false \
+            -F prerelease="${PRERELEASE}" \
+            -f make_latest="${PUBLISH_LATEST}" >/dev/null
+
+      - name: Promote stable rolling Docker tags
+        if: ${{ needs.preflight.outputs.publish_latest == 'true' }}
+        shell: bash
+        env:
+          IMAGE_NAME: matrixorigin/astra
+          IMAGE_VERSION: ${{ needs.preflight.outputs.version }}
+          ROLLING_VERSION: ${{ needs.preflight.outputs.rolling_version }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${IMAGE_NAME}:${ROLLING_VERSION}" \
+            --tag "${IMAGE_NAME}:latest" \
+            "${IMAGE_NAME}:${IMAGE_VERSION}"
+
+          expected="$(docker buildx imagetools inspect "${IMAGE_NAME}:${IMAGE_VERSION}" --raw | sha256sum | awk '{ print $1 }')"
+          for target in "${ROLLING_VERSION}" latest; do
+            actual="$(docker buildx imagetools inspect "${IMAGE_NAME}:${target}" --raw | sha256sum | awk '{ print $1 }')"
+            if [ "${actual}" != "${expected}" ]; then
+              echo "Promoted tag ${target} does not match ${IMAGE_VERSION}." >&2
+              exit 1
+            fi
+          done
+
+      - name: Write publication summary
+        shell: bash
+        run: |
+          {
+            echo "## Astra release published"
+            echo
+            echo "- Release: \`${{ needs.preflight.outputs.source_tag }}\`"
+            echo "- Source: \`${{ needs.preflight.outputs.source_sha }}\`"
+            echo "- Clients: Linux/macOS, AMD64/ARM64"
+            echo "- Server: \`matrixorigin/astra:${{ needs.preflight.outputs.version }}\`"
+            if [ "${{ needs.preflight.outputs.publish_latest }}" = "true" ]; then
+              echo "- Promoted: \`${{ needs.preflight.outputs.rolling_version }}\`, \`latest\`"
+            else
+              echo "- Prerelease: rolling Docker tags were not changed"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  registry-mirror:
+    name: Publish Optional Registry Mirror
+    if: >-
+      vars.CONTAINER_MIRROR_REGISTRY != '' &&
+      vars.CONTAINER_MIRROR_IMAGE != ''
+    needs:
+      - preflight
+      - publish
+    runs-on: ${{ vars.CONTAINER_MIRROR_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 45
+    continue-on-error: true
+    env:
+      http_proxy: ${{ vars.CONTAINER_MIRROR_HTTP_PROXY || '' }}
+      https_proxy: ${{ vars.CONTAINER_MIRROR_HTTPS_PROXY || '' }}
+      no_proxy: ${{ vars.CONTAINER_MIRROR_NO_PROXY || '' }}
+
+    steps:
+      - name: Install pinned crane
+        shell: bash
+        env:
+          CRANE_VERSION: v0.20.6
+          CRANE_LINUX_X86_64_SHA256: c1d593d01551f2c9a3df5ca0a0be4385a839bd9b86d4a76e18d7b17d16559127
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          curl -fsSL \
+            -o "${RUNNER_TEMP}/go-containerregistry.tar.gz" \
+            "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz"
+          echo "${CRANE_LINUX_X86_64_SHA256}  ${RUNNER_TEMP}/go-containerregistry.tar.gz" \
+            | sha256sum --check --strict
+          tar -xzf "${RUNNER_TEMP}/go-containerregistry.tar.gz" -C "${RUNNER_TEMP}/bin" crane
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+          "${RUNNER_TEMP}/bin/crane" version
+
+      - name: Copy the verified public manifest
+        shell: bash
+        env:
+          IMAGE_VERSION: ${{ needs.preflight.outputs.version }}
+          ROLLING_VERSION: ${{ needs.preflight.outputs.rolling_version }}
+          PUBLISH_LATEST: ${{ needs.preflight.outputs.publish_latest }}
+          SOURCE_IMAGE: matrixorigin/astra
+          MIRROR_REGISTRY: ${{ vars.CONTAINER_MIRROR_REGISTRY }}
+          TARGET_IMAGE: ${{ vars.CONTAINER_MIRROR_IMAGE }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          MIRROR_USERNAME: ${{ secrets.IDC_REGISTRY_USERNAME }}
+          MIRROR_PASSWORD: ${{ secrets.IDC_REGISTRY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${DOCKERHUB_TOKEN}" | crane auth login index.docker.io -u "${DOCKERHUB_USERNAME}" --password-stdin
+          printf '%s' "${MIRROR_PASSWORD}" | crane auth login "${MIRROR_REGISTRY}" -u "${MIRROR_USERNAME}" --password-stdin
+
+          source_ref="docker.io/${SOURCE_IMAGE}:${IMAGE_VERSION}"
+          source_digest="$(crane digest "${source_ref}")"
+          tags=("${IMAGE_VERSION}")
+          if [ "${PUBLISH_LATEST}" = "true" ]; then
+            tags+=("${ROLLING_VERSION}" latest)
+          fi
+          for tag in "${tags[@]}"; do
+            crane copy --platform=all --jobs 2 \
+              "${source_ref}" \
+              "${TARGET_IMAGE}:${tag}"
+            target_digest="$(crane digest "${TARGET_IMAGE}:${tag}")"
+            if [ "${target_digest}" != "${source_digest}" ]; then
+              echo "Mirror tag ${TARGET_IMAGE}:${tag} does not match ${source_ref}." >&2
+              exit 1
+            fi
+          done

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -50,6 +50,12 @@ jobs:
           persist-credentials: false
       - name: Validate repository metadata and documentation
         run: python3 scripts/ci/validate_repository.py
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: 1.25.5
+          cache: false
+      - name: Validate GitHub Actions workflows
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
       - name: Test CI contracts
         run: python3 -m unittest discover -s scripts/ci -p 'test_*.py'
       - name: Validate Terminal-Bench harness contracts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,7 @@ jobs:
           -E 'test(/local_cli_catalog_exposes_the_root_work_lifecycle/)'
       - name: Dump processes on failure
         if: failure() && env.RUN_TESTS == 'true'
-        run: ps -ef | grep -E 'cargo|nextest|astra|bash|sleep' || true
+        run: pgrep -af 'cargo|nextest|astra|bash|sleep' || true
 
   shard-b:
     name: "Test: astra-runtime"

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
 # Runtime image intentionally ships the API server plus the single public CLI.
 # Test-only mock_mcp_server and the standalone astra-edge daemon are excluded.
-RUN cargo chef cook --release --no-default-features --recipe-path recipe.json \
+RUN cargo chef cook --release --locked --no-default-features --recipe-path recipe.json \
         -p astra-runtime --bin astra-server \
         -p astra-cli --bin astra
 
@@ -67,7 +67,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 RUN ASTRA_BUILD_SOURCE_GIT_SHA="${IMAGE_REVISION}" \
     ASTRA_BUILD_SOURCE_GIT_DIRTY="${IMAGE_SOURCE_DIRTY}" \
-    cargo build --release --no-default-features \
+    cargo build --release --locked --no-default-features \
         -p astra-runtime --bin astra-server \
         -p astra-cli --bin astra && \
     mkdir -p /out && \

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,10 @@ help:
 	@echo "  make dev-start-docker   - Start deps + API in Docker"
 	@echo "  make dev-api-docker-up  - Start API server in Docker"
 	@echo "  make dev-api-docker-down - Stop API server Docker container"
-	@echo "  make release-check      - Validate release metadata (VERSION=...)"
+	@echo ""
+	@echo "Release maintenance:"
+	@echo "  make release-prepare    - Synchronize release versions (VERSION=...)"
+	@echo "  make release-check      - Run the read-only release preflight (VERSION=...)"
 
 # ============================================================================
 # Variables
@@ -514,6 +517,14 @@ dev-api-docker-scale:
 	@cd deployment/all-in-one && docker compose --env-file ../../.env up -d --no-deps --scale api=$(REPLICAS) api
 	@echo "✅ Scaled to $(REPLICAS) replicas"
 
+.PHONY: release-prepare
+release-prepare:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "❌ VERSION is required, for example: make release-prepare VERSION=0.2.0"; \
+		exit 1; \
+	fi
+	@scripts/prepare-release-version.py "$(VERSION)"
+
 .PHONY: release-check
 release-check:
 	@if [ -z "$(VERSION)" ]; then \
@@ -521,20 +532,9 @@ release-check:
 		exit 1; \
 	fi
 	@scripts/validate-release-version.sh "$(VERSION)"
-	@if [ "$(IMAGE_SOURCE_DIRTY)" != "false" ]; then \
-		echo "❌ Release source has uncommitted tracked changes"; \
-		exit 1; \
-	fi
-	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-list -n 1 "v$(IMAGE_VERSION)" 2>/dev/null)" ]; then \
-		echo "❌ HEAD must be the commit tagged v$(IMAGE_VERSION)"; \
-		exit 1; \
-	fi
-	@if [ "$$(git cat-file -t "v$(IMAGE_VERSION)" 2>/dev/null)" != "tag" ]; then \
-		echo "❌ v$(IMAGE_VERSION) must be an annotated tag"; \
-		exit 1; \
-	fi
-	@echo "✅ Release metadata and tagged source are consistent"
-	@echo "   Push v$(IMAGE_VERSION) to run the verified binary and multi-platform image workflows."
+	@python3 scripts/ci/validate_repository.py
+	@echo "✅ Release metadata, installer, artifacts, and workflow contracts are consistent"
+	@echo "   Commit and merge the reviewed version changes, then run Release Astra from main."
 
 # ============================================================================
 # Compose Stack Deployment

--- a/README.md
+++ b/README.md
@@ -208,17 +208,20 @@ One checksum-verified archive installs both the `astra` CLI and the
 `astra-edge` User Runner — Linux and macOS, `amd64` and `arm64`:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/matrixorigin/Astra/main/scripts/install-astra.sh | sh
+curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/matrixorigin/Astra/main/scripts/install-astra.sh | sh -s -- --dir "$HOME/.local/bin"
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 #### 2. Run the guided setup
 
-Clone Astra and follow one guided flow from embedding configuration through the
-first administrator and model:
+Use the same version for the client and Server deployment, then follow one
+guided flow from embedding configuration through the first administrator and
+model. The installer prints these version-matched next steps as well:
 
 ```bash
-git clone https://github.com/matrixorigin/Astra.git
-cd Astra
+ASTRA_VERSION="$(astra --version | awk '{print $2}')"
+git clone --branch "v${ASTRA_VERSION}" --depth 1 https://github.com/matrixorigin/Astra.git "Astra-${ASTRA_VERSION}"
+cd "Astra-${ASTRA_VERSION}"
 make stack-setup
 ```
 
@@ -230,9 +233,8 @@ leave-for-inspection choices before the administrator/model wizard begins.
 API keys are hidden while typing and the local `.env` is owner-only. Choose mock
 embeddings for deterministic evaluation; use a real OpenAI-compatible endpoint
 for production retrieval. The wizard never deletes persistent volumes.
-It runs in Linux/macOS terminals and Windows WSL or Git Bash; on a restricted
-Windows shell, use the scripted stack targets and run `astra admin setup`
-directly.
+The released clients and full guided path support Linux, macOS, and Windows
+through WSL. Native Windows and Git Bash are not release targets yet.
 
 For a non-interactive local evaluation, use deterministic mock embeddings:
 
@@ -253,8 +255,8 @@ and `make stack-verify` explicitly.
 
 #### 3. Confirm the CLI and service
 
-The stack ships `astra-server`; the prebuilt `astra` binary installed in step 1
-drives it:
+The versioned stack ships the matching `astra-server`; the prebuilt `astra`
+binary installed in step 1 drives it:
 
 ```bash
 astra health
@@ -263,8 +265,10 @@ astra health
 The CLI defaults to `http://127.0.0.1:17001`, which is where the stack binds,
 so no extra configuration is needed. If you remapped `ASTRA_API_PORT`, set
 `ASTRA_API_URL` or pass `--api-url` to each command. Pass `-v <version>` to the
-installer, and set `ASTRA_IMAGE` before `make stack-up`, when you need a pinned
-CLI and server pair.
+installer to select an older or prerelease client; always use its matching Git
+tag for the deployment checkout. MatrixOne and Memoria are pinned to the
+compatibility set exercised by that Astra release instead of floating on
+`latest`.
 
 For scripted or advanced environments, replace the guided account/model phase
 with the following two operations.

--- a/crates/astra-cli/src/cli/slash/slash_info.rs
+++ b/crates/astra-cli/src/cli/slash/slash_info.rs
@@ -2007,7 +2007,10 @@ pub(crate) async fn handle_info_command(
         }
 
         "/version" => {
-            eprintln!("{}", "  astra version 0.1.0 (Rust)".bold());
+            eprintln!(
+                "{}",
+                format!("  astra version {} (Rust)", env!("CARGO_PKG_VERSION")).bold()
+            );
         }
 
         "/info" | "/whoami" => {

--- a/crates/runtime/src/app_state.rs
+++ b/crates/runtime/src/app_state.rs
@@ -8,7 +8,7 @@ use crate::turn::services::{
 use astra_services::auth;
 
 const DEFAULT_NAME: &str = "Agent Engine API";
-const DEFAULT_VERSION: &str = "0.1.0";
+const DEFAULT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_DOCS: &str = "";
 
 #[async_trait]

--- a/crates/runtime/src/server/runtime_tool_executor.rs
+++ b/crates/runtime/src/server/runtime_tool_executor.rs
@@ -752,7 +752,7 @@ impl RuntimeToolExecutor {
             &workspace_root,
             user_id.clone(),
             session_id.clone(),
-            "astra-server/0.1.0",
+            concat!("astra-server/", env!("CARGO_PKG_VERSION")),
             Duration::from_secs(15),
         );
         let capabilities = crate::capabilities::full_server_capabilities_for_tests();

--- a/crates/runtime/tests/http_contract.rs
+++ b/crates/runtime/tests/http_contract.rs
@@ -142,6 +142,28 @@ fn assert_health_contract_json(
     assert_contract_json(actual, &resolved_expected, label);
 }
 
+fn assert_root_contract_json(actual: &serde_json::Value, expected: &serde_json::Value) {
+    let expected_version = expected
+        .as_object()
+        .and_then(|object| object.get("version"))
+        .and_then(serde_json::Value::as_str);
+    assert_eq!(
+        expected_version,
+        Some("<dynamic-package-version>"),
+        "root contract must use the dynamic package version sentinel"
+    );
+
+    let mut resolved_expected = expected.clone();
+    resolved_expected
+        .as_object_mut()
+        .expect("root contract should be a JSON object")
+        .insert(
+            "version".to_string(),
+            serde_json::Value::String(env!("CARGO_PKG_VERSION").to_string()),
+        );
+    assert_contract_json(actual, &resolved_expected, "root");
+}
+
 fn build_request(
     method: &str,
     path: &str,
@@ -165,7 +187,7 @@ async fn root_matches_shared_contract() {
     let (status, json) = read_json(build_test_app(true), "/").await;
 
     assert_eq!(status.as_u16(), contract.root.status);
-    assert_contract_json(&json, &contract.root.json, "root");
+    assert_root_contract_json(&json, &contract.root.json);
 }
 
 #[tokio::test]

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -39,7 +39,11 @@ start and verify the complete published stack in one command from the
 repository root:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/matrixorigin/Astra/main/scripts/install-astra.sh | sh
+curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/matrixorigin/Astra/main/scripts/install-astra.sh | sh -s -- --dir "$HOME/.local/bin"
+export PATH="$HOME/.local/bin:$PATH"
+ASTRA_VERSION="$(astra --version | awk '{print $2}')"
+git clone --branch "v${ASTRA_VERSION}" --depth 1 https://github.com/matrixorigin/Astra.git "Astra-${ASTRA_VERSION}"
+cd "Astra-${ASTRA_VERSION}"
 MEMORIA_EMBEDDING_PROVIDER=mock make stack-start
 ```
 
@@ -47,6 +51,8 @@ MEMORIA_EMBEDDING_PROVIDER=mock make stack-start
 `astra-server`, waits for readiness, and verifies a memory round trip. It does
 not connect a local filesystem/process provider. Use a real embedding endpoint
 instead of mock mode for semantic-memory evaluation or production.
+The checked-out release pins all three service images to one tested
+compatibility set.
 
 On later starts, `make stack-up` reuses the generated secrets. Repeat any
 process-level embedding settings, or persist them in the stack `.env` file

--- a/deployment/all-in-one/.env.example
+++ b/deployment/all-in-one/.env.example
@@ -12,9 +12,12 @@
 #   openssl rand -hex 32
 
 # --- Docker images -----------------------------------------------------------
-ASTRA_IMAGE=matrixorigin/astra:latest
-MEMORIA_IMAGE=matrixorigin/memoria:latest
-MATRIXONE_IMAGE=matrixorigin/matrixone:latest
+# These three images are one tested compatibility set. Release PRs update the
+# Astra version and deliberately advance dependency digests only after the
+# all-in-one candidate smoke passes on AMD64 and ARM64.
+ASTRA_IMAGE=matrixorigin/astra:0.1.0
+MEMORIA_IMAGE=matrixorigin/memoria@sha256:9075cb57c0304197d906d1fdb6c71cbeb1e000153ab5fe3b766ddcd0134e8478
+MATRIXONE_IMAGE=matrixorigin/matrixone@sha256:c95d1b468e3fc5f4f2b377da14f4601e7efefa6eb143758636d60114a5bbb436
 
 # --- Host ports --------------------------------------------------------------
 # Published development ports bind to loopback by default.

--- a/deployment/all-in-one/README.md
+++ b/deployment/all-in-one/README.md
@@ -11,8 +11,17 @@ The development flow is separate and still uses `docker-compose.deps.yml` throug
 Install the released client binaries if they are not already available:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/matrixorigin/Astra/main/scripts/install-astra.sh | sh
+curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/matrixorigin/Astra/main/scripts/install-astra.sh | sh -s -- --dir "$HOME/.local/bin"
+export PATH="$HOME/.local/bin:$PATH"
 ```
+
+Use this directory from the matching `vX.Y.Z` source checkout. The installer
+prints the exact clone command after resolving the latest stable release. The
+checked-in `.env.example` pins Astra, MatrixOne, and Memoria to the release's
+tested compatibility set; advancing only one image makes the deployment an
+intentional compatibility test rather than the supported default.
+The canonical Compose file requires those image variables and fails before a
+pull if `.env` is missing, rather than silently substituting mutable images.
 
 From the repository root, the recommended first-run path is guided:
 
@@ -25,9 +34,9 @@ before starting Compose. It inventories an existing stack, reuses healthy
 services, repairs disconnected containers without deleting volumes, verifies a
 memory round trip, and then launches `astra admin setup`. Startup failures offer
 repair/retry, stop-and-preserve, and leave-for-inspection choices. API keys are
-hidden and the local `.env` is owner-only. The wizard works in Linux/macOS
-terminals and Windows WSL or Git Bash; restricted Windows shells can use the
-explicit targets and `astra admin setup`.
+hidden and the local `.env` is owner-only. The released clients and full
+guided path support Linux, macOS, and Windows through WSL. Native Windows and
+Git Bash are not release targets yet.
 Loopback embedding probes bypass HTTP proxies; other endpoints honor the host
 proxy configuration and suggest `NO_PROXY` when a private URL is intercepted.
 
@@ -221,18 +230,22 @@ development credentials on an untrusted network.
 
 ## Images
 
-By default the stack pulls:
+The release's `.env.example` selects one tested compatibility set:
 
-- `matrixorigin/astra:latest`
-- `matrixorigin/memoria:latest`
-- `matrixorigin/matrixone:latest`
+- an exact semantic Astra version;
+- immutable multi-platform Memoria and MatrixOne manifest digests.
 
-Override image tags in `.env`, for example:
+`make stack-env` copies those selections into the local `.env`. Upgrading the
+source checkout does not silently rewrite an existing deployment. To perform a
+deliberate compatibility test, change one or more image references in `.env`,
+for example:
 
 ```dotenv
-ASTRA_IMAGE=matrixorigin/astra:0.1.0
-MEMORIA_IMAGE=matrixorigin/memoria:latest
+ASTRA_IMAGE=matrixorigin/astra:0.2.0-rc.1
 ```
+
+Avoid floating `latest` tags in reproducibility reports and production-like
+evaluations; always record the exact image references used.
 
 ## Operations
 

--- a/deployment/all-in-one/docker-compose.yml
+++ b/deployment/all-in-one/docker-compose.yml
@@ -9,7 +9,7 @@ x-env-files: &astra-env-files
 
 services:
   matrixone-init:
-    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:latest}
+    image: ${MATRIXONE_IMAGE:?Set MATRIXONE_IMAGE in deployment/all-in-one/.env}
     user: root
     environment:
       HOST_UID: ${UID:-1000}
@@ -42,7 +42,7 @@ services:
     restart: "no"
 
   matrixone:
-    image: ${MATRIXONE_IMAGE:-matrixorigin/matrixone:latest}
+    image: ${MATRIXONE_IMAGE:?Set MATRIXONE_IMAGE in deployment/all-in-one/.env}
     hostname: matrixone
     user: "${UID:-1000}:${GID:-1000}"
     depends_on:
@@ -75,7 +75,7 @@ services:
         max-file: "3"
 
   memoria-init:
-    image: ${MEMORIA_IMAGE:-matrixorigin/memoria:latest}
+    image: ${MEMORIA_IMAGE:?Set MEMORIA_IMAGE in deployment/all-in-one/.env}
     user: root
     environment:
       HOST_UID: ${UID:-1000}
@@ -113,7 +113,7 @@ services:
     restart: "no"
 
   memoria:
-    image: ${MEMORIA_IMAGE:-matrixorigin/memoria:latest}
+    image: ${MEMORIA_IMAGE:?Set MEMORIA_IMAGE in deployment/all-in-one/.env}
     hostname: memoria
     user: "${UID:-1000}:${GID:-1000}"
     ports:
@@ -166,7 +166,7 @@ services:
         max-file: "3"
 
   api:
-    image: ${ASTRA_IMAGE:-matrixorigin/astra:latest}
+    image: ${ASTRA_IMAGE:?Set ASTRA_IMAGE in deployment/all-in-one/.env}
     hostname: api
     command: ["astra-server"]
     env_file: *astra-env-files

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -175,9 +175,10 @@ prereleases when resolving `latest`, and rolling Docker tags remain unchanged:
 
 The separate **Publish Astra Docker Snapshot** workflow is for immutable,
 non-semantic snapshots from the current `main` head. It rejects feature-branch
-source, semantic versions, rolling tags, and attempts to overwrite a different
-snapshot. Re-running the same source and name succeeds only when the published
-platform digests match exactly.
+source, semantic versions, rolling tags, names outside the `snapshot-*`
+namespace, misleading architecture suffixes, and attempts to overwrite a
+different snapshot. Re-running the same source and name succeeds only when the
+published platform digests match exactly.
 
 ## Verify the release
 

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -1,135 +1,215 @@
 # Releasing Astra
 
-This guide describes the maintainer workflow for publishing Astra from the
-`matrixorigin/Astra` repository. Releases use semantic versions and immutable
-Git tags; the GitHub Release, installer, source, and release automation all
-live here. Docker images are published as `matrixorigin/astra` on Docker Hub.
+This guide defines the maintainer workflow for publishing Astra from the
+`matrixorigin/Astra` repository. One protected workflow owns the source tag,
+GitHub Release, client archives, public server image, rolling Docker tags, and
+optional registry mirror. A release is selected once, verified as one candidate
+set, and only then made visible to users.
 
-## Release contract
-
-A tag named `vX.Y.Z` triggers both release workflows:
-
-- `release-binaries.yml` publishes archives containing the `astra` CLI and
-  `astra-edge` User Runner for Linux and macOS on AMD64 and ARM64, plus
-  SHA-256 checksum files, to a GitHub Release.
-- `release-docker.yml` publishes the multi-architecture
-  `matrixorigin/astra:X.Y.Z` image to Docker Hub.
+## What one release contains
 
 | Runtime role | Published form | User entrypoint |
 | --- | --- | --- |
-| CLI | GitHub Release archive | `astra` |
-| Edge / User Runner | The same GitHub Release archive | `astra-edge` |
-| Server | Verified multi-platform Docker image | `matrixorigin/astra:X.Y.Z` |
+| CLI | Checksum-verified GitHub Release archive | `astra` |
+| Edge / User Runner | The same client archive | `astra-edge` |
+| Server | Verified multi-platform image | `matrixorigin/astra:X.Y.Z` |
+| Local dependencies | Versioned compatibility pins | all-in-one `.env.example` |
 | Web dashboard | Source checkout for now | development workflow |
 
-The Docker workflow first starts each untagged platform image by its immutable
-digest through the documented all-in-one deployment, then verifies API health
-plus an exact memory write/retrieval. Only after every platform passes does the
-workflow publish the `X.Y.Z` manifest. A stable release then updates `X.Y` and
-`latest`; a prerelease such as `v0.2.0-rc.1` is marked as a GitHub prerelease
-and does not update those rolling tags. A failed candidate therefore changes no
-user-facing Docker tag.
+The client set covers Linux and macOS on AMD64 and ARM64. Each build executes
+both binaries before packaging them. The server set covers Linux AMD64 and
+ARM64; each untagged digest is started through the documented all-in-one stack
+and must pass API readiness, dependency health, and an exact memory
+write/retrieval/cleanup round trip.
 
-Both workflows require an annotated tag, bind every build to its peeled commit
-SHA, reject a commit that is not reachable from the default branch, and verify
-that the remote tag was neither moved nor deleted before publication. They run
-independently so a failed platform does not conceal a successful one, but a
-release is complete only when both are green. The binary workflow needs only
-the repository-provided `GITHUB_TOKEN`; there is no cross-repository release
-token or secondary release mirror.
+Stable releases update the Docker `X.Y` and `latest` tags only after the
+versioned Docker manifest and GitHub Release are both available. A prerelease
+such as `0.2.0-rc.1` publishes only its exact version and is marked as a GitHub
+prerelease.
 
-## Repository configuration
+## Why publication starts from a workflow, not a tag push
 
-The Docker workflow requires these repository secrets:
+Tag-triggered workflows execute release logic stored with the tagged commit.
+Allowing any historical commit reachable from `main` to initiate publication
+therefore lets obsolete automation become the release control plane.
 
-- `DOCKERHUB_USERNAME`
-- `DOCKERHUB_TOKEN`
+The **Release Astra** workflow is manually dispatched from the protected
+default branch instead. It selects the current `main` commit, validates the
+complete version and release contract, builds every candidate, and creates the
+annotated tag only after all candidates pass. GitHub does not start a second
+workflow for a tag created with `GITHUB_TOKEN`, so one run remains the sole
+release owner.
 
-Protect `refs/tags/v*` with an active GitHub tag ruleset. Restrict create,
-update, and delete operations to release maintainers and disallow force
-updates. Workflow checks detect mutation after a run starts; the repository
-ruleset controls who may start a release in the first place.
+Publication is deliberately ordered:
 
-The optional private registry mirror runs only when both
+1. validate the exact source and version;
+2. build and execute all client candidates;
+3. build untagged server digests and smoke every platform;
+4. create or validate the immutable annotated tag;
+5. create or verify the exact Docker version manifest;
+6. stage and publish the GitHub Release with verified client assets;
+7. update stable rolling Docker tags;
+8. copy the already-public manifest to an optional private mirror.
+
+The GitHub Release is not published until the exact Docker version exists. If
+a late step fails, rerun the failed jobs from the same Actions run so its
+verified artifacts are reused. The annotated tag records its owning Actions
+run, so that run can continue idempotently without allowing a different run to
+claim it. The workflow also has an explicit recovery mode for an existing tag;
+it refuses to move the tag or overwrite a different versioned Docker manifest.
+
+## Required repository configuration
+
+Create a GitHub Environment named `release`:
+
+- require approval from release maintainers;
+- allow deployments only from `main`;
+- add the Environment secret `ASTRA_RELEASE_ENVIRONMENT_GUARD=configured`;
+- use this as the single publication gate after every candidate is green.
+
+Create a second Environment named `release-snapshot` for reviewed snapshot
+publishing. It should have its own approval policy and the Environment secret
+`ASTRA_SNAPSHOT_ENVIRONMENT_GUARD=configured`. These guard values are deliberate
+fail-closed markers, not credentials: if GitHub creates a referenced but
+unconfigured Environment automatically, publication stops before changing a
+tag or manifest.
+
+Provide `DOCKERHUB_USERNAME` and a least-privilege `DOCKERHUB_TOKEN`, capable
+of writing only `matrixorigin/astra`, as repository or organization Actions
+secrets. Candidate jobs use them to push untagged digests for runtime smoke;
+only the environment-gated publication job gives those digests a user-visible
+tag. Keep `IDC_REGISTRY_USERNAME` and `IDC_REGISTRY_PASSWORD` as repository or
+organization secrets when the optional mirror is enabled.
+
+After migration, remove the unused `ASTRA_SUITE_PAT` secret and
+`RELEASE_MIRROR_REPOSITORY` variable once a repository search confirms that no
+workflow still references them.
+
+Protect `refs/tags/v*` with an active tag ruleset:
+
+- restrict updates and deletions, and disallow force updates;
+- if creation is restricted too, grant bypass only to the automation identity
+  used by **Release Astra** and verify that a release rehearsal can create its
+  annotated tag;
+- do not grant a broad bypass to ordinary repository writers.
+
+A manually created tag cannot publish anything and cannot be adopted by
+recovery, but it will reserve that version until an administrator removes it.
+
+Repository Actions should default to read-only permissions. The release
+controller grants `contents: write` only to the publication job that creates
+the tag and GitHub Release.
+
+The optional registry mirror is enabled only when both
 `CONTAINER_MIRROR_REGISTRY` and `CONTAINER_MIRROR_IMAGE` repository variables
-are set. It additionally uses `IDC_REGISTRY_USERNAME` and
-`IDC_REGISTRY_PASSWORD`; proxy and runner variables are documented inline in
-`release-docker.yml`. These settings copy an already verified Docker manifest
-and do not own the public GitHub Release.
+are set. Proxy and runner variables are documented in `release.yml`. Mirror
+failure is reported without invalidating a public release that has already
+completed.
 
-The source tree also versions the public `@astra/sdk` package and the Helm
-chart, but the tag workflows do not publish either to npm or a chart registry.
-Until dedicated publication gates exist, treat those as explicit maintainer
-actions and do not advertise them as tag-produced artifacts.
+The source tree versions `@astra/sdk` and the Helm chart, but the workflow does
+not yet publish either to npm or a chart registry. Treat them as explicit
+maintainer actions until dedicated verification and provenance gates exist.
 
-## Prepare the release
+Legacy releases in `matrixorigin/astra-suite` and the existing `v0.0.x` tags
+are historical inputs, not publication fallbacks. The current installer reads
+only GitHub Releases owned by `matrixorigin/Astra`, and recovery accepts only
+annotated tags created by this unified workflow. For the first repository-owned
+release, choose a new version whose tag and Docker version do not exist; until
+that release is complete, latest-release installation will fail explicitly
+instead of silently installing a legacy package.
 
-1. Open a release pull request from a feature branch.
-2. Update the release version in `Cargo.toml`, `packages/sdk/package.json`, its
-   package lock, `web/package.json`, its package lock, `CITATION.cff`, and both
-   `version` and `appVersion` in `deployment/kubernetes/chart/Chart.yaml`.
-   Update `Cargo.lock` when the workspace version changes.
-3. Confirm that the version matches the intended tag without the leading `v`.
-   Both tag-triggered release workflows reject a mismatched workspace version
-   before building or publishing artifacts.
-4. Summarize user-visible changes, compatibility impact, and migration steps in
-   the pull request.
-5. Apply the most specific `kind/*`, `documentation`, or `improvement` label to
-   each included pull request so the generated release notes are categorized.
-6. Run `scripts/validate-release-version.sh X.Y.Z`, `make check`,
-   `make test-offline`, and any integration lane required by
-   the affected boundaries.
-7. Merge only after required CI and review pass on the exact release commit.
+## Prepare a release
+
+1. Open a release pull request from a non-default feature branch.
+2. Synchronize the workspace, client, Web, lockfile, citation, Helm, all-in-one,
+   and production-template Astra versions in one reviewable change:
+
+   ```bash
+   make release-prepare VERSION=0.2.0
+   ```
+
+   The command refuses to overwrite uncommitted edits to version files,
+   requires the old metadata to be internally consistent, writes the new files
+   atomically, and validates the resulting version set. It does not commit,
+   tag, build, or publish anything.
+3. Deliberately review the pinned MatrixOne and Memoria manifest digests. Change
+   them only when that compatibility set has been tested.
+4. Summarize user-visible changes, migrations, compatibility impact, and known
+   limitations in the release pull request.
+5. Apply accurate `kind/*`, `documentation`, or `improvement` labels so
+   generated release notes remain useful.
+6. Run the read-only local preflight:
+
+   ```bash
+   make release-check VERSION=0.2.0
+   ```
+
+7. Run `make check`, `make test-offline`, and the integration lanes required by
+   the changed boundaries.
+8. Merge only after required CI and review pass on the exact version commit.
+
+`make release-check` validates synchronized versions, installer and archive
+unhappy paths, repository release contracts, workflow ownership, and
+documentation links. It accepts a working-tree diff so it can run before the
+release commit; it does not modify files, create tags, or publish data.
 
 ## Publish
 
-Create an annotated tag on the reviewed commit. Run the read-only preflight
-after creating it, then push only that tag:
+1. Open **Actions → Release Astra → Run workflow**.
+2. Select `main` in the branch selector.
+3. Enter the version without a leading `v`, for example `0.2.0`.
+4. Leave **recover existing tag** disabled for a new release.
+5. Wait for the client and server candidate matrices to pass.
+6. Review the preflight summary and approve the single `release` Environment
+   gate for the publication job.
 
-```bash
-git switch main
-git pull --ff-only
-git tag -a v0.2.0 -m "Astra v0.2.0"
-make release-check VERSION=0.2.0
-git push origin v0.2.0
+Do not create the tag manually. The workflow creates `vX.Y.Z` as an annotated
+tag on the source SHA after all candidate verification succeeds.
+
+For a public rehearsal, publish an `rc` version first. The installer ignores
+prereleases when resolving `latest`, and rolling Docker tags remain unchanged:
+
+```text
+0.2.0-rc.1
 ```
 
-`make release-check` is deliberately read-only: it verifies version metadata,
-the clean tracked worktree, the annotated tag, and its commit relationship. It
-never builds or pushes an image. Do not move or reuse a published version tag.
-The client workflow's manual input is for recovering a failed publication from
-an existing tag, not for selecting unreviewed source. Manual Docker runs publish
-snapshot tags only; semantic-version Docker releases must start from the
-matching Git tag so the source, binaries, and container image identify the same
-commit.
+The separate **Publish Astra Docker Snapshot** workflow is for immutable,
+non-semantic snapshots from the current `main` head. It rejects feature-branch
+source, semantic versions, rolling tags, and attempts to overwrite a different
+snapshot. Re-running the same source and name succeeds only when the published
+platform digests match exactly.
 
 ## Verify the release
 
-Wait for both release workflows to pass, then verify:
+Verify all of the following before announcing it:
 
-- The GitHub Release points to the intended commit and has all four client
-  archives, their individual checksums, `checksums.txt`, and its checksum.
-- Each client archive contains the `astra` and `astra-edge` executables and the
-  Apache-2.0 `LICENSE` file at its root.
-- Generated release notes group the included pull requests accurately.
-- A downloaded archive matches its published SHA-256 value.
-- The documented installer downloads from `matrixorigin/Astra`, rejects a
-  missing checksum, and reports the expected version from `astra --version`.
-- The Docker version tag resolves to both `linux/amd64` and `linux/arm64`.
-- The Docker runtime smoke passed on every built platform, including the
-  all-in-one health and memory round-trip checks.
-- Both binaries report the expected version, and the CLI completes a basic
-  health check.
-- For a stable release, the `X.Y` and `latest` tags resolve to the new manifest;
-  for a prerelease, they remain unchanged.
+- the GitHub Release points to the workflow-selected SHA;
+- all four client archives, their sidecars, `checksums.txt`, and its checksum
+  are present;
+- a clean Linux and macOS machine can run the documented installer;
+- `astra --version`, `astra-edge --version`, and `astra --help` work;
+- the exact Docker version resolves to Linux AMD64 and ARM64;
+- the all-in-one source checkout at `vX.Y.Z` uses the same Astra version plus
+  the tested MatrixOne and Memoria digests;
+- `make stack-setup` reaches the first successful CLI turn;
+- stable `X.Y` and `latest` tags resolve to the version manifest, while a
+  prerelease leaves them unchanged.
 
-Finally, run the documented install command on one clean Linux or macOS host.
-The installer must resolve this repository's latest stable Release, verify the
-platform checksum, install both client binaries, and complete a real CLI turn.
+## Recover or correct a release
 
-## Correct a bad release
+Prefer **Re-run failed jobs** on the original Actions run. This reuses the
+candidate artifacts that already passed verification.
 
-Do not rewrite the Git tag or replace release assets in place. Fix the problem
-through the normal pull request workflow and publish a new patch version. If an
-artifact is unsafe to use, mark its GitHub Release as a prerelease and state the
-replacement version prominently while the fix is prepared.
+Use **recover existing tag** only when a previous **Release Astra** run created
+the annotated tag but its original run can no longer be resumed. Recovery
+rejects manual and legacy tags, verifies the recorded owner is a real
+**Release Astra** run from the default branch at the same source SHA, then
+validates the unchanged tag, checksums, and any existing versioned Docker
+manifest. It never moves a tag or silently replaces different immutable
+output. If the recorded Actions run is no longer available, publish a patch
+version instead of weakening ownership checks.
+
+Do not rewrite a tag or replace a completed release in place. Fix product or
+packaging defects through a normal pull request and publish a patch version. If
+an existing artifact is unsafe, mark the release as a prerelease and identify
+the replacement version prominently while preparing the patch.

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -8,11 +8,13 @@ The guided setup requires Docker Compose v2, OpenSSL, and Python 3.9 or newer.
 
 ```bash
 # 1. Install the checksum-verified CLI and Edge/User Runner
-curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/matrixorigin/Astra/main/scripts/install-astra.sh | sh
+curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/matrixorigin/Astra/main/scripts/install-astra.sh | sh -s -- --dir "$HOME/.local/bin"
+export PATH="$HOME/.local/bin:$PATH"
 
-# 2. Clone the deployment files
-git clone https://github.com/matrixorigin/Astra.git
-cd Astra
+# 2. Clone the deployment files from the exact installed release
+ASTRA_VERSION="$(astra --version | awk '{print $2}')"
+git clone --branch "v${ASTRA_VERSION}" --depth 1 https://github.com/matrixorigin/Astra.git "Astra-${ASTRA_VERSION}"
+cd "Astra-${ASTRA_VERSION}"
 
 # 3. Start the stack and follow the guided prompts
 make stack-setup
@@ -39,10 +41,13 @@ For semantic memory, set `MEMORIA_EMBEDDING_BASE_URL` and, when the endpoint
 requires it, `MEMORIA_EMBEDDING_API_KEY`, then run `make stack-start`.
 `stack-start` initializes configuration, starts Compose, waits for health, and
 verifies an exact memory round trip.
-The Make wizard works in Linux/macOS terminals and Windows WSL or Git Bash;
-restricted Windows shells can use the explicit targets and `astra admin setup`.
+The released clients and full guided path support Linux, macOS, and Windows
+through WSL. Native Windows and Git Bash are not release targets yet.
 Loopback embedding endpoints are tested directly; other endpoints honor the
 host proxy settings and report when `NO_PROXY` may be needed for a private URL.
+The release checkout pins Astra, MatrixOne, and Memoria to the compatibility
+set verified by the release workflow; do not replace those pins with `latest`
+when diagnosing a reproducibility or upgrade problem.
 
 The installer also provides `astra-edge`. To give Web sessions access to one
 explicit local workspace, run:

--- a/docs/reference/makefile-commands.md
+++ b/docs/reference/makefile-commands.md
@@ -59,6 +59,18 @@
 | `make stack-down` | Stop the stack while preserving its data |
 | `make stack-clean` | Immediately delete the stack and its persisted data (destructive; no confirmation prompt) |
 
+## Release maintenance
+
+| Command | Description |
+| --- | --- |
+| `make release-prepare VERSION=X.Y.Z` | Safely synchronize release versions without committing, tagging, building, or publishing |
+| `make release-check VERSION=X.Y.Z` | Read-only preflight for synchronized versions, installer/archive unhappy paths, repository workflow contracts, and documentation links |
+
+Publication itself is owned by the protected **Release Astra** GitHub workflow;
+neither Make target creates a tag or publishes an artifact. `release-prepare`
+refuses to overwrite existing version-file edits and leaves MatrixOne/Memoria
+digest changes for deliberate maintainer review.
+
 ## Memoria
 
 | Command | Description |

--- a/fixtures/contracts/http_shell_contract.json
+++ b/fixtures/contracts/http_shell_contract.json
@@ -3,7 +3,7 @@
     "status": 200,
     "json": {
       "name": "Agent Engine API",
-      "version": "0.1.0",
+      "version": "<dynamic-package-version>",
       "docs": ""
     }
   },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -223,20 +223,39 @@ Installs a checksum-verified archive containing the `astra` CLI and
 `astra-edge` User Runner from this repository's GitHub Releases:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/matrixorigin/Astra/main/scripts/install-astra.sh | sh
+curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/matrixorigin/Astra/main/scripts/install-astra.sh | sh -s -- --dir "$HOME/.local/bin"
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 The installer, source tag, release assets, and user documentation deliberately
 live in the same repository. Checksums are mandatory; a missing or mismatched
-checksum fails the installation.
+checksum fails the installation. Existing clients are backed up during the
+two-binary replacement and restored if the update cannot finish. After a
+successful install, the script prints a version-matched source checkout and
+`make stack-setup` command so the CLI, User Runner, Server, MatrixOne, and
+Memoria do not silently drift across releases.
 
 ### `scripts/validate-release-version.sh` and `scripts/verify-release-artifacts.sh`
 The release workflows use these scripts as shared, locally testable gates.
-The first requires every versioned workspace surface to match the Git tag. The
+The first requires every versioned workspace surface, including the default
+all-in-one Astra image, to match the selected release version. The
 second requires the complete four-platform client archive set, verifies every
 checksum and archive layout, and creates the aggregate checksum manifest.
-`scripts/ci/test_release_contract.sh` exercises the success and tampering paths
-without compiling binaries or publishing artifacts.
+`scripts/ci/test_release_contract.sh` exercises the success, rollback, and
+tampering paths without compiling binaries or publishing artifacts.
+`scripts/ci/test_release_manifest_contract.sh` separately proves immutable
+Docker-tag creation, exact recovery, and rejection of duplicate platform
+candidates with an offline registry fixture. The shared
+`scripts/reconcile-docker-manifest.sh` performs the same platform-to-digest
+reconciliation at the actual publication boundary.
+
+### `scripts/prepare-release-version.py`
+
+Used by `make release-prepare VERSION=X.Y.Z` to synchronize all release version
+surfaces before review. It starts only from a consistent, unmodified version
+set, stages every replacement before replacing any destination, and validates
+the result. It deliberately leaves MatrixOne and Memoria digest selection to a
+maintainer.
 
 ### `scripts/ops/*.sh`
 Operational helpers for health checks, backup/restore, and deployment.

--- a/scripts/ci/test_prepare_release_version.py
+++ b/scripts/ci/test_prepare_release_version.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/prepare-release-version.py"
+SPEC = importlib.util.spec_from_file_location("prepare_release_version", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+PREPARE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PREPARE)
+
+
+class PrepareReleaseVersionTests(unittest.TestCase):
+    def test_same_version_preserves_file_formatting(self) -> None:
+        manifest = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+        match = re.search(
+            r'^\[workspace\.package\]\n.*?^version\s*=\s*"([^"]+)"',
+            manifest,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        version = match.group(1)
+        for path, rendered in PREPARE.render_updates(version).items():
+            self.assertEqual(
+                (ROOT / path).read_text(encoding="utf-8"),
+                rendered,
+                f"same-version rendering changed {path}",
+            )
+
+    def test_next_version_reaches_every_release_surface(self) -> None:
+        version = "9.8.7-rc.1"
+        updates = PREPARE.render_updates(version)
+        expected_files = set(PREPARE.VERSION_FILES)
+        self.assertEqual(expected_files, set(updates))
+        self.assertIn(f'version = "{version}"', updates[Path("Cargo.toml")])
+        self.assertIn(
+            f"ASTRA_IMAGE=matrixorigin/astra:{version}",
+            updates[Path("deployment/all-in-one/.env.example")],
+        )
+        self.assertGreaterEqual(
+            updates[Path("packages/sdk/package-lock.json")].count(
+                f'"version": "{version}"'
+            ),
+            2,
+        )
+        self.assertGreaterEqual(
+            updates[Path("web/package-lock.json")].count(f'"version": "{version}"'),
+            3,
+        )
+        self.assertIn(
+            f"ASTRA_IMAGE=matrixorigin/astra:{version}",
+            updates[Path(".env.production.example")],
+        )
+
+    def test_semver_validation_rejects_ambiguous_versions(self) -> None:
+        self.assertEqual("0.2.0-rc.1", PREPARE.normalize_version("v0.2.0-rc.1"))
+        for value in ("01.0.0", "0.1.0-01", "0.1.0-rc..1", "0.1"):
+            with self.subTest(value=value), self.assertRaises(SystemExit):
+                PREPARE.normalize_version(value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_release_contract.sh
+++ b/scripts/ci/test_release_contract.sh
@@ -51,6 +51,9 @@ printf '%s\n' \
     '    *) url="$1"; shift ;;' \
     '  esac' \
     'done' \
+    'case "$url" in' \
+    '  */releases/latest) printf '\''{"tag_name":"v0.1.0"}\n'\''; exit 0 ;;' \
+    'esac' \
     'cp "${ASTRA_TEST_RELEASE_DIR}/${url##*/}" "$destination"' \
     > "${fake_bin_dir}/curl"
 chmod 0755 "${fake_bin_dir}/curl"
@@ -60,6 +63,59 @@ PATH="${fake_bin_dir}:${PATH}" \
     "${repo_root}/scripts/install-astra.sh" --version 0.1.0 >/dev/null
 [[ "$("${install_dir}/astra" --version)" = "astra 0.1.0" ]]
 [[ "$("${install_dir}/astra-edge" --version)" = "astra-edge 0.1.0" ]]
+
+latest_output="$(
+    PATH="${fake_bin_dir}:${PATH}" \
+        ASTRA_TEST_RELEASE_DIR="$dist_dir" \
+        ASTRA_INSTALL_DIR="$install_dir" \
+        "${repo_root}/scripts/install-astra.sh" --dry-run
+)"
+grep -Fq "Release: v0.1.0" <<< "$latest_output"
+grep -Fq "git clone --branch v0.1.0 --depth 1" <<< "$latest_output"
+grep -Fq "make stack-setup" <<< "$latest_output"
+
+for invalid_version in 01.0.0 0.1.0-01 0.1.0-rc..1; do
+    if "${repo_root}/scripts/install-astra.sh" \
+        --version "${invalid_version}" --dry-run >/dev/null 2>&1; then
+        echo "installer accepted invalid semantic version ${invalid_version}" >&2
+        exit 1
+    fi
+done
+
+# If replacing the second binary fails, the installer must restore the previous
+# matching CLI/Runner pair instead of leaving a mixed installation behind.
+rollback_install_dir="${fixture_root}/rollback-installed"
+rollback_marker="${fixture_root}/fail-cli-move-once"
+mkdir -p "$rollback_install_dir"
+printf '%s\n' '#!/bin/sh' 'echo "astra old"' > "${rollback_install_dir}/astra"
+printf '%s\n' '#!/bin/sh' 'echo "astra-edge old"' > "${rollback_install_dir}/astra-edge"
+chmod 0755 "${rollback_install_dir}/astra" "${rollback_install_dir}/astra-edge"
+real_mv="$(command -v mv)"
+cat > "${fake_bin_dir}/mv" <<'SH'
+#!/bin/sh
+set -eu
+case "${2:-}" in
+    */.astra-install.*/astra)
+        if [ ! -e "${ASTRA_TEST_MV_MARKER}" ]; then
+            : > "${ASTRA_TEST_MV_MARKER}"
+            exit 1
+        fi
+        ;;
+esac
+exec "${ASTRA_TEST_REAL_MV}" "$@"
+SH
+chmod 0755 "${fake_bin_dir}/mv"
+if PATH="${fake_bin_dir}:${PATH}" \
+    ASTRA_TEST_RELEASE_DIR="$dist_dir" \
+    ASTRA_INSTALL_DIR="$rollback_install_dir" \
+    ASTRA_TEST_MV_MARKER="$rollback_marker" \
+    ASTRA_TEST_REAL_MV="$real_mv" \
+    "${repo_root}/scripts/install-astra.sh" --version 0.1.0 >/dev/null 2>&1; then
+    echo "installer unexpectedly succeeded after a simulated commit failure" >&2
+    exit 1
+fi
+[[ "$("${rollback_install_dir}/astra" --version)" = "astra old" ]]
+[[ "$("${rollback_install_dir}/astra-edge" --version)" = "astra-edge old" ]]
 
 # A checksum sidecar is one exact record, not a file whose first line happens
 # to be valid.

--- a/scripts/ci/test_release_contract.sh
+++ b/scripts/ci/test_release_contract.sh
@@ -80,7 +80,14 @@ for invalid_version in 01.0.0 0.1.0-01 0.1.0-rc..1; do
         echo "installer accepted invalid semantic version ${invalid_version}" >&2
         exit 1
     fi
+    if "${repo_root}/scripts/validate-release-version.sh" \
+        "${invalid_version}" --syntax-only >/dev/null 2>&1; then
+        echo "release preflight accepted invalid semantic version ${invalid_version}" >&2
+        exit 1
+    fi
 done
+"${repo_root}/scripts/validate-release-version.sh" \
+    0.1.0-rc.1 --syntax-only >/dev/null
 
 # If replacing the second binary fails, the installer must restore the previous
 # matching CLI/Runner pair instead of leaving a mixed installation behind.

--- a/scripts/ci/test_release_manifest_contract.sh
+++ b/scripts/ci/test_release_manifest_contract.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Exercise Docker manifest publication and recovery without a registry.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/astra-manifest-contract.XXXXXX")"
+trap 'rm -rf "${fixture_root}"' EXIT HUP INT TERM
+
+fake_bin="${fixture_root}/bin"
+digest_dir="${fixture_root}/digests"
+mkdir -p "${fake_bin}" "${digest_dir}"
+
+amd64_candidate="$(printf 'a%.0s' {1..64})"
+arm64_candidate="$(printf 'b%.0s' {1..64})"
+amd64_image="sha256:$(printf 'c%.0s' {1..64})"
+arm64_image="sha256:$(printf 'd%.0s' {1..64})"
+touch "${digest_dir}/${amd64_candidate}" "${digest_dir}/${arm64_candidate}"
+
+cat > "${fake_bin}/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "${1:-}" == buildx && "${2:-}" == imagetools ]] || exit 90
+operation="${3:-}"
+shift 3
+
+case "${operation}" in
+    create)
+        [[ "${1:-}" == --tag && -n "${2:-}" ]] || exit 91
+        touch "${ASTRA_TEST_DOCKER_STATE}/target"
+        ;;
+    inspect)
+        reference="${1:-}"
+        if [[ "${reference}" == *"@sha256:${ASTRA_TEST_AMD64_CANDIDATE}" ]]; then
+            architecture=amd64
+            image_digest="${ASTRA_TEST_AMD64_IMAGE}"
+        elif [[ "${reference}" == *"@sha256:${ASTRA_TEST_ARM64_CANDIDATE}" ]]; then
+            architecture="${ASTRA_TEST_SECOND_ARCH:-arm64}"
+            image_digest="${ASTRA_TEST_ARM64_IMAGE}"
+        else
+            [[ -e "${ASTRA_TEST_DOCKER_STATE}/target" ]] || exit 1
+            if [[ "${2:-}" == --format ]]; then
+                printf '{"schemaVersion":2,"manifests":[{"digest":"%s","platform":{"os":"linux","architecture":"amd64"}},{"digest":"%s","platform":{"os":"linux","architecture":"arm64"}}]}\n' \
+                    "${ASTRA_TEST_AMD64_IMAGE}" "${ASTRA_TEST_TARGET_ARM64_IMAGE:-${ASTRA_TEST_ARM64_IMAGE}}"
+            else
+                printf 'mock manifest\n'
+            fi
+            exit 0
+        fi
+
+        if [[ "${2:-}" == --format ]]; then
+            printf '{"schemaVersion":2,"manifests":[{"digest":"%s","platform":{"os":"linux","architecture":"%s"}},{"digest":"sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","annotations":{"vnd.docker.reference.type":"attestation-manifest"},"platform":{"os":"unknown","architecture":"unknown"}}]}\n' \
+                "${image_digest}" "${architecture}"
+        else
+            printf 'mock candidate\n'
+        fi
+        ;;
+    *) exit 92 ;;
+esac
+SH
+chmod 0755 "${fake_bin}/docker"
+
+matrix='{"include":[{"platform":"linux/amd64"},{"platform":"linux/arm64"}]}'
+common_env=(
+    "PATH=${fake_bin}:${PATH}"
+    "ASTRA_TEST_AMD64_CANDIDATE=${amd64_candidate}"
+    "ASTRA_TEST_ARM64_CANDIDATE=${arm64_candidate}"
+    "ASTRA_TEST_AMD64_IMAGE=${amd64_image}"
+    "ASTRA_TEST_ARM64_IMAGE=${arm64_image}"
+)
+
+success_state="${fixture_root}/success-state"
+mkdir -p "${success_state}"
+env "${common_env[@]}" ASTRA_TEST_DOCKER_STATE="${success_state}" \
+    "${repo_root}/scripts/reconcile-docker-manifest.sh" \
+    matrixorigin/astra 0.1.0 "${matrix}" "${digest_dir}" reject >/dev/null
+
+# Recovery may reuse exactly matching immutable output.
+env "${common_env[@]}" ASTRA_TEST_DOCKER_STATE="${success_state}" \
+    "${repo_root}/scripts/reconcile-docker-manifest.sh" \
+    matrixorigin/astra 0.1.0 "${matrix}" "${digest_dir}" verify >/dev/null
+
+# A normal publication must never overwrite a tag, even if its content matches.
+if env "${common_env[@]}" ASTRA_TEST_DOCKER_STATE="${success_state}" \
+    "${repo_root}/scripts/reconcile-docker-manifest.sh" \
+    matrixorigin/astra 0.1.0 "${matrix}" "${digest_dir}" reject >/dev/null 2>&1; then
+    echo "manifest contract overwrote an existing immutable tag" >&2
+    exit 1
+fi
+
+# Two digest files are insufficient: their actual platforms must match the matrix.
+wrong_state="${fixture_root}/wrong-state"
+mkdir -p "${wrong_state}"
+if env "${common_env[@]}" ASTRA_TEST_DOCKER_STATE="${wrong_state}" \
+    ASTRA_TEST_SECOND_ARCH=amd64 \
+    "${repo_root}/scripts/reconcile-docker-manifest.sh" \
+    matrixorigin/astra 0.1.0 "${matrix}" "${digest_dir}" reject >/dev/null 2>&1; then
+    echo "manifest contract accepted duplicate AMD64 candidates" >&2
+    exit 1
+fi
+[[ ! -e "${wrong_state}/target" ]]
+
+# Recovery must reject an existing tag whose platform digest differs.
+mismatch_state="${fixture_root}/mismatch-state"
+mkdir -p "${mismatch_state}"
+touch "${mismatch_state}/target"
+mismatch_digest="sha256:$(printf 'f%.0s' {1..64})"
+if env "${common_env[@]}" ASTRA_TEST_DOCKER_STATE="${mismatch_state}" \
+    ASTRA_TEST_TARGET_ARM64_IMAGE="${mismatch_digest}" \
+    "${repo_root}/scripts/reconcile-docker-manifest.sh" \
+    matrixorigin/astra 0.1.0 "${matrix}" "${digest_dir}" verify >/dev/null 2>&1; then
+    echo "manifest recovery accepted different immutable output" >&2
+    exit 1
+fi

--- a/scripts/ci/test_release_manifest_contract.sh
+++ b/scripts/ci/test_release_manifest_contract.sh
@@ -39,7 +39,14 @@ case "${operation}" in
             architecture="${ASTRA_TEST_SECOND_ARCH:-arm64}"
             image_digest="${ASTRA_TEST_ARM64_IMAGE}"
         else
-            [[ -e "${ASTRA_TEST_DOCKER_STATE}/target" ]] || exit 1
+            if [[ "${ASTRA_TEST_TARGET_INSPECT_ERROR:-false}" == true ]]; then
+                echo 'ERROR: registry request failed: TLS handshake timeout' >&2
+                exit 1
+            fi
+            if [[ ! -e "${ASTRA_TEST_DOCKER_STATE}/target" ]]; then
+                echo 'ERROR: matrixorigin/astra:test: not found' >&2
+                exit 1
+            fi
             if [[ "${2:-}" == --format ]]; then
                 printf '{"schemaVersion":2,"manifests":[{"digest":"%s","platform":{"os":"linux","architecture":"amd64"}},{"digest":"%s","platform":{"os":"linux","architecture":"arm64"}}]}\n' \
                     "${ASTRA_TEST_AMD64_IMAGE}" "${ASTRA_TEST_TARGET_ARM64_IMAGE:-${ASTRA_TEST_ARM64_IMAGE}}"
@@ -100,6 +107,19 @@ if env "${common_env[@]}" ASTRA_TEST_DOCKER_STATE="${wrong_state}" \
     exit 1
 fi
 [[ ! -e "${wrong_state}/target" ]]
+
+# A registry/network/authentication failure is not proof that a tag is absent.
+# Publication must fail closed without attempting to create or replace it.
+lookup_error_state="${fixture_root}/lookup-error-state"
+mkdir -p "${lookup_error_state}"
+if env "${common_env[@]}" ASTRA_TEST_DOCKER_STATE="${lookup_error_state}" \
+    ASTRA_TEST_TARGET_INSPECT_ERROR=true \
+    "${repo_root}/scripts/reconcile-docker-manifest.sh" \
+    matrixorigin/astra 0.1.0 "${matrix}" "${digest_dir}" reject >/dev/null 2>&1; then
+    echo "manifest contract treated a registry failure as an absent tag" >&2
+    exit 1
+fi
+[[ ! -e "${lookup_error_state}/target" ]]
 
 # Recovery must reject an existing tag whose platform digest differs.
 mismatch_state="${fixture_root}/mismatch-state"

--- a/scripts/ci/validate_repository.py
+++ b/scripts/ci/validate_repository.py
@@ -183,6 +183,7 @@ def main() -> None:
     for required in (
         "workflow_dispatch:",
         "Official Docker snapshots cannot publish unreviewed feature-branch source",
+        "Snapshot tags must start with snapshot-",
         "Semantic versions are owned by the unified Release workflow",
         "Require Docker publication credentials",
         "ASTRA_SNAPSHOT_ENVIRONMENT_GUARD",

--- a/scripts/ci/validate_repository.py
+++ b/scripts/ci/validate_repository.py
@@ -126,6 +126,7 @@ def main() -> None:
         "workflow_dispatch:",
         "recover_existing_tag:",
         'GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}',
+        'validate-release-version.sh "${version}" --syntax-only',
         "release-binaries.yml",
         "release-container-candidates.yml",
         "environment: release",
@@ -135,6 +136,7 @@ def main() -> None:
         "Reject conflicting Docker version before creating the tag",
         "Resolve publication continuation state",
         "Release-Run:",
+        "Could not safely determine whether GitHub Release",
         "Recovery cannot adopt manual or legacy tags",
         "Recovery will not trust an unverifiable release owner",
         'run.get("path", "")',
@@ -170,6 +172,7 @@ def main() -> None:
         "make stack-verify",
         "release-digest-",
         "Write container candidate summary",
+        "Candidate image version",
     ):
         if required not in container_candidates:
             errors.append(
@@ -197,6 +200,7 @@ def main() -> None:
     for required in (
         "candidate platforms do not match the requested build matrix",
         "already exists and will not be overwritten",
+        "could not safely determine whether",
         "published manifest",
         "does not match the verified candidates",
     ):

--- a/scripts/ci/validate_repository.py
+++ b/scripts/ci/validate_repository.py
@@ -11,7 +11,11 @@ import subprocess
 
 
 def tracked_files() -> list[Path]:
-    output = subprocess.check_output(["git", "ls-files", "-z"])
+    # Include untracked, non-ignored files so a local preflight validates newly
+    # added workflows and documentation before they are staged or committed.
+    output = subprocess.check_output(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"]
+    )
     return [Path(item.decode("utf-8")) for item in output.split(b"\0") if item]
 
 
@@ -65,6 +69,7 @@ def main() -> None:
         Path("scripts/ci/test_interactive_setup_contract.sh"),
         Path("scripts/ops/test_production_env_contract.sh"),
         Path("scripts/ci/test_release_contract.sh"),
+        Path("scripts/ci/test_release_manifest_contract.sh"),
         Path("scripts/ci/test_sccache_fallback.sh"),
     ]
     for contract_script in contract_scripts:
@@ -94,51 +99,111 @@ def main() -> None:
             if not pinned_action.fullmatch(action):
                 errors.append(f"{source}: action must be pinned to a full commit SHA ({action})")
 
-    release_workflow = Path(".github/workflows/release-docker.yml").read_text(encoding="utf-8")
-    build_start = release_workflow.find("\n  build:")
-    smoke_start = release_workflow.find("\n  smoke:")
-    merge_start = release_workflow.find("\n  merge:")
-    promote_start = release_workflow.find("\n  promote:")
-    mirror_start = release_workflow.find("\n  registry-mirror:")
-    if not 0 <= build_start < smoke_start < merge_start < promote_start < mirror_start:
+    static_checks = Path(".github/workflows/static-checks.yml").read_text(
+        encoding="utf-8"
+    )
+    if "github.com/rhysd/actionlint/cmd/actionlint@v1.7.12" not in static_checks:
         errors.append(
-            ".github/workflows/release-docker.yml: release jobs must smoke untagged digests, "
-            "publish the verified manifest, and only then promote rolling tags"
+            ".github/workflows/static-checks.yml: CI must validate workflow semantics "
+            "with the repository-pinned actionlint version"
         )
-    else:
-        build_job = release_workflow[build_start:smoke_start]
-        smoke_job = release_workflow[smoke_start:merge_start]
-        merge_job = release_workflow[merge_start:promote_start]
-        promote_job = release_workflow[promote_start:mirror_start]
-        if "push-by-digest=true" not in build_job or "name-canonical=true" not in build_job:
+
+    release_controller = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    container_candidates = Path(
+        ".github/workflows/release-container-candidates.yml"
+    ).read_text(encoding="utf-8")
+    snapshot_workflow = Path(".github/workflows/release-docker.yml").read_text(
+        encoding="utf-8"
+    )
+
+    for forbidden in ("push:\n    tags:", "on:\n  push:"):
+        if forbidden in release_controller:
             errors.append(
-                ".github/workflows/release-docker.yml: candidate builds must be pushed by digest without a tag"
+                ".github/workflows/release.yml: releases must start from the protected "
+                "default-branch control plane, not an arbitrary tag's historical workflow"
             )
-        if "type=raw,value=" in smoke_job or "- merge" in smoke_job:
+    for required in (
+        "workflow_dispatch:",
+        "recover_existing_tag:",
+        'GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}',
+        "release-binaries.yml",
+        "release-container-candidates.yml",
+        "environment: release",
+        "ASTRA_RELEASE_ENVIRONMENT_GUARD",
+        "Require Docker publication credentials",
+        "Reject an existing Docker version before candidate builds",
+        "Reject conflicting Docker version before creating the tag",
+        "Resolve publication continuation state",
+        "Release-Run:",
+        "Recovery cannot adopt manual or legacy tags",
+        "Recovery will not trust an unverifiable release owner",
+        'run.get("path", "")',
+        "Create or validate the immutable release tag",
+        "Stage GitHub Release and verified assets",
+        "Create or verify the immutable Docker version manifest",
+        "scripts/reconcile-docker-manifest.sh",
+        "Publish GitHub Release",
+        "Promote stable rolling Docker tags",
+    ):
+        if required not in release_controller:
             errors.append(
-                ".github/workflows/release-docker.yml: smoke job must verify build digests before any tag is published"
+                f".github/workflows/release.yml: missing unified release contract ({required})"
             )
-        if "- build" not in smoke_job or "@sha256:" not in smoke_job or "make stack-verify" not in smoke_job:
+
+    docker_manifest = release_controller.find(
+        "Create or verify the immutable Docker version manifest"
+    )
+    github_publish = release_controller.find("Publish GitHub Release")
+    rolling_promotion = release_controller.find("Promote stable rolling Docker tags")
+    if not 0 <= docker_manifest < github_publish < rolling_promotion:
+        errors.append(
+            ".github/workflows/release.yml: version artifacts must be reconciled before "
+            "the GitHub Release and rolling Docker tags become public"
+        )
+
+    for required in (
+        "workflow_call:",
+        "push-by-digest=true",
+        "name-canonical=true",
+        "@sha256:",
+        "make stack-up",
+        "make stack-verify",
+        "release-digest-",
+        "Write container candidate summary",
+    ):
+        if required not in container_candidates:
             errors.append(
-                ".github/workflows/release-docker.yml: candidate digests must be verified through the all-in-one runtime"
+                ".github/workflows/release-container-candidates.yml: missing untagged "
+                f"candidate or runtime-smoke contract ({required})"
             )
-        if (
-            "- smoke" not in merge_job
-            or "type=raw,value=latest" in merge_job
-            or "actual_platforms" not in merge_job
-            or "expected_platforms" not in merge_job
-        ):
+
+    for required in (
+        "workflow_dispatch:",
+        "Official Docker snapshots cannot publish unreviewed feature-branch source",
+        "Semantic versions are owned by the unified Release workflow",
+        "Require Docker publication credentials",
+        "ASTRA_SNAPSHOT_ENVIRONMENT_GUARD",
+        "release-container-candidates.yml",
+        "scripts/reconcile-docker-manifest.sh",
+    ):
+        if required not in snapshot_workflow:
             errors.append(
-                ".github/workflows/release-docker.yml: version manifest must depend on smoke and validate its platform set"
+                f".github/workflows/release-docker.yml: missing immutable snapshot guard ({required})"
             )
-        if (
-            "- merge" not in promote_job
-            or '--tag "${IMAGE_NAME}:latest"' not in promote_job
-            or "expected_platforms" not in promote_job
-            or "actual_platforms" not in promote_job
-        ):
+
+    manifest_reconciler = Path("scripts/reconcile-docker-manifest.sh").read_text(
+        encoding="utf-8"
+    )
+    for required in (
+        "candidate platforms do not match the requested build matrix",
+        "already exists and will not be overwritten",
+        "published manifest",
+        "does not match the verified candidates",
+    ):
+        if required not in manifest_reconciler:
             errors.append(
-                ".github/workflows/release-docker.yml: rolling promotion must depend on and match the verified manifest"
+                "scripts/reconcile-docker-manifest.sh: missing immutable platform "
+                f"reconciliation contract ({required})"
             )
 
     binary_release_workflow = Path(".github/workflows/release-binaries.yml").read_text(
@@ -156,32 +221,33 @@ def main() -> None:
                 f"(found {forbidden.strip()})"
             )
     for required in (
-        "permissions:\n      contents: write",
-        "fetch-depth: 0",
-        "git merge-base --is-ancestor",
-        "EVENT_SOURCE_SHA",
+        "workflow_call:",
+        "Execute client candidates",
+        "--locked",
         "source_sha",
         "astra-edge",
         "scripts/verify-release-artifacts.sh",
-        "fail_on_unmatched_files: true",
+        "release-client-assets",
     ):
         if required not in binary_release_workflow:
             errors.append(
-                ".github/workflows/release-binaries.yml: missing current-repository release guard "
+                ".github/workflows/release-binaries.yml: missing verified client candidate contract "
                 f"({required})"
             )
 
-    for required in (
-        "fetch-depth: 0",
-        "EVENT_SOURCE_SHA",
-        "source_sha",
-        "EXPECTED_TAG_OBJECT",
-    ):
-        if required not in release_workflow:
-            errors.append(
-                ".github/workflows/release-docker.yml: missing immutable release source guard "
-                f"({required})"
-            )
+    dockerfile = Path("Dockerfile").read_text(encoding="utf-8")
+    if "cargo chef cook --release --locked" not in dockerfile \
+        or "cargo build --release --locked" not in dockerfile:
+        errors.append("Dockerfile: release builds must not update Cargo.lock resolution")
+
+    runtime_versions = {
+        Path("crates/astra-cli/src/cli/slash/slash_info.rs"): 'format!("  astra version {} (Rust)", env!("CARGO_PKG_VERSION"))',
+        Path("crates/runtime/src/app_state.rs"): 'const DEFAULT_VERSION: &str = env!("CARGO_PKG_VERSION")',
+        Path("crates/runtime/src/server/runtime_tool_executor.rs"): 'concat!("astra-server/", env!("CARGO_PKG_VERSION"))',
+    }
+    for source, required in runtime_versions.items():
+        if required not in source.read_text(encoding="utf-8"):
+            errors.append(f"{source}: runtime identity must derive from the Cargo package version")
 
     installer = Path("scripts/install-astra.sh").read_text(encoding="utf-8")
     if 'REPOSITORY="matrixorigin/Astra"' not in installer:
@@ -202,14 +268,35 @@ def main() -> None:
         "web/package.json",
         "CITATION.cff",
         "deployment/kubernetes/chart/Chart.yaml",
+        "deployment/all-in-one/.env.example",
+        ".env.production.example",
     ):
         if version_source not in release_version_validator:
             errors.append(
                 f"scripts/validate-release-version.sh: missing release version source {version_source}"
             )
 
+    for dependency_image in ("MEMORIA_IMAGE", "MATRIXONE_IMAGE", "@sha256:"):
+        if dependency_image not in release_version_validator:
+            errors.append(
+                "scripts/validate-release-version.sh: all-in-one release dependencies "
+                f"must be immutable ({dependency_image})"
+            )
+
+    stack_compose = Path("deployment/all-in-one/docker-compose.yml").read_text(
+        encoding="utf-8"
+    )
+    for image_variable in ("ASTRA_IMAGE", "MEMORIA_IMAGE", "MATRIXONE_IMAGE"):
+        if f"${{{image_variable}:-" in stack_compose:
+            errors.append(
+                "deployment/all-in-one/docker-compose.yml: released stack must require "
+                f"the compatibility pin for {image_variable} instead of silently falling back"
+            )
+
     makefile = Path("Makefile").read_text(encoding="utf-8")
     for required in (
+        "release-prepare:",
+        'scripts/prepare-release-version.py "$(VERSION)"',
         "stack-start: stack-env",
         "$(MAKE) stack-up",
         "$(MAKE) stack-verify",

--- a/scripts/install-astra.sh
+++ b/scripts/install-astra.sh
@@ -62,7 +62,7 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
-for command_name in awk curl grep install mktemp sort tar; do
+for command_name in awk cp curl grep install mktemp mv sort tar; do
     command -v "$command_name" >/dev/null 2>&1 || fail "${command_name} is required"
 done
 
@@ -85,8 +85,8 @@ curl_download() {
 if [ -z "$VERSION" ]; then
     info "Resolving the latest stable Astra release"
     release_json=$(curl_download -sS "https://api.github.com/repos/${REPOSITORY}/releases/latest") \
-        || fail "no stable Astra GitHub Release is available"
-    tag=$(printf '%s\n' "$release_json" | sed -n 's/^[[:space:]]*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
+        || fail "no stable Astra GitHub Release is available; see https://github.com/${REPOSITORY}/releases"
+    tag=$(printf '%s\n' "$release_json" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
     [ -n "$tag" ] || fail "the latest GitHub Release did not contain a tag"
     VERSION=${tag#v}
 else
@@ -94,7 +94,26 @@ else
     tag="v${VERSION}"
 fi
 
-if ! printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+if ! printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' \
+    || ! awk -v version="$VERSION" '
+        BEGIN {
+            separator = index(version, "-")
+            core = separator ? substr(version, 1, separator - 1) : version
+            if (split(core, identifiers, ".") != 3) exit 1
+            for (i = 1; i <= 3; i++) {
+                if (identifiers[i] != "0" && identifiers[i] ~ /^0/) exit 1
+            }
+            if (!separator) exit 0
+            prerelease = substr(version, separator + 1)
+            count = split(prerelease, identifiers, ".")
+            for (i = 1; i <= count; i++) {
+                if (identifiers[i] == "") exit 1
+                if (identifiers[i] ~ /^[0-9]+$/ \
+                    && identifiers[i] != "0" \
+                    && identifiers[i] ~ /^0/) exit 1
+            }
+        }
+    ' </dev/null; then
     fail "invalid release version: ${VERSION}"
 fi
 [ "$tag" = "v${VERSION}" ] || fail "unsupported release tag: ${tag}"
@@ -118,16 +137,50 @@ info "Release: ${tag} (${target})"
 info "Source:  ${archive_url}"
 info "Target:  ${INSTALL_DIR}/astra and ${INSTALL_DIR}/astra-edge"
 
+show_next_steps() {
+    printf '\n'
+    info "Next: start the matching Astra Server stack"
+    printf '%s\n' \
+        "  git clone --branch ${tag} --depth 1 https://github.com/${REPOSITORY}.git Astra-${VERSION}" \
+        "  cd Astra-${VERSION}" \
+        "  make stack-setup"
+    info "Already have a Server? Run: astra login"
+}
+
 if [ "$DRY_RUN" = true ]; then
+    show_next_steps
     exit 0
 fi
 
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/astra-install.XXXXXX")
 install_stage=""
+backup_stage=""
+installation_started=false
+installation_committed=false
 cleanup() {
+    if [ "$installation_started" = true ] && [ "$installation_committed" != true ]; then
+        restore_failed=false
+        for binary in $BINARIES; do
+            if [ -e "${backup_stage}/${binary}" ] || [ -L "${backup_stage}/${binary}" ]; then
+                mv -f "${backup_stage}/${binary}" "${INSTALL_DIR}/${binary}" \
+                    || restore_failed=true
+            else
+                rm -f "${INSTALL_DIR}/${binary}" || restore_failed=true
+            fi
+        done
+        if [ "$restore_failed" = true ]; then
+            printf '%s\n' \
+                "error: installation failed and automatic rollback was incomplete; inspect ${INSTALL_DIR}/astra and ${INSTALL_DIR}/astra-edge" >&2
+        else
+            printf '%s\n' "error: installation failed; previous Astra clients were restored" >&2
+        fi
+    fi
     rm -rf "$tmp_dir"
     if [ -n "$install_stage" ]; then
         rm -rf "$install_stage"
+    fi
+    if [ -n "$backup_stage" ]; then
+        rm -rf "$backup_stage"
     fi
 }
 trap cleanup EXIT
@@ -175,15 +228,26 @@ if [ ! -w "$INSTALL_DIR" ]; then
     fail "${INSTALL_DIR} is not writable; choose a writable directory with --dir"
 fi
 install_stage=$(mktemp -d "${INSTALL_DIR}/.astra-install.XXXXXX")
+backup_stage=$(mktemp -d "${INSTALL_DIR}/.astra-backup.XXXXXX")
 for binary in $BINARIES; do
     install -m 0755 "${tmp_dir}/${binary}" "${install_stage}/${binary}"
+    destination="${INSTALL_DIR}/${binary}"
+    if [ -e "$destination" ] || [ -L "$destination" ]; then
+        if [ ! -f "$destination" ] && [ ! -L "$destination" ]; then
+            fail "${destination} exists but is not a regular file or symlink"
+        fi
+        cp -pP "$destination" "${backup_stage}/${binary}"
+    fi
 done
+installation_started=true
 mv -f "${install_stage}/astra-edge" "${INSTALL_DIR}/astra-edge"
 # Move the CLI last so a visible new `astra` always has its matching Runner.
 mv -f "${install_stage}/astra" "${INSTALL_DIR}/astra"
+installation_committed=true
 info "Installed astra and astra-edge ${VERSION} to ${INSTALL_DIR}"
 
 case ":${PATH}:" in
     *":${INSTALL_DIR}:"*) ;;
     *) info "Add ${INSTALL_DIR} to PATH before invoking Astra" ;;
 esac
+show_next_steps

--- a/scripts/prepare-release-version.py
+++ b/scripts/prepare-release-version.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Synchronize Astra's versioned release surfaces without publishing anything."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+from typing import NoReturn
+
+
+ROOT = Path(__file__).resolve().parent.parent
+VERSION_FILES = (
+    Path("Cargo.toml"),
+    Path("Cargo.lock"),
+    Path("packages/sdk/package.json"),
+    Path("packages/sdk/package-lock.json"),
+    Path("web/package.json"),
+    Path("web/package-lock.json"),
+    Path("CITATION.cff"),
+    Path("deployment/kubernetes/chart/Chart.yaml"),
+    Path("deployment/all-in-one/.env.example"),
+    Path(".env.production.example"),
+)
+SEMVER = re.compile(
+    r"(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)"
+    r"(?:-(?:[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+)
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"error: {message}")
+
+
+def normalize_version(argument: str) -> str:
+    version = argument.removeprefix("v")
+    if SEMVER.fullmatch(version) is None:
+        fail(f"invalid semantic version: {argument}")
+    prerelease = version.partition("-")[2]
+    if any(
+        identifier.isdigit() and len(identifier) > 1 and identifier.startswith("0")
+        for identifier in prerelease.split(".")
+        if identifier
+    ):
+        fail(f"numeric prerelease identifiers cannot have leading zeros: {version}")
+    return version
+
+
+def replace_once(text: str, pattern: str, replacement: str, label: str) -> str:
+    updated, count = re.subn(pattern, replacement, text, count=1, flags=re.MULTILINE)
+    if count != 1:
+        fail(f"could not locate exactly one {label}")
+    return updated
+
+
+def update_workspace_manifest(text: str, version: str) -> str:
+    section_match = re.search(
+        r"^\[workspace\.package\]\n(?P<body>.*?)(?=^\[|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if section_match is None:
+        fail("Cargo.toml is missing [workspace.package]")
+    body = replace_once(
+        section_match.group("body"),
+        r'^(version\s*=\s*")[^"]+("\s*)$',
+        rf"\g<1>{version}\g<2>",
+        "Cargo workspace version",
+    )
+    return text[: section_match.start("body")] + body + text[section_match.end("body") :]
+
+
+def update_lockfile(text: str, version: str) -> str:
+    package_pattern = re.compile(
+        r"^\[\[package\]\]\n.*?(?=^\[\[package\]\]|\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    changed = 0
+
+    def update_package(match: re.Match[str]) -> str:
+        nonlocal changed
+        block = match.group(0)
+        name_match = re.search(r'^name = "([^"]+)"$', block, flags=re.MULTILINE)
+        if (
+            name_match is None
+            or not name_match.group(1).startswith("astra-")
+            or re.search(r"^source = ", block, flags=re.MULTILINE)
+        ):
+            return block
+        updated = replace_once(
+            block,
+            r'^(version = ")[^"]+("\s*)$',
+            rf"\g<1>{version}\g<2>",
+            f"Cargo.lock version for {name_match.group(1)}",
+        )
+        changed += 1
+        return updated
+
+    updated = package_pattern.sub(update_package, text)
+    if changed == 0:
+        fail("Cargo.lock contains no local astra-* packages")
+    return updated
+
+
+def update_package_json(text: str, version: str, lockfile: bool) -> str:
+    document = json.loads(text)
+    document["version"] = version
+    if lockfile:
+        root_package = document.get("packages", {}).get("")
+        if not isinstance(root_package, dict):
+            fail("npm lockfile is missing packages['']")
+        root_package["version"] = version
+        for package_path, package in document["packages"].items():
+            if package_path and package.get("name") == "@astra/sdk":
+                package["version"] = version
+    return json.dumps(document, ensure_ascii=False, indent=2) + "\n"
+
+
+def render_updates(version: str) -> dict[Path, str]:
+    source = {
+        path: (ROOT / path).read_text(encoding="utf-8") for path in VERSION_FILES
+    }
+    updates = {
+        Path("Cargo.toml"): update_workspace_manifest(source[Path("Cargo.toml")], version),
+        Path("Cargo.lock"): update_lockfile(source[Path("Cargo.lock")], version),
+        Path("packages/sdk/package.json"): update_package_json(
+            source[Path("packages/sdk/package.json")], version, False
+        ),
+        Path("packages/sdk/package-lock.json"): update_package_json(
+            source[Path("packages/sdk/package-lock.json")], version, True
+        ),
+        Path("web/package.json"): update_package_json(
+            source[Path("web/package.json")], version, False
+        ),
+        Path("web/package-lock.json"): update_package_json(
+            source[Path("web/package-lock.json")], version, True
+        ),
+    }
+    updates[Path("CITATION.cff")] = replace_once(
+        source[Path("CITATION.cff")],
+        r"^version:\s*.*$",
+        f"version: {version}",
+        "CITATION.cff version",
+    )
+    chart = source[Path("deployment/kubernetes/chart/Chart.yaml")]
+    chart = replace_once(chart, r"^version:\s*.*$", f"version: {version}", "Helm version")
+    updates[Path("deployment/kubernetes/chart/Chart.yaml")] = replace_once(
+        chart,
+        r"^appVersion:\s*.*$",
+        f'appVersion: "{version}"',
+        "Helm appVersion",
+    )
+    updates[Path("deployment/all-in-one/.env.example")] = replace_once(
+        source[Path("deployment/all-in-one/.env.example")],
+        r"^ASTRA_IMAGE=.*$",
+        f"ASTRA_IMAGE=matrixorigin/astra:{version}",
+        "all-in-one Astra image",
+    )
+    updates[Path(".env.production.example")] = replace_once(
+        source[Path(".env.production.example")],
+        r"^ASTRA_IMAGE=.*$",
+        f"ASTRA_IMAGE=matrixorigin/astra:{version}",
+        "production Astra image",
+    )
+    return updates
+
+
+def write_atomically(updates: dict[Path, str]) -> None:
+    staged: list[tuple[Path, Path]] = []
+    try:
+        for relative, content in updates.items():
+            destination = ROOT / relative
+            descriptor, temporary_name = tempfile.mkstemp(
+                prefix=f".{destination.name}.release-", dir=destination.parent
+            )
+            temporary = Path(temporary_name)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+                output.write(content)
+            os.chmod(temporary, stat.S_IMODE(destination.stat().st_mode))
+            staged.append((temporary, destination))
+        for temporary, destination in staged:
+            os.replace(temporary, destination)
+    finally:
+        for temporary, _ in staged:
+            temporary.unlink(missing_ok=True)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        fail("usage: prepare-release-version.py <version>")
+    version = normalize_version(sys.argv[1])
+
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain=v1", "--", *(str(path) for path in VERSION_FILES)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if dirty:
+        fail("release version files already have uncommitted changes; commit or restore them first")
+
+    manifest = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    current_match = re.search(
+        r'^\[workspace\.package\]\n.*?^version\s*=\s*"([^"]+)"',
+        manifest,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if current_match is None:
+        fail("could not read the current Cargo workspace version")
+    current = current_match.group(1)
+    subprocess.run(
+        [str(ROOT / "scripts/validate-release-version.sh"), current],
+        cwd=ROOT,
+        check=True,
+    )
+
+    updates = render_updates(version)
+    if all(
+        (ROOT / path).read_text(encoding="utf-8") == content
+        for path, content in updates.items()
+    ):
+        print(f"release version {version} is already synchronized")
+        return
+    write_atomically(updates)
+    subprocess.run(
+        [str(ROOT / "scripts/validate-release-version.sh"), version],
+        cwd=ROOT,
+        check=True,
+    )
+    print(f"prepared Astra {version} release metadata in {len(updates)} files")
+    print("review the diff and the pinned MatrixOne/Memoria compatibility digests before committing")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reconcile-docker-manifest.sh
+++ b/scripts/reconcile-docker-manifest.sh
@@ -156,7 +156,17 @@ if [[ "$(printf '%s\n' "${expected_platform_names[@]}")" != "$(printf '%s\n' "${
 fi
 
 target="${image_name}:${image_tag}"
-if docker buildx imagetools inspect "${target}" >/dev/null 2>&1; then
+target_exists=false
+if inspect_output="$(docker buildx imagetools inspect "${target}" 2>&1)"; then
+    target_exists=true
+elif ! grep -Eqi '(: not found|manifest unknown|name unknown|HTTP 404|status[^0-9]*404)' \
+    <<< "${inspect_output}"; then
+    echo "could not safely determine whether ${target} exists:" >&2
+    printf '%s\n' "${inspect_output}" >&2
+    exit 1
+fi
+
+if [[ "${target_exists}" == true ]]; then
     if [[ "${existing_policy}" == "reject" ]]; then
         echo "${target} already exists and will not be overwritten" >&2
         exit 1

--- a/scripts/reconcile-docker-manifest.sh
+++ b/scripts/reconcile-docker-manifest.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Create an immutable Docker tag from verified candidate digests, then prove
+# that its Linux platform-to-digest mapping matches the requested build matrix.
+
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+    echo "usage: $0 <image> <tag> <matrix-json> <digest-dir> <reject|verify>" >&2
+    exit 2
+fi
+
+image_name="$1"
+image_tag="$2"
+matrix_json="$3"
+digest_dir="$4"
+existing_policy="$5"
+
+case "${existing_policy}" in
+    reject|verify) ;;
+    *)
+        echo "existing-tag policy must be reject or verify" >&2
+        exit 2
+        ;;
+esac
+
+for command_name in docker python3 sha256sum; do
+    command -v "${command_name}" >/dev/null 2>&1 || {
+        echo "${command_name} is required" >&2
+        exit 1
+    }
+done
+
+if [[ ! -d "${digest_dir}" ]]; then
+    echo "candidate digest directory does not exist: ${digest_dir}" >&2
+    exit 1
+fi
+
+mapfile -t expected_platform_names < <(
+    python3 -c '
+import json, sys
+document = json.load(sys.stdin)
+platforms = document.get("include", [])
+if not platforms:
+    raise SystemExit("empty build matrix")
+for entry in platforms:
+    platform = entry.get("platform")
+    if not isinstance(platform, str) or not platform:
+        raise SystemExit("invalid platform in build matrix")
+    print(platform)
+' <<< "${matrix_json}" | sort -u
+)
+expected_source_count="$(
+    python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("include", [])))' \
+        <<< "${matrix_json}"
+)"
+if [[ "${#expected_platform_names[@]}" -ne "${expected_source_count}" ]]; then
+    echo "build matrix contains duplicate platform names" >&2
+    exit 1
+fi
+
+shopt -s nullglob
+digest_files=("${digest_dir}"/*)
+if [[ "${#digest_files[@]}" -ne "${expected_source_count}" ]]; then
+    echo "expected ${expected_source_count} candidate digests, found ${#digest_files[@]}" >&2
+    exit 1
+fi
+
+platform_digest_set() {
+    local reference="$1"
+    local manifest_json manifest_platforms image_json platform digest
+
+    manifest_json="$(docker buildx imagetools inspect "${reference}" --format '{{json .Manifest}}')"
+    manifest_platforms="$(
+        python3 -c '
+import json, re, sys
+document = json.load(sys.stdin)
+manifests = document.get("manifests")
+if not isinstance(manifests, list):
+    print("__SINGLE__")
+    raise SystemExit
+found = []
+unexpected = []
+for manifest in manifests:
+    platform = manifest.get("platform", {})
+    if platform.get("os") == "linux" and platform.get("architecture") in {"amd64", "arm64"}:
+        architecture = platform["architecture"]
+        digest = manifest.get("digest")
+        if not isinstance(digest, str) or re.fullmatch(r"sha256:[0-9a-f]{64}", digest) is None:
+            raise SystemExit("image manifest has an invalid digest")
+        found.append(f"linux/{architecture}={digest}")
+    elif not (
+        platform.get("os") == "unknown"
+        and platform.get("architecture") == "unknown"
+        and manifest.get("annotations", {}).get("vnd.docker.reference.type")
+            == "attestation-manifest"
+    ):
+        unexpected.append(platform)
+if unexpected:
+    raise SystemExit(f"index contains unexpected platforms: {unexpected}")
+if not found:
+    raise SystemExit("index contains no supported Linux image manifest")
+print("\n".join(sorted(set(found))))
+' <<< "${manifest_json}"
+    )"
+    if [[ "${manifest_platforms}" != "__SINGLE__" ]]; then
+        printf '%s\n' "${manifest_platforms}"
+        return
+    fi
+
+    image_json="$(docker buildx imagetools inspect "${reference}" --format '{{json .Image}}')"
+    platform="$(
+        python3 -c '
+import json, sys
+image = json.load(sys.stdin)
+if image.get("os") != "linux" or image.get("architecture") not in {"amd64", "arm64"}:
+    raise SystemExit("unsupported single-platform image")
+print("linux/" + image["architecture"])
+' <<< "${image_json}"
+    )"
+    digest="sha256:$(docker buildx imagetools inspect "${reference}" --raw | sha256sum | awk '{print $1}')"
+    printf '%s=%s\n' "${platform}" "${digest}"
+}
+
+sources=()
+candidate_platforms_file="$(mktemp "${RUNNER_TEMP:-/tmp}/astra-platforms.XXXXXX")"
+trap 'rm -f "${candidate_platforms_file}"' EXIT HUP INT TERM
+
+for digest_file in "${digest_files[@]}"; do
+    if [[ ! -f "${digest_file}" ]]; then
+        echo "candidate digest entry is not a regular file: ${digest_file}" >&2
+        exit 1
+    fi
+    digest="$(basename "${digest_file}")"
+    if [[ ! "${digest}" =~ ^[0-9a-f]{64}$ ]]; then
+        echo "invalid candidate digest filename: ${digest}" >&2
+        exit 1
+    fi
+    source="${image_name}@sha256:${digest}"
+    sources+=("${source}")
+    mapfile -t source_platforms < <(platform_digest_set "${source}")
+    if [[ "${#source_platforms[@]}" -ne 1 ]]; then
+        echo "candidate ${source} must contain exactly one supported Linux platform" >&2
+        exit 1
+    fi
+    printf '%s\n' "${source_platforms[0]}" >> "${candidate_platforms_file}"
+done
+sort -u -o "${candidate_platforms_file}" "${candidate_platforms_file}"
+
+mapfile -t candidate_platform_names < <(cut -d= -f1 "${candidate_platforms_file}" | sort -u)
+if [[ "$(printf '%s\n' "${expected_platform_names[@]}")" != "$(printf '%s\n' "${candidate_platform_names[@]}")" ]]; then
+    echo "candidate platforms do not match the requested build matrix" >&2
+    diff \
+        <(printf '%s\n' "${expected_platform_names[@]}") \
+        <(printf '%s\n' "${candidate_platform_names[@]}") || true
+    exit 1
+fi
+
+target="${image_name}:${image_tag}"
+if docker buildx imagetools inspect "${target}" >/dev/null 2>&1; then
+    if [[ "${existing_policy}" == "reject" ]]; then
+        echo "${target} already exists and will not be overwritten" >&2
+        exit 1
+    fi
+    echo "${target} already exists; verifying its immutable platform set."
+else
+    docker buildx imagetools create --tag "${target}" "${sources[@]}"
+fi
+
+actual_platforms_file="$(mktemp "${RUNNER_TEMP:-/tmp}/astra-published-platforms.XXXXXX")"
+trap 'rm -f "${candidate_platforms_file}" "${actual_platforms_file}"' EXIT HUP INT TERM
+platform_digest_set "${target}" > "${actual_platforms_file}"
+sort -u -o "${actual_platforms_file}" "${actual_platforms_file}"
+
+if ! cmp -s "${candidate_platforms_file}" "${actual_platforms_file}"; then
+    echo "published manifest ${target} does not match the verified candidates" >&2
+    diff "${candidate_platforms_file}" "${actual_platforms_file}" || true
+    exit 1
+fi
+
+echo "verified ${target}:"
+sed 's/^/  /' "${actual_platforms_file}"

--- a/scripts/validate-release-version.sh
+++ b/scripts/validate-release-version.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-    echo "usage: $0 <version>" >&2
+syntax_only=false
+if [[ $# -eq 2 && "$2" == "--syntax-only" ]]; then
+    syntax_only=true
+elif [[ $# -ne 1 ]]; then
+    echo "usage: $0 <version> [--syntax-only]" >&2
     exit 2
 fi
 
@@ -13,7 +16,7 @@ if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; the
 fi
 
 release_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-python3 - "$release_root" "$release_version" <<'PY'
+python3 - "$release_root" "$release_version" "$syntax_only" <<'PY'
 import json
 import re
 import sys
@@ -22,6 +25,7 @@ from pathlib import Path
 
 root = Path(sys.argv[1])
 expected = sys.argv[2]
+syntax_only = sys.argv[3] == "true"
 
 core, separator, prerelease = expected.partition("-")
 core_identifiers = core.split(".")
@@ -40,6 +44,10 @@ if separator:
         for identifier in prerelease_identifiers
     ):
         raise SystemExit(f"invalid semantic prerelease version: {expected}")
+
+if syntax_only:
+    print(f"release version syntax is valid: {expected}")
+    raise SystemExit(0)
 
 with (root / "Cargo.toml").open("rb") as manifest:
     document = tomllib.load(manifest)

--- a/scripts/validate-release-version.sh
+++ b/scripts/validate-release-version.sh
@@ -23,6 +23,24 @@ from pathlib import Path
 root = Path(sys.argv[1])
 expected = sys.argv[2]
 
+core, separator, prerelease = expected.partition("-")
+core_identifiers = core.split(".")
+if len(core_identifiers) != 3 or any(
+    not identifier.isdigit()
+    or (len(identifier) > 1 and identifier.startswith("0"))
+    for identifier in core_identifiers
+):
+    raise SystemExit(f"invalid semantic release version: {expected}")
+if separator:
+    prerelease_identifiers = prerelease.split(".")
+    if any(
+        not identifier
+        or re.fullmatch(r"[0-9A-Za-z-]+", identifier) is None
+        or (identifier.isdigit() and len(identifier) > 1 and identifier.startswith("0"))
+        for identifier in prerelease_identifiers
+    ):
+        raise SystemExit(f"invalid semantic prerelease version: {expected}")
+
 with (root / "Cargo.toml").open("rb") as manifest:
     document = tomllib.load(manifest)
 
@@ -40,7 +58,18 @@ with (root / "packages/sdk/package-lock.json").open(encoding="utf-8") as package
     versions["TypeScript SDK lockfile"] = json.load(package)["version"]
 
 with (root / "web/package-lock.json").open(encoding="utf-8") as package:
-    versions["Web application lockfile"] = json.load(package)["version"]
+    web_lock = json.load(package)
+    versions["Web application lockfile"] = web_lock["version"]
+    local_sdk_versions = {
+        entry["version"]
+        for entry in web_lock["packages"].values()
+        if entry.get("name") == "@astra/sdk" and "version" in entry
+    }
+    if len(local_sdk_versions) != 1:
+        raise SystemExit(
+            "web/package-lock.json: expected one version for the linked @astra/sdk package"
+        )
+    versions["Web lockfile linked SDK"] = local_sdk_versions.pop()
 
 with (root / "Cargo.lock").open("rb") as lockfile:
     locked_packages = tomllib.load(lockfile)["package"]
@@ -62,6 +91,31 @@ versions["Helm chart"] = yaml_scalar(
 versions["Helm appVersion"] = yaml_scalar(
     root / "deployment/kubernetes/chart/Chart.yaml", "appVersion"
 )
+
+def env_value(path: Path, key: str) -> str:
+    pattern = re.compile(rf"^{re.escape(key)}=(.*)$")
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if match := pattern.match(line):
+            return match.group(1).strip()
+    raise SystemExit(f"{path}: missing {key}")
+
+stack_env = root / "deployment/all-in-one/.env.example"
+versions["All-in-one Astra image"] = env_value(stack_env, "ASTRA_IMAGE").removeprefix(
+    "matrixorigin/astra:"
+)
+versions["Production Astra image"] = env_value(
+    root / ".env.production.example", "ASTRA_IMAGE"
+).removeprefix("matrixorigin/astra:")
+
+for key, repository in (
+    ("MEMORIA_IMAGE", "matrixorigin/memoria"),
+    ("MATRIXONE_IMAGE", "matrixorigin/matrixone"),
+):
+    value = env_value(stack_env, key)
+    if re.fullmatch(rf"{re.escape(repository)}@sha256:[0-9a-f]{{64}}", value) is None:
+        raise SystemExit(
+            f"{stack_env}: {key} must pin {repository} by a full sha256 manifest digest"
+        )
 
 mismatches = {name: value for name, value in versions.items() if value != expected}
 if mismatches:


### PR DESCRIPTION
## Summary

This PR systematizes Astra's release and upgrade journey around one protected control plane:

- add a unified `Release Astra` workflow that selects the current default-branch source, verifies client and Server candidates, creates the annotated tag only after verification, publishes the exact Docker manifest and GitHub Release, then promotes stable rolling tags;
- build and smoke-test Linux AMD64/ARM64 Server candidates through the documented All-in-One stack, reconcile immutable platform digests, and make retries/recovery ownership-safe;
- keep Docker snapshot publication separate from semantic releases, with source, tag, architecture, and overwrite guards;
- add `make release-prepare VERSION=X.Y.Z` and a read-only `make release-check VERSION=X.Y.Z` preflight;
- synchronize Cargo, SDK, Web, lockfiles, CITATION, Helm, Compose, and production release metadata;
- make installer upgrades checksum-verified, version-matched, and rollback-safe for the CLI + User Runner pair;
- remove runtime version drift and require locked Docker/Cargo resolution;
- improve CI workflow validation, release contracts, archive/manifest tests, documentation, and supported-platform guidance.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `make release-check VERSION=0.1.0`
- 41 CI contract/unit tests
- installer success, rollback, tamper, checksum, and archive-layout contracts
- Docker manifest creation, recovery, and duplicate-platform contracts
- targeted Rust HTTP contract test
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps`
- Docker Compose config validation
- `git diff --check`

No full image build or full CI suite was run locally.

## Maintainer setup required before first publication

- create protected `release` and `release-snapshot` Environments with required reviewers and `main` branch restrictions;
- add the environment guard secrets documented in `docs/guides/releasing.md`;
- add least-privilege `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` Actions secrets;
- configure tag rules for immutable `v*` tags.
