### PR TITLE
fix(runtime): stream LLM start before provider response

### DIFF
--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -6029,6 +6029,15 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 attempt = attempt_in_round,
                 "durable inference admission completed"
             );
+            if let Some(ref emitter) = state.messaging.progress_emitter {
+                emitter.llm_call_started(state.llm_rounds_completed as u32);
+            } else {
+                self.emit_progress_event(json!({
+                    "type": "agent_progress",
+                    "status": "llm_call_started",
+                    "turn": state.llm_rounds_completed,
+                }));
+            }
             state
                 .step_recorder
                 .begin_llm_round(&llm_cfg.model_name, state.inference_purpose);
@@ -13183,6 +13192,7 @@ mod tests {
 
         let observe_first_text = async {
             let mut visible_order = Vec::new();
+            let mut saw_llm_call_started = false;
             loop {
                 let event = tokio::time::timeout(Duration::from_millis(500), rx.recv())
                     .await
@@ -13192,11 +13202,24 @@ mod tests {
                     .get("type")
                     .and_then(Value::as_str)
                     .unwrap_or_default();
+                if event_type == "agent_progress"
+                    && event.get("status").and_then(Value::as_str) == Some("llm_call_started")
+                {
+                    assert!(
+                        !provider_completed.load(Ordering::SeqCst),
+                        "LLM start waited for provider response completion"
+                    );
+                    saw_llm_call_started = true;
+                }
                 if matches!(event_type, "reasoning_delta" | "text_delta") {
                     visible_order.push(event_type.to_string());
                 }
                 if event_type == "text_delta" {
                     assert_eq!(event["content"].as_str(), Some("visible first"));
+                    assert!(
+                        saw_llm_call_started,
+                        "visible provider output arrived before the LLM start lifecycle event"
+                    );
                     assert!(
                         !provider_completed.load(Ordering::SeqCst),
                         "text-first control window waited for the full provider response"

--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -6030,7 +6030,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 "durable inference admission completed"
             );
             if let Some(ref emitter) = state.messaging.progress_emitter {
-                emitter.llm_call_started(state.llm_rounds_completed as u32);
+                emitter.llm_call_started(state.llm_rounds_completed);
             } else {
                 self.emit_progress_event(json!({
                     "type": "agent_progress",

--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -6187,6 +6187,16 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 .await
             };
 
+            if state.messaging.progress_emitter.is_none() {
+                self.emit_progress_event(json!({
+                    "type": "agent_progress",
+                    "status": "llm_call_completed",
+                    "turn": state.llm_rounds_completed,
+                    "ttft_ms": attempt_first_stream_update_ms,
+                    "duration_ms": llm_round_start.elapsed().as_millis() as u64,
+                }));
+            }
+
             let provider_attempts = durable_invocation.provider_attempt_facts().await;
             if !provider_attempts.is_empty() {
                 if let Some(trace) = state.last_llm_context_manifest_trace.as_mut() {
@@ -11329,6 +11339,37 @@ mod tests {
         state
     }
 
+    fn assert_root_llm_progress_pairs(events: &[Value], expected_pairs: usize) {
+        let lifecycle: Vec<_> = events
+            .iter()
+            .filter(|event| {
+                event.get("type").and_then(Value::as_str) == Some("agent_progress")
+                    && matches!(
+                        event.get("status").and_then(Value::as_str),
+                        Some("llm_call_started" | "llm_call_completed")
+                    )
+            })
+            .collect();
+        assert_eq!(
+            lifecycle.len(),
+            expected_pairs * 2,
+            "each provider attempt must emit one exact LLM lifecycle pair: {lifecycle:?}"
+        );
+        for pair in lifecycle.chunks_exact(2) {
+            assert_eq!(
+                pair[0].get("status").and_then(Value::as_str),
+                Some("llm_call_started")
+            );
+            assert_eq!(
+                pair[1].get("status").and_then(Value::as_str),
+                Some("llm_call_completed")
+            );
+            assert_eq!(pair[0].get("turn"), pair[1].get("turn"));
+            assert!(pair[1].get("ttft_ms").is_some());
+            assert!(pair[1].get("duration_ms").and_then(Value::as_u64).is_some());
+        }
+    }
+
     #[derive(Clone)]
     struct GatewayState {
         requests: Arc<tokio::sync::Mutex<Vec<Value>>>,
@@ -13237,6 +13278,7 @@ mod tests {
             host.take_terminal_control_outcome(),
             None | Some(crate::turn::terminal_control::TerminalControlOutcome::Passthrough)
         ));
+        assert_root_llm_progress_pairs(&host.take_emitted_events(), 1);
         inference_ledger.assert_quiescent();
         server.abort();
     }
@@ -13642,7 +13684,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let _guard = astra_services::session_journal::JournalDirGuard::new(temp.path());
         let session_id = "00000000-0000-0000-0000-000000000127";
-        let (gateway_url, _requests, server) = spawn_gateway(
+        let (gateway_url, requests, server) = spawn_gateway(
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             json!({"error": {"message": "upstream exploded"}}),
         )
@@ -13675,6 +13717,8 @@ mod tests {
             Err(error) => error,
         };
         assert_eq!(error.kind, astra_core::ErrorKind::ServerError);
+        let emitted_events = host.take_emitted_events();
+        assert_root_llm_progress_pairs(&emitted_events, 1);
 
         state
             .turn_event_buffer
@@ -13722,6 +13766,10 @@ mod tests {
         assert_eq!(
             llm_events[1]["metadata"]["trace"]["session_turn_source"].as_str(),
             Some("state")
+        );
+        assert!(
+            requests.lock().await.len() > 1,
+            "transport retries must stay inside one LLM lifecycle pair"
         );
 
         inference_ledger.assert_quiescent();

--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -6029,9 +6029,7 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                 attempt = attempt_in_round,
                 "durable inference admission completed"
             );
-            if let Some(ref emitter) = state.messaging.progress_emitter {
-                emitter.llm_call_started(state.llm_rounds_completed);
-            } else {
+            if state.messaging.progress_emitter.is_none() {
                 self.emit_progress_event(json!({
                     "type": "agent_progress",
                     "status": "llm_call_started",

--- a/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -878,10 +878,6 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
     turn_index: usize,
     prep: TurnIterationPrep,
 ) -> Result<TurnExecutionControl, astra_core::ClassifiedError> {
-    if let Some(ref emitter) = state.messaging.progress_emitter {
-        emitter.llm_call_started(turn_index as u32);
-    }
-
     inject_polled_user_intents(host, state).await?;
 
     // Policy evidence always reaches the model. Interaction mode controls only

--- a/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -1363,6 +1363,9 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
         messages = pre_llm_messages.len(),
         "LLM call started"
     );
+    if let Some(ref emitter) = state.messaging.progress_emitter {
+        emitter.llm_call_started(turn_index as u32);
+    }
     let turn_result = host.execute_turn(state).await;
     // `text_only` applies to exactly one model boundary. Clear it as soon as
     // the host returns, including error paths, so a failed settlement request

--- a/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -878,6 +878,10 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
     turn_index: usize,
     prep: TurnIterationPrep,
 ) -> Result<TurnExecutionControl, astra_core::ClassifiedError> {
+    if let Some(ref emitter) = state.messaging.progress_emitter {
+        emitter.llm_call_started(turn_index as u32);
+    }
+
     inject_polled_user_intents(host, state).await?;
 
     // Policy evidence always reaches the model. Interaction mode controls only
@@ -1363,9 +1367,6 @@ pub(crate) async fn execute_turn_and_ingest_phase<H: AgenticLoopHost>(
         messages = pre_llm_messages.len(),
         "LLM call started"
     );
-    if let Some(ref emitter) = state.messaging.progress_emitter {
-        emitter.llm_call_started(turn_index as u32);
-    }
     let turn_result = host.execute_turn(state).await;
     // `text_only` applies to exactly one model boundary. Clear it as soon as
     // the host returns, including error paths, so a failed settlement request


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] test
- [ ] docs
- [ ] chore

## Which issue(s) this PR fixes

N/A

## What this PR does / why we need it

The Server runtime previously emitted `llm_call_started` from the generic agentic-loop entry point. Root Server runs do not own that typed progress emitter, so consumers could only infer the model call from the first reasoning/text/usage event after the provider stream opened. This made the UI report “calling” several seconds after Astra had already started the provider request.

This change emits the existing `agent_progress` LLM lifecycle for root Server runs around the actual provider future: `llm_call_started` after durable inference admission and immediately before dispatch, followed by exactly one `llm_call_completed` as soon as the provider future returns. Completion is emitted for success and error before post-provider persistence. Transport retries inside that provider future remain one lifecycle pair; a new host-level provider attempt produces its own pair.

Existing sub-runs retain the canonical typed-emitter lifecycle unchanged. The root lifecycle is enabled only when no typed progress emitter exists, preventing duplicate events.

No request/response schema, database schema, model behavior, tool behavior, or CLI execution path changes.

## Architecture and complexity delta

- Canonical owner changed or extended: `ServerAgenticLoopHost`, which owns durable inference admission and the outbound provider-call boundary for root Server runs.
- Existing implementations/callers searched: generic agentic-loop progress emission, Server event streaming, provider attempt observers, lifecycle fanout, and delayed/error provider tests.
- Superseded code, states, tables, shims, and self-only tests removed: N/A; the existing scoped lifecycle remains unchanged.
- Net code/state/table delta: one production call-site pair and focused assertions in existing tests; no new state or tables.
- If parallel implementations remain, the external boundary and retirement condition: the typed-emitter path owns sub-run lifecycle; the mutually exclusive root Server path owns root lifecycle.

## Production wiring and verification

- Public product entrypoint exercised: Server `execute_turn` streaming path with a delayed provider gateway.
- Unhappy paths exercised: provider HTTP 500 plus multiple internal transport retries still emit one closed lifecycle pair.
- Database schema/query/transaction/migration verified against a real database, or `N/A` with reason: N/A; no schema, query, transaction, or migration changes.

Verification:

- `cargo fmt --check`
- `cargo clippy -p astra-runtime --all-targets -- -D warnings`
- `cargo test -p astra-runtime --lib text_first_control_window_streams_before_provider_completion`
- `cargo test -p astra-runtime --lib execute_turn_persists_full_journal_error_response_when_session_capture_enabled`
