### PR TITLE
fix(cli): align nested git action contracts

### DIFF
--- a/crates/astra-cli/src/cli/journal_digest.rs
+++ b/crates/astra-cli/src/cli/journal_digest.rs
@@ -399,6 +399,32 @@ fn tool_call_stats(calls: Option<&Vec<session_journal::ToolCallRecord>>) -> Tool
     stats
 }
 
+fn authoritative_tool_call_stats(event: &session_journal::JournalEvent) -> ToolCallStats {
+    let record_stats = tool_call_stats(event.tool_calls.as_ref());
+    let record_count = event.tool_calls.as_ref().map_or(0, Vec::len);
+    let Some(outcomes) = event
+        .tool_outcomes
+        .as_ref()
+        .filter(|outcomes| outcomes.is_consistent())
+        .filter(|outcomes| outcomes.requested as usize > record_count)
+    else {
+        return record_stats;
+    };
+
+    ToolCallStats {
+        ok: outcomes
+            .succeeded
+            .saturating_add(outcomes.reused)
+            .saturating_add(outcomes.suppressed),
+        fail: outcomes
+            .failed
+            .saturating_add(outcomes.rejected)
+            .saturating_add(outcomes.deferred),
+        fresh: outcomes.succeeded,
+        noop_or_cached: outcomes.reused.saturating_add(outcomes.suppressed),
+    }
+}
+
 /// Treat a tool call as a failure when either:
 /// - transport reports failure (`ok == false`), OR
 /// - transport succeeded but the result body encodes an error that the
@@ -783,7 +809,7 @@ pub fn build_digest(session_id: &str, focus: DigestFocus) -> Result<JournalDiges
                     total_root_llm_rounds += u64::from(rounds);
                     root_attempts_with_llm_rounds += 1;
                 }
-                let stats = tool_call_stats(ev.tool_calls.as_ref());
+                let stats = authoritative_tool_call_stats(ev);
                 let (reentry_c, locked_out_c) = skill_reentry_counts(ev.tool_calls.as_ref());
                 // Fallback: if tool_calls Vec is absent, use tool_count scalar.
                 let effective_total = if stats.total() > 0 {
@@ -951,7 +977,7 @@ pub fn build_digest(session_id: &str, focus: DigestFocus) -> Result<JournalDiges
                     total_root_llm_rounds += u64::from(rounds);
                     root_attempts_with_llm_rounds += 1;
                 }
-                let stats = tool_call_stats(ev.tool_calls.as_ref());
+                let stats = authoritative_tool_call_stats(ev);
                 let effective_total = if stats.total() > 0 {
                     u64::from(stats.total())
                 } else {
@@ -2320,6 +2346,26 @@ mod tests {
         assert!(d.failed_tool_calls.is_empty());
         // But aggregate counts still work
         assert_eq!(d.aggregates.tool_calls_failed, 1);
+    }
+
+    #[test]
+    fn digest_uses_remote_tool_outcomes_when_call_details_are_absent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _g = JournalDirGuard::new(tmp.path());
+
+        let sid = "test-remote-outcomes-00000000-0000-0000-0000-000000000014";
+        fs::write(
+            journal_path_for_test(sid),
+            r#"{"type":"turn","ts":"2026-01-01T00:00:00Z","session_id":"S","turn":1,"tool_count":3,"tool_outcomes":{"requested":4,"executed":3,"succeeded":2,"failed":1,"rejected":1,"reused":0,"suppressed":0,"deferred":0}}"#,
+        )
+        .expect("write journal");
+
+        let d = build_digest(sid, DigestFocus::Summary).expect("digest");
+        assert_eq!(d.aggregates.total_tool_calls, 4);
+        assert_eq!(d.aggregates.total_fresh_tool_calls, 2);
+        assert_eq!(d.aggregates.tool_calls_failed, 2);
+        assert_eq!(d.turns[0].tool_calls_ok, 2);
+        assert_eq!(d.turns[0].tool_calls_fail, 2);
     }
 
     #[test]

--- a/crates/astra-cli/src/cli/session/session_side_effects.rs
+++ b/crates/astra-cli/src/cli/session/session_side_effects.rs
@@ -319,6 +319,7 @@ pub(crate) fn append_one_shot_journal_events(
     .with_budget_pressure(result.budget_pressure)
     .with_cache_tokens(result.cache_read_tokens, result.cache_creation_tokens)
     .with_conversation_commit(prepared.commit);
+    result.apply_canonical_tool_outcomes(&mut turn_event);
     turn_event.llm_rounds = result.llm_rounds;
     // Content redaction is allowed to suppress the embedded commit. Do not
     // advertise a canonical settlement when the exact intended commit will
@@ -474,6 +475,18 @@ mod tests {
 
         let mut second = crate::tests::stub_stream_result("second answer");
         second.tool_calls_count = 2;
+        second.tool_ledger_aggregate =
+            astra_turn_core::tool_ledger_receipt::ToolLedgerCanonicalAggregate {
+                attempted: 2,
+                terminal: 2,
+                unresolved: 0,
+                result_classes: astra_turn_core::tool_ledger_receipt::ToolLedgerResultClassCounts {
+                    succeeded: 1,
+                    failed: 1,
+                    ..Default::default()
+                },
+                consistent: true,
+            };
         second.tools_used = vec!["tool_search".to_string(), "agent".to_string()];
         second.llm_rounds = Some(3);
         append_one_shot_journal_events(
@@ -521,6 +534,8 @@ mod tests {
             Some(["agent".to_string(), "tool_search".to_string()].as_slice())
         );
         assert!(turns[1].tool_calls.is_none());
+        assert_eq!(turns[1].tool_outcomes.as_ref().unwrap().succeeded, 1);
+        assert_eq!(turns[1].tool_outcomes.as_ref().unwrap().failed, 1);
         assert_eq!(turns[1].llm_rounds, Some(3));
         let traces: Vec<_> = events
             .iter()

--- a/crates/astra-cli/src/cli/stream/streaming_types.rs
+++ b/crates/astra-cli/src/cli/stream/streaming_types.rs
@@ -337,6 +337,42 @@ pub(crate) struct StreamResult {
 }
 
 impl StreamResult {
+    /// Project the complete run-total ledger into the durable journal shape.
+    /// Per-call records may be absent or only cover the Edge wrapper for a
+    /// Server-owned run, so every CLI entrypoint must use this aggregate when
+    /// it is internally complete.
+    pub(crate) fn canonical_tool_outcomes(
+        &self,
+    ) -> Option<astra_services::session_journal::ToolOutcomeSummary> {
+        let aggregate = self.tool_ledger_aggregate;
+        if !aggregate.is_complete_for(self.tool_calls_count) {
+            return None;
+        }
+        let classes = aggregate.result_classes;
+        let outcomes = astra_services::session_journal::ToolOutcomeSummary {
+            requested: aggregate.attempted,
+            executed: classes.succeeded.saturating_add(classes.failed),
+            succeeded: classes.succeeded,
+            failed: classes.failed,
+            rejected: classes.rejected,
+            reused: classes.reused,
+            suppressed: classes.suppressed,
+            deferred: 0,
+        };
+        outcomes.is_consistent().then_some(outcomes)
+    }
+
+    pub(crate) fn apply_canonical_tool_outcomes(
+        &self,
+        event: &mut astra_services::session_journal::JournalEvent,
+    ) {
+        let Some(outcomes) = self.canonical_tool_outcomes() else {
+            return;
+        };
+        event.tool_count = Some(outcomes.executed);
+        event.tool_outcomes = Some(outcomes);
+    }
+
     /// Merge terminal background-agent outputs into the user-facing aggregate
     /// response used by one-shot CLI and server surfaces.
     ///

--- a/crates/astra-cli/src/cli/turn/turn_commit.rs
+++ b/crates/astra-cli/src/cli/turn/turn_commit.rs
@@ -642,6 +642,11 @@ fn build_primary_turn_event(
     )
     .with_memoria_time(result.memoria_ms)
     .with_cache_tokens(result.cache_read_tokens, result.cache_creation_tokens);
+    // Server-owned runs expose a complete fixed-size ledger aggregate even
+    // though the Edge cannot retain their per-call records. Persist that
+    // authority alongside any local detail window so offline journal tools do
+    // not silently turn remote failures into successes.
+    result.apply_canonical_tool_outcomes(&mut turn_event);
     turn_event =
         turn_event.with_applied_user_intents(result.applied_user_intents.iter().map(|intent| {
             (
@@ -841,13 +846,25 @@ mod tests {
     }
 
     #[test]
-    fn server_only_tool_details_remain_unknown_in_cli_projection() {
+    fn server_only_tool_details_keep_authoritative_outcomes_in_cli_projection() {
         let state = SessionState {
             turn: 1,
             ..Default::default()
         };
         let mut result = crate::tests::stub_stream_result("done");
         result.tool_calls_count = 2;
+        result.tool_ledger_aggregate =
+            astra_turn_core::tool_ledger_receipt::ToolLedgerCanonicalAggregate {
+                attempted: 2,
+                terminal: 2,
+                unresolved: 0,
+                result_classes: astra_turn_core::tool_ledger_receipt::ToolLedgerResultClassCounts {
+                    succeeded: 1,
+                    failed: 1,
+                    ..Default::default()
+                },
+                consistent: true,
+            };
         result.tools_used = vec!["bash".into(), "git".into()];
         result.tool_call_records.clear();
 
@@ -855,6 +872,18 @@ mod tests {
         let (event, _) = build_primary_turn_event(&state, "review", &mut result, Instant::now());
         assert_eq!(event.total_tool_ms, None);
         assert_eq!(event.total_llm_ms, None);
+        assert!(event.tool_calls.is_none());
+        assert_eq!(event.tool_count, Some(2));
+        assert_eq!(
+            event.tool_outcomes,
+            Some(session_journal::ToolOutcomeSummary {
+                requested: 2,
+                executed: 2,
+                succeeded: 1,
+                failed: 1,
+                ..Default::default()
+            })
+        );
 
         let learning = analyze_chat_turn_learning("review", state.turn, &[], &result);
         let mut sidecars = Vec::new();

--- a/crates/astra-cli/src/edge_tools.rs
+++ b/crates/astra-cli/src/edge_tools.rs
@@ -230,17 +230,6 @@ pub(crate) fn is_plan_mode_blocked_tool(tool: &str, args: &Value) -> bool {
     astra_turn_core::plan_mode_policy::is_plan_mode_blocked_tool(tool, args)
 }
 
-fn git_stash_sub_action_args(args: &Value) -> Value {
-    let sub_action = args.get("sub_action").and_then(Value::as_str);
-    let Some(sub_action) = sub_action else {
-        return args.clone();
-    };
-
-    let mut map = args.as_object().cloned().unwrap_or_default();
-    map.insert("action".to_string(), Value::String(sub_action.to_string()));
-    Value::Object(map)
-}
-
 #[path = "edge_tools/diagnose.rs"]
 mod diagnose;
 #[path = "edge_tools/file_state.rs"]
@@ -4645,7 +4634,23 @@ impl ToolExecutor {
                     return outcome;
                 }
                 astra_tools::git_tool_contract::GitAction::Stash => {
-                    let Some(_workspace_mutation_lease) =
+                    if let Err(error) =
+                        astra_tools::git_gix::validate_git_request(&self.project_root, args)
+                    {
+                        return EdgeToolRun::failure_evidence(error.message, error.evidence)
+                            .into_outcome();
+                    }
+                    let stash_action =
+                        match astra_tools::git_tool_contract::git_stash_sub_action_from_args(args) {
+                            Ok(action) => action,
+                            Err(error) => {
+                                return ToolExecutionOutcome::error(format!("Error: {error}"));
+                            }
+                        };
+                    // Read-only stash listing follows the ordinary path so it
+                    // does not contend on the workspace mutation lease.
+                    if stash_action.mutates_workspace() {
+                        let Some(_workspace_mutation_lease) =
                         astra_tools::workspace_observation::acquire_workspace_mutation_lease_with_options(
                             &self.project_root,
                             cancel_token,
@@ -4660,17 +4665,37 @@ impl ToolExecutor {
                             "workspace coordination lock was unavailable, contended, or the host temporary lock namespace is not trustworthy; no git stash was run. Retry after the active writer finishes or repair the host temporary-directory ownership and sticky-bit permissions".to_string(),
                         );
                     };
-                    if cancel_token.is_some_and(tokio_util::sync::CancellationToken::is_cancelled) {
-                        return cancelled_tool_execution_outcome("git", false);
+                        if cancel_token
+                            .is_some_and(tokio_util::sync::CancellationToken::is_cancelled)
+                        {
+                            return cancelled_tool_execution_outcome("git", false);
+                        }
+                        let mut outcome = self.stash_with_metadata(args);
+                        outcome.output = self.finalize_tool_output(outcome.output, name);
+                        self.record_output_size(outcome.output.len());
+                        return outcome;
                     }
-                    let stash_args = git_stash_sub_action_args(args);
-                    let mut outcome = self.stash_with_metadata(&stash_args);
-                    outcome.output = self.finalize_tool_output(outcome.output, name);
-                    self.record_output_size(outcome.output.len());
-                    return outcome;
                 }
                 astra_tools::git_tool_contract::GitAction::Worktree => {
-                    let Some(_workspace_mutation_lease) =
+                    if let Err(error) =
+                        astra_tools::git_gix::validate_git_request(&self.project_root, args)
+                    {
+                        return EdgeToolRun::failure_evidence(error.message, error.evidence)
+                            .into_outcome();
+                    }
+                    let worktree_action =
+                        match astra_tools::git_tool_contract::git_worktree_sub_action_from_args(
+                            args,
+                        ) {
+                            Ok(action) => action,
+                            Err(error) => {
+                                return ToolExecutionOutcome::error(format!("Error: {error}"));
+                            }
+                        };
+                    // `list` is a pure observation and must not wait for a
+                    // writer lease held by an unrelated operation.
+                    if worktree_action.mutates_workspace() {
+                        let Some(_workspace_mutation_lease) =
                         astra_tools::workspace_observation::acquire_workspace_mutation_lease_with_options(
                             &self.project_root,
                             cancel_token,
@@ -4685,13 +4710,16 @@ impl ToolExecutor {
                             "workspace coordination lock was unavailable, contended, or the host temporary lock namespace is not trustworthy; no git worktree was run. Retry after the active writer finishes or repair the host temporary-directory ownership and sticky-bit permissions".to_string(),
                         );
                     };
-                    if cancel_token.is_some_and(tokio_util::sync::CancellationToken::is_cancelled) {
-                        return cancelled_tool_execution_outcome("git", false);
+                        if cancel_token
+                            .is_some_and(tokio_util::sync::CancellationToken::is_cancelled)
+                        {
+                            return cancelled_tool_execution_outcome("git", false);
+                        }
+                        let mut outcome = self.worktree_with_metadata(args);
+                        outcome.output = self.finalize_tool_output(outcome.output, name);
+                        self.record_output_size(outcome.output.len());
+                        return outcome;
                     }
-                    let mut outcome = self.worktree_with_metadata(args);
-                    outcome.output = self.finalize_tool_output(outcome.output, name);
-                    self.record_output_size(outcome.output.len());
-                    return outcome;
                 }
                 astra_tools::git_tool_contract::GitAction::Status
                 | astra_tools::git_tool_contract::GitAction::Diff
@@ -5215,10 +5243,7 @@ impl ToolExecutor {
                         astra_tools::git_tool_contract::GitAction::RevertCommit => {
                             self.revert_commit(args)
                         }
-                        astra_tools::git_tool_contract::GitAction::Stash => {
-                            let stash_args = git_stash_sub_action_args(args);
-                            self.stash(&stash_args)
-                        }
+                        astra_tools::git_tool_contract::GitAction::Stash => self.stash(args),
                         astra_tools::git_tool_contract::GitAction::CheckoutFile => {
                             self.checkout_file(args)
                         }
@@ -6317,8 +6342,8 @@ mod tests {
         background_task_output_result_fields, cli_default_capabilities, cli_tool_output_is_error,
         detect_git_remote_repos, embedded_work_unit_observation, extract_github_owner_repo,
         file_checkpoint_dir_for, format_background_task_error, format_background_task_output,
-        format_background_task_output_wait_timeout, format_background_task_stop_error,
-        git_stash_sub_action_args, memoria, parse_memory_search_contents, utf16_col_to_char_idx,
+        format_background_task_output_wait_timeout, format_background_task_stop_error, memoria,
+        parse_memory_search_contents, utf16_col_to_char_idx,
     };
     use crate::background_task_error::BackgroundTaskError;
     use crate::lock_recovery::LockRecovery;
@@ -6474,13 +6499,6 @@ mod tests {
         assert_eq!(observation.id, "fanout-group-1");
         assert_eq!(observation.kind, "agent_fanout");
         assert_eq!(observation.status, WorkUnitStatus::Completed);
-    }
-
-    #[test]
-    fn git_stash_bridge_remaps_canonical_sub_action() {
-        let canonical =
-            git_stash_sub_action_args(&serde_json::json!({"action":"stash","sub_action":"push"}));
-        assert_eq!(canonical["action"], "push");
     }
 
     struct ImmediateSpawnExecutor;

--- a/crates/astra-cli/src/edge_tools/git_gix.rs
+++ b/crates/astra-cli/src/edge_tools/git_gix.rs
@@ -528,18 +528,16 @@ impl ToolExecutor {
     }
 
     pub(crate) fn stash_with_metadata(&self, args: &Value) -> super::ToolExecutionOutcome {
-        let action = args
-            .get("action")
-            .and_then(Value::as_str)
-            .map(|action| action.trim().to_ascii_lowercase())
-            .unwrap_or_default();
+        let action = astra_tools::git_tool_contract::git_stash_sub_action_from_args(args).ok();
         let outcome = stash_with_metadata(&self.project_root, args);
-        if matches!(action.as_str(), "push" | "save")
-            && let Some(stash_ref) = outcome
-                .tool_result_fields
-                .as_ref()
-                .and_then(|fields| fields.get("stash_ref"))
-                .and_then(Value::as_str)
+        if matches!(
+            action,
+            Some(astra_tools::git_tool_contract::GitStashSubAction::Push)
+        ) && let Some(stash_ref) = outcome
+            .tool_result_fields
+            .as_ref()
+            .and_then(|fields| fields.get("stash_ref"))
+            .and_then(Value::as_str)
         {
             self.record_git_stash_rollback(
                 stash_ref.to_string(),
@@ -548,8 +546,13 @@ impl ToolExecutor {
                     .map(ToString::to_string),
             );
             self.clear_file_state();
-        } else if matches!(action.as_str(), "apply" | "pop")
-            && !outcome.output.starts_with("Error:")
+        } else if matches!(
+            action,
+            Some(
+                astra_tools::git_tool_contract::GitStashSubAction::Apply
+                    | astra_tools::git_tool_contract::GitStashSubAction::Pop
+            )
+        ) && !outcome.output.starts_with("Error:")
         {
             self.clear_file_state();
         }
@@ -657,16 +660,24 @@ impl ToolExecutor {
 
 /// Create, list, or remove git worktrees for isolated parallel work.
 pub fn worktree(project_root: &Path, args: &Value) -> String {
-    let action = match args.get("action").and_then(Value::as_str) {
-        Some(a) => a,
-        None => return "Error: 'action' is required (add, list, remove)".to_string(),
+    let action = match astra_tools::git_tool_contract::git_worktree_sub_action_from_args(args) {
+        Ok(action) => action,
+        Err(error) => return format!("Error: {error}"),
     };
 
     match action {
-        "add" | "create" => worktree_add(project_root, args),
-        "list" | "ls" => worktree_list(project_root),
-        "remove" | "rm" | "delete" => worktree_remove(project_root, args),
-        _ => format!("Error: unknown worktree action '{action}'. Use: add, list, remove"),
+        astra_tools::git_tool_contract::GitWorktreeSubAction::Add => {
+            worktree_add(project_root, args)
+        }
+        astra_tools::git_tool_contract::GitWorktreeSubAction::List => worktree_list(project_root),
+        astra_tools::git_tool_contract::GitWorktreeSubAction::Remove => {
+            worktree_remove(project_root, args)
+        }
+        astra_tools::git_tool_contract::GitWorktreeSubAction::Enter
+        | astra_tools::git_tool_contract::GitWorktreeSubAction::Exit => {
+            "Error: git worktree enter/exit requires the session-aware CLI/edge executor"
+                .to_string()
+        }
     }
 }
 
@@ -2044,7 +2055,7 @@ mod tests {
             "should require action"
         );
         assert!(
-            stash(&root, &json!({"action": "fly"})).contains("unknown stash action"),
+            stash(&root, &json!({"action": "fly"})).contains("unknown git stash sub_action"),
             "should reject unknown action"
         );
     }
@@ -2052,7 +2063,7 @@ mod tests {
     #[test]
     fn git_action_stash_list_works() {
         let root = repo_root();
-        let result = stash(&root, &json!({"action": "list"}));
+        let result = stash(&root, &json!({"action": "stash", "sub_action": "list"}));
         // Should return stash list or "No stashes found"
         assert!(
             result.contains("stash@") || result.contains("No stashes") || result.is_empty(),

--- a/crates/astra-cli/src/edge_tools/tests/schema_tests.rs
+++ b/crates/astra-cli/src/edge_tools/tests/schema_tests.rs
@@ -343,6 +343,17 @@ fn git_commit_and_revert_actions_declare_required_fields() {
         conditional_required_for(git, "worktree"),
         vec!["sub_action".to_string()]
     );
+    let worktree_sub_actions =
+        git["function"]["parameters"]["x-astra-per-action-sub-actions"]["worktree"]
+            .as_array()
+            .expect("git worktree sub_action contract")
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect::<Vec<_>>();
+    assert_eq!(
+        worktree_sub_actions,
+        astra_tools::git_tool_contract::GIT_WORKTREE_SUB_ACTIONS
+    );
 }
 
 #[test]

--- a/crates/astra-cli/src/edge_tools/tests/worktree_tests.rs
+++ b/crates/astra-cli/src/edge_tools/tests/worktree_tests.rs
@@ -157,14 +157,53 @@ fn git_worktree_error_paths() {
     let exe = ToolExecutor::new(dir.path());
 
     // enter without branch
-    let result = exe.worktree(&json!({"action": "enter"}));
+    let result = exe.worktree(&json!({"action": "worktree", "sub_action": "enter"}));
     assert!(result.contains("Error"));
     assert!(result.contains("branch"));
 
     // exit when not in session
-    let result = exe.worktree(&json!({"action": "exit"}));
+    let result = exe.worktree(&json!({"action": "worktree", "sub_action": "exit"}));
     assert!(result.contains("Error"));
     assert!(result.contains("Not in a worktree session"));
+}
+
+#[tokio::test]
+async fn git_worktree_public_contract_dispatches_sub_action() {
+    let dir = init_temp_git_repo();
+    let exe = ToolExecutor::new(dir.path());
+
+    let outcome = exe
+        .execute_with_metadata(
+            "git",
+            &json!({
+                "action": "worktree",
+                "sub_action": "list",
+            }),
+        )
+        .await;
+
+    assert!(
+        !outcome.is_error,
+        "public worktree list failed: {outcome:?}"
+    );
+    assert!(outcome.output.contains("Git Worktrees:"), "{outcome:?}");
+    assert!(!outcome.output.contains("unknown worktree action"));
+}
+
+#[test]
+fn git_worktree_public_contract_reports_sub_action_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = ToolExecutor::new(dir.path());
+
+    let missing = exe.worktree(&json!({"action": "worktree"}));
+    assert!(missing.contains("requires non-empty string field `sub_action`"));
+
+    let unknown = exe.worktree(&json!({
+        "action": "worktree",
+        "sub_action": "teleport",
+    }));
+    assert!(unknown.contains("unknown git worktree sub_action 'teleport'"));
+    assert!(!unknown.contains("unknown worktree action 'worktree'"));
 }
 
 #[tokio::test]
@@ -175,7 +214,8 @@ async fn git_worktree_enter_records_rollback_handle() {
         .store(7, std::sync::atomic::Ordering::Relaxed);
 
     let outcome = exe.worktree_with_metadata(&json!({
-        "action": "enter",
+        "action": "worktree",
+        "sub_action": "enter",
         "branch": "session-demo",
     }));
     assert!(
@@ -192,7 +232,8 @@ async fn git_worktree_enter_records_rollback_handle() {
     assert_eq!(listed_json["total_git_worktree_entries"].as_u64(), Some(1));
 
     let cleanup = exe.worktree(&json!({
-        "action": "exit",
+        "action": "worktree",
+        "sub_action": "exit",
         "exit_action": "remove",
         "discard_changes": true,
     }));

--- a/crates/astra-cli/src/edge_tools/worktree.rs
+++ b/crates/astra-cli/src/edge_tools/worktree.rs
@@ -687,17 +687,13 @@ impl ToolExecutor {
     }
 
     pub(crate) fn worktree_with_metadata(&self, args: &Value) -> super::ToolExecutionOutcome {
-        let action = match args.get("action").and_then(Value::as_str) {
-            Some(a) => a,
-            None => {
-                return super::ToolExecutionOutcome::error(
-                    "Error: 'action' is required (enter, exit, add, list, remove)".to_string(),
-                );
-            }
+        let action = match astra_tools::git_tool_contract::git_worktree_sub_action_from_args(args) {
+            Ok(action) => action,
+            Err(error) => return super::ToolExecutionOutcome::error(format!("Error: {error}")),
         };
 
         match action {
-            "enter" => {
+            astra_tools::git_tool_contract::GitWorktreeSubAction::Enter => {
                 let branch = match args.get("branch").and_then(Value::as_str) {
                     Some(b) if !b.is_empty() => b,
                     _ => {
@@ -747,7 +743,7 @@ impl ToolExecutor {
                     Err(e) => super::ToolExecutionOutcome::error(format!("Error: {e}")),
                 }
             }
-            "exit" => {
+            astra_tools::git_tool_contract::GitWorktreeSubAction::Exit => {
                 let exit_action = args
                     .get("exit_action")
                     .and_then(Value::as_str)
@@ -775,7 +771,7 @@ impl ToolExecutor {
                     Err(e) => super::ToolExecutionOutcome::error(format!("Error: {e}")),
                 }
             }
-            "add" | "create" => {
+            astra_tools::git_tool_contract::GitWorktreeSubAction::Add => {
                 let outcome = super::git_gix::worktree_add_with_metadata(&self.project_root, args);
                 if let Some(fields) = outcome.tool_result_fields.as_ref()
                     && let Some(worktree_path) = fields.get("worktree_path").and_then(Value::as_str)
@@ -801,12 +797,14 @@ impl ToolExecutor {
                 }
                 outcome
             }
-            "list" | "ls" => super::ToolExecutionOutcome {
-                output: super::git_gix::worktree_list(&self.project_root),
-                tool_result_fields: None,
-                is_error: false,
-            },
-            "remove" | "rm" | "delete" => {
+            astra_tools::git_tool_contract::GitWorktreeSubAction::List => {
+                super::ToolExecutionOutcome {
+                    output: super::git_gix::worktree_list(&self.project_root),
+                    tool_result_fields: None,
+                    is_error: false,
+                }
+            }
+            astra_tools::git_tool_contract::GitWorktreeSubAction::Remove => {
                 let normalized_path = args
                     .get("path")
                     .and_then(Value::as_str)
@@ -830,9 +828,6 @@ impl ToolExecutor {
                     is_error,
                 }
             }
-            _ => super::ToolExecutionOutcome::error(format!(
-                "Error: unknown worktree action '{action}'. Use: enter, exit, add, list, remove"
-            )),
         }
     }
 

--- a/crates/astra-harness/src/capability_matrix.rs
+++ b/crates/astra-harness/src/capability_matrix.rs
@@ -127,6 +127,17 @@ pub const CAPABILITY_CASES: &[CapabilityCase] = &[
         },
     },
     CapabilityCase {
+        id: "tools.cli_server.git_worktree_list_contract",
+        quadrant: CapabilityQuadrant::ToolExecution,
+        topology: Topology::CliServer,
+        kind: CaseKind::Happy,
+        boundary: "git(action=worktree, sub_action=list) is projected, admitted, and executed as a read-only Edge operation",
+        system_test: "git_worktree_public_contract_dispatches_sub_action",
+        model_validation: ModelValidation::Probe {
+            case: "git_worktree_list_contract",
+        },
+    },
+    CapabilityCase {
         id: "tools.edge_server.duplicate_callback",
         quadrant: CapabilityQuadrant::ToolExecution,
         topology: Topology::EdgeServer,

--- a/crates/astra-test-harness/cases/git_worktree_list_contract.yaml
+++ b/crates/astra-test-harness/cases/git_worktree_list_contract.yaml
@@ -1,0 +1,57 @@
+name: git_worktree_list_contract
+description: |
+  **What**: Invoke the consolidated Git tool's documented worktree list shape.
+  **Tests**: Model-visible schema, parent/sub-action binding, read-only Edge
+  dispatch, and durable successful tool evidence.
+  **Why**: A dispatcher once routed action=worktree correctly, then incorrectly
+  reused that parent value as the nested action and rejected every documented
+  worktree request.
+  **Pass means**: DeepSeek emits action=worktree with sub_action=list, the Edge
+  executor returns the real Git worktree listing, and no fallback shell is used.
+  **Fail means**: Schema projection, nested validation, execution routing, or
+  durable result classification has drifted.
+prompt: |
+  这是一次只读 Git worktree 契约检查。只调用一次 `git` 工具，参数必须准确使用
+  `action="worktree"` 和 `sub_action="list"`。不要调用 bash 或任何其他工具。
+  收到真实工具结果后，如果结果包含 `Git Worktrees:` 且不是错误，只回复
+  `WORKTREE_LIST_OK`。
+models:
+  - deepseek-v4-flash
+capability: tool_use
+difficulty: 1
+weight: 2.0
+timeout_seconds: 120
+debug_log: true
+criteria:
+  - type: exit_code
+    code: 0
+  - type: journal_tool_call_count
+    name: git
+    min: 1
+    max: 1
+    document: arguments
+    path: /action
+    equals: worktree
+  - type: journal_tool_call_count
+    name: git
+    min: 1
+    max: 1
+    document: arguments
+    path: /sub_action
+    equals: list
+  - type: journal_tool_json_contains
+    name: git
+    document: result
+    path: ""
+    contains: "Git Worktrees:"
+  - type: journal_tool_success_ratio
+    min: 1.0
+    min_calls: 1
+  - type: tools_count_between
+    min: 1
+    max: 1
+  - type: text_contains
+    needle: WORKTREE_LIST_OK
+  - type: turn_rounds_between
+    min: 2
+    max: 4

--- a/crates/astra-tools/src/executor.rs
+++ b/crates/astra-tools/src/executor.rs
@@ -1193,12 +1193,15 @@ pub fn is_workspace_mutation_tool(name: &str, args: &Value) -> bool {
                 crate::git_tool_contract::GitAction::Commit
                 | crate::git_tool_contract::GitAction::RevertCommit
                 | crate::git_tool_contract::GitAction::Push => true,
-                crate::git_tool_contract::GitAction::Stash => args
-                    .get("sub_action")
-                    .and_then(Value::as_str)
-                    .is_some_and(git_stash_sub_action_mutates_workspace),
-                crate::git_tool_contract::GitAction::CheckoutFile
-                | crate::git_tool_contract::GitAction::Worktree => true,
+                crate::git_tool_contract::GitAction::Stash => {
+                    crate::git_tool_contract::git_stash_sub_action_from_args(args)
+                        .is_ok_and(|action| action.mutates_workspace())
+                }
+                crate::git_tool_contract::GitAction::Worktree => {
+                    crate::git_tool_contract::git_worktree_sub_action_from_args(args)
+                        .map_or(true, |action| action.mutates_workspace())
+                }
+                crate::git_tool_contract::GitAction::CheckoutFile => true,
                 crate::git_tool_contract::GitAction::Status
                 | crate::git_tool_contract::GitAction::Diff
                 | crate::git_tool_contract::GitAction::Log
@@ -1251,13 +1254,6 @@ fn validate_host_owned_write_boundary(
     Ok(())
 }
 
-fn git_stash_sub_action_mutates_workspace(action: &str) -> bool {
-    matches!(
-        action,
-        "push" | "save" | "apply" | "pop" | "drop" | "branch"
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::Path;
@@ -1272,6 +1268,25 @@ mod tests {
         let ctx = ToolContext::test(tmp.path());
         let exec = DefaultToolExecutor::new(ctx);
         (tmp, exec)
+    }
+
+    #[test]
+    fn git_nested_read_actions_do_not_claim_workspace_mutation() {
+        for args in [
+            serde_json::json!({"action": "stash", "sub_action": "list"}),
+            serde_json::json!({"action": "worktree", "sub_action": "list"}),
+        ] {
+            assert!(!is_workspace_mutation_tool("git", &args), "{args}");
+        }
+
+        for args in [
+            serde_json::json!({"action": "stash", "sub_action": "push"}),
+            serde_json::json!({"action": "worktree", "sub_action": "enter"}),
+            serde_json::json!({"action": "worktree", "sub_action": "add"}),
+            serde_json::json!({"action": "worktree", "sub_action": "remove"}),
+        ] {
+            assert!(is_workspace_mutation_tool("git", &args), "{args}");
+        }
     }
 
     #[test]

--- a/crates/astra-tools/src/git_gix.rs
+++ b/crates/astra-tools/src/git_gix.rs
@@ -413,7 +413,13 @@ pub fn validate_git_request(
             "Error: git field `paths` is only valid for git(action=diff)",
         ));
     }
-    for candidate in [path, file]
+    // Worktree targets are allowed to be registered sibling paths outside the
+    // repository root. Their authority is checked by the Edge path preflight;
+    // repository file filters remain strictly root-relative here.
+    let repository_path = (action != crate::git_tool_contract::GitAction::Worktree)
+        .then_some(path)
+        .flatten();
+    for candidate in [repository_path, file]
         .into_iter()
         .flatten()
         .chain(paths.iter().flatten().copied())
@@ -469,9 +475,27 @@ pub fn validate_git_request(
         crate::git_tool_contract::GitAction::LogSearch => {
             required_exact_string(args, "query", action)?;
         }
-        crate::git_tool_contract::GitAction::Stash
-        | crate::git_tool_contract::GitAction::Worktree => {
-            required_exact_string(args, "sub_action", action)?;
+        crate::git_tool_contract::GitAction::Stash => {
+            crate::git_tool_contract::git_stash_sub_action_from_args(args).map_err(|error| {
+                GitRequestValidationError::invalid_arguments(format!("Error: {error}"))
+            })?;
+        }
+        crate::git_tool_contract::GitAction::Worktree => {
+            let sub_action = crate::git_tool_contract::git_worktree_sub_action_from_args(args)
+                .map_err(|error| {
+                    GitRequestValidationError::invalid_arguments(format!("Error: {error}"))
+                })?;
+            match sub_action {
+                crate::git_tool_contract::GitWorktreeSubAction::Enter
+                | crate::git_tool_contract::GitWorktreeSubAction::Add => {
+                    required_exact_string(args, "branch", action)?;
+                }
+                crate::git_tool_contract::GitWorktreeSubAction::Remove => {
+                    required_exact_string(args, "path", action)?;
+                }
+                crate::git_tool_contract::GitWorktreeSubAction::Exit
+                | crate::git_tool_contract::GitWorktreeSubAction::List => {}
+            }
         }
         crate::git_tool_contract::GitAction::CheckoutFile => {
             required_exact_string(args, "path", action)?;
@@ -2737,7 +2761,7 @@ pub fn revert_commit_with_metadata(project_root: &Path, args: &Value) -> ToolExe
 /// Stash working tree changes.
 ///
 /// Parameters:
-/// - `action` (required): "push" (save), "apply", "pop" (restore + drop), "list", "drop"
+/// - `sub_action` (required): "push", "apply", "pop" (restore + drop), "list", "drop"
 /// - `message` (optional): description for push
 /// - `index` (optional): stash index for apply/pop/drop (default 0)
 /// - `stash_ref` (optional): exact stash selector or OID for apply
@@ -2746,18 +2770,15 @@ pub fn stash(project_root: &Path, args: &Value) -> String {
 }
 
 pub fn stash_with_metadata(project_root: &Path, args: &Value) -> ToolExecutionOutcome {
-    let action = match args.get("action").and_then(Value::as_str) {
-        Some(a) => a,
-        None => {
-            return ToolExecutionOutcome::error(
-                "Error: 'action' is required (push, apply, pop, list, drop)".to_string(),
-            );
-        }
+    let action = match crate::git_tool_contract::git_stash_sub_action_from_args(args) {
+        Ok(action) => action,
+        Err(error) => return ToolExecutionOutcome::error(format!("Error: {error}")),
     };
+    let action_name = action.as_str();
 
     let mut cmd = std::process::Command::new("git");
     cmd.current_dir(project_root);
-    let before_stash_oid = matches!(action, "push" | "save")
+    let before_stash_oid = matches!(action, crate::git_tool_contract::GitStashSubAction::Push)
         .then(|| {
             std::process::Command::new("git")
                 .args(["rev-parse", "--verify", "refs/stash"])
@@ -2770,34 +2791,29 @@ pub fn stash_with_metadata(project_root: &Path, args: &Value) -> ToolExecutionOu
         .flatten();
 
     match action {
-        "push" | "save" => {
+        crate::git_tool_contract::GitStashSubAction::Push => {
             cmd.arg("stash").arg("push");
             if let Some(msg) = args.get("message").and_then(Value::as_str) {
                 cmd.arg("-m").arg(msg);
             }
         }
-        "apply" => {
+        crate::git_tool_contract::GitStashSubAction::Apply => {
             let selector = match apply_stash_selector(args) {
                 Ok(selector) => selector,
                 Err(error) => return ToolExecutionOutcome::error(error),
             };
             cmd.arg("stash").arg("apply").arg(selector);
         }
-        "pop" => {
+        crate::git_tool_contract::GitStashSubAction::Pop => {
             let selector = stash_index_selector(args);
             cmd.arg("stash").arg("pop").arg(selector);
         }
-        "list" => {
+        crate::git_tool_contract::GitStashSubAction::List => {
             cmd.arg("stash").arg("list");
         }
-        "drop" => {
+        crate::git_tool_contract::GitStashSubAction::Drop => {
             let selector = stash_index_selector(args);
             cmd.arg("stash").arg("drop").arg(selector);
-        }
-        _ => {
-            return ToolExecutionOutcome::error(format!(
-                "Error: unknown stash action '{action}'. Use: push, apply, pop, list, drop"
-            ));
         }
     }
 
@@ -2809,15 +2825,19 @@ pub fn stash_with_metadata(project_root: &Path, args: &Value) -> ToolExecutionOu
                 let result = stdout.trim();
                 let output = if result.is_empty() {
                     match action {
-                        "push" | "save" => "✓ Changes stashed".to_string(),
-                        "list" => "No stashes found".to_string(),
-                        _ => format!("✓ Stash {action} done"),
+                        crate::git_tool_contract::GitStashSubAction::Push => {
+                            "✓ Changes stashed".to_string()
+                        }
+                        crate::git_tool_contract::GitStashSubAction::List => {
+                            "No stashes found".to_string()
+                        }
+                        _ => format!("✓ Stash {action_name} done"),
                     }
                 } else {
                     result.to_string()
                 };
                 let mut tool_result_fields = None;
-                if matches!(action, "push" | "save") {
+                if matches!(action, crate::git_tool_contract::GitStashSubAction::Push) {
                     let after_stash_oid = std::process::Command::new("git")
                         .args(["rev-parse", "--verify", "refs/stash"])
                         .current_dir(project_root)
@@ -2840,12 +2860,14 @@ pub fn stash_with_metadata(project_root: &Path, args: &Value) -> ToolExecutionOu
                     is_error: false,
                 };
                 let applied = match action {
-                    "apply" | "pop" | "drop" => true,
-                    "push" | "save" => outcome
+                    crate::git_tool_contract::GitStashSubAction::Apply
+                    | crate::git_tool_contract::GitStashSubAction::Pop
+                    | crate::git_tool_contract::GitStashSubAction::Drop => true,
+                    crate::git_tool_contract::GitStashSubAction::Push => outcome
                         .tool_result_fields
                         .as_ref()
                         .is_some_and(|fields| fields.contains_key("stash_ref")),
-                    _ => false,
+                    crate::git_tool_contract::GitStashSubAction::List => false,
                 };
                 if applied {
                     outcome = outcome.with_workspace_mutation_applied();
@@ -2858,7 +2880,9 @@ pub fn stash_with_metadata(project_root: &Path, args: &Value) -> ToolExecutionOu
                     // the gix error verbatim and flag as failure explicitly.
                     ToolExecutionOutcome::error(err.to_string())
                 } else {
-                    ToolExecutionOutcome::error(format!("Error: git stash {action} failed: {err}"))
+                    ToolExecutionOutcome::error(format!(
+                        "Error: git stash {action_name} failed: {err}"
+                    ))
                 }
             }
         }
@@ -2979,19 +3003,7 @@ pub fn git_dispatch(project_root: &Path, args: &Value) -> ToolExecutionOutcome {
         crate::git_tool_contract::GitAction::RevertCommit => {
             revert_commit_with_metadata(project_root, args)
         }
-        crate::git_tool_contract::GitAction::Stash => {
-            // Remap: read `sub_action` and set it as `action` for the
-            // inner stash function which expects action ∈ {push,apply,pop,list,drop}.
-            let stash_sub_action = args.get("sub_action").and_then(Value::as_str);
-            let remapped_args = if let Some(sa) = stash_sub_action {
-                let mut map = args.as_object().cloned().unwrap_or_default();
-                map.insert("action".to_string(), Value::String(sa.to_string()));
-                Value::Object(map)
-            } else {
-                args.clone()
-            };
-            stash_with_metadata(project_root, &remapped_args)
-        }
+        crate::git_tool_contract::GitAction::Stash => stash_with_metadata(project_root, args),
         crate::git_tool_contract::GitAction::CheckoutFile => ToolExecutionOutcome::error(
             "Error: git.checkout_file requires a CLI/edge executor with checkout_file support."
                 .to_string(),
@@ -3069,6 +3081,42 @@ mod tests {
                 .unwrap();
 
         assert_eq!(action, crate::git_tool_contract::GitAction::Diff);
+    }
+
+    #[test]
+    fn git_request_validation_enforces_parent_specific_sub_actions() {
+        let dir = TempDir::new().expect("tempdir");
+
+        validate_git_request(
+            dir.path(),
+            &json!({"action": "worktree", "sub_action": "list"}),
+        )
+        .expect("worktree list is a complete read request");
+
+        for args in [
+            json!({"action": "worktree"}),
+            json!({"action": "worktree", "sub_action": "enter"}),
+            json!({"action": "worktree", "sub_action": "remove"}),
+            json!({"action": "stash", "sub_action": "enter"}),
+        ] {
+            let error = validate_git_request(dir.path(), &args)
+                .expect_err("incomplete or cross-parent sub-action must fail");
+            assert_eq!(error.evidence.kind, astra_core::ErrorKind::ToolInvalidArgs);
+            assert_eq!(
+                error.evidence.cause,
+                astra_core::ToolFailureCause::InvalidArguments
+            );
+        }
+
+        validate_git_request(
+            dir.path(),
+            &json!({
+                "action": "worktree",
+                "sub_action": "enter",
+                "branch": "feature/test"
+            }),
+        )
+        .expect("worktree enter with a branch is structurally complete");
     }
 
     #[test]
@@ -4646,7 +4694,7 @@ mod tests {
         let root = repo_root();
         let result = stash(&root, &json!({"action": "fly"}));
         assert!(
-            result.contains("unknown stash action"),
+            result.contains("unknown git stash sub_action"),
             "should reject unknown: {result}"
         );
     }
@@ -4654,7 +4702,7 @@ mod tests {
     #[test]
     fn git_action_stash_list_works() {
         let root = repo_root();
-        let result = stash(&root, &json!({"action": "list"}));
+        let result = stash(&root, &json!({"action": "stash", "sub_action": "list"}));
         // Should return stash list or "No stashes found"
         assert!(
             result.contains("stash@") || result.contains("No stashes") || result.is_empty(),

--- a/crates/astra-tools/src/git_tool_contract.rs
+++ b/crates/astra-tools/src/git_tool_contract.rs
@@ -19,6 +19,17 @@ pub const GIT_ACTIONS: &[&str] = &[
 
 pub const GIT_ACTIONS_DISPLAY: &str = "status, diff, log, show, blame, file_history, log_search, contributors, commit, revert_commit, stash, checkout_file, worktree, push";
 
+/// Canonical model-facing stash sub-actions. Legacy `save` remains accepted by
+/// the executor, but `push` is the single advertised spelling.
+pub const GIT_STASH_SUB_ACTIONS: &[&str] = &["push", "apply", "pop", "list", "drop"];
+pub const GIT_STASH_SUB_ACTIONS_DISPLAY: &str = "push, apply, pop, list, drop";
+
+/// Canonical model-facing worktree sub-actions. `enter` and `exit` are part of
+/// the Edge session contract, while `add`, `list`, and `remove` wrap Git's
+/// persistent worktree operations.
+pub const GIT_WORKTREE_SUB_ACTIONS: &[&str] = &["enter", "exit", "add", "list", "remove"];
+pub const GIT_WORKTREE_SUB_ACTIONS_DISPLAY: &str = "enter, exit, add, list, remove";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GitAction {
     Status,
@@ -35,6 +46,56 @@ pub enum GitAction {
     CheckoutFile,
     Worktree,
     Push,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitStashSubAction {
+    Push,
+    Apply,
+    Pop,
+    List,
+    Drop,
+}
+
+impl GitStashSubAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Push => "push",
+            Self::Apply => "apply",
+            Self::Pop => "pop",
+            Self::List => "list",
+            Self::Drop => "drop",
+        }
+    }
+
+    pub fn mutates_workspace(self) -> bool {
+        !matches!(self, Self::List)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitWorktreeSubAction {
+    Enter,
+    Exit,
+    Add,
+    List,
+    Remove,
+}
+
+impl GitWorktreeSubAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Enter => "enter",
+            Self::Exit => "exit",
+            Self::Add => "add",
+            Self::List => "list",
+            Self::Remove => "remove",
+        }
+    }
+
+    pub fn mutates_workspace(self) -> bool {
+        !matches!(self, Self::List)
+    }
 }
 
 impl GitAction {
@@ -96,6 +157,61 @@ pub fn git_action_from_args(args: &Value) -> Result<GitAction, String> {
     }
 }
 
+fn nested_action_from_args<'a>(
+    args: &'a Value,
+    parent_action: &str,
+    display: &str,
+) -> Result<&'a str, String> {
+    match args.get("sub_action") {
+        Some(Value::String(action)) if !action.trim().is_empty() => Ok(action),
+        Some(Value::String(_)) | None => {
+            // Internal callers historically passed the nested action through
+            // `action`. Preserve that compatibility without allowing a public
+            // `action=stash|worktree` request to re-enter the old catch-22.
+            if let Some(Value::String(action)) = args.get("action")
+                && action != parent_action
+                && !action.trim().is_empty()
+            {
+                return Ok(action);
+            }
+            Err(format!(
+                "git(action={parent_action}) requires non-empty string field `sub_action`. Use one of: {display}."
+            ))
+        }
+        Some(_) => Err(format!(
+            "field `sub_action` for git(action={parent_action}) must be a string"
+        )),
+    }
+}
+
+pub fn git_stash_sub_action_from_args(args: &Value) -> Result<GitStashSubAction, String> {
+    let action = nested_action_from_args(args, "stash", GIT_STASH_SUB_ACTIONS_DISPLAY)?;
+    match action {
+        "push" | "save" => Ok(GitStashSubAction::Push),
+        "apply" => Ok(GitStashSubAction::Apply),
+        "pop" => Ok(GitStashSubAction::Pop),
+        "list" => Ok(GitStashSubAction::List),
+        "drop" => Ok(GitStashSubAction::Drop),
+        other => Err(format!(
+            "unknown git stash sub_action '{other}'. Use one of: {GIT_STASH_SUB_ACTIONS_DISPLAY}."
+        )),
+    }
+}
+
+pub fn git_worktree_sub_action_from_args(args: &Value) -> Result<GitWorktreeSubAction, String> {
+    let action = nested_action_from_args(args, "worktree", GIT_WORKTREE_SUB_ACTIONS_DISPLAY)?;
+    match action {
+        "enter" => Ok(GitWorktreeSubAction::Enter),
+        "exit" => Ok(GitWorktreeSubAction::Exit),
+        "add" | "create" => Ok(GitWorktreeSubAction::Add),
+        "list" | "ls" => Ok(GitWorktreeSubAction::List),
+        "remove" | "rm" | "delete" => Ok(GitWorktreeSubAction::Remove),
+        other => Err(format!(
+            "unknown git worktree sub_action '{other}'. Use one of: {GIT_WORKTREE_SUB_ACTIONS_DISPLAY}."
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -131,5 +247,52 @@ mod tests {
         let unknown =
             git_action_from_args(&json!({"action": "merge"})).expect_err("unknown must fail");
         assert!(unknown.contains("unknown `git` action 'merge'"));
+    }
+
+    #[test]
+    fn nested_action_parsers_use_sub_action_and_keep_legacy_inner_calls() {
+        assert_eq!(
+            git_stash_sub_action_from_args(&json!({"action": "stash", "sub_action": "list"})),
+            Ok(GitStashSubAction::List)
+        );
+        assert_eq!(
+            git_worktree_sub_action_from_args(&json!({"action": "worktree", "sub_action": "list"})),
+            Ok(GitWorktreeSubAction::List)
+        );
+        assert_eq!(
+            git_stash_sub_action_from_args(&json!({"action": "save"})),
+            Ok(GitStashSubAction::Push)
+        );
+        assert_eq!(
+            git_worktree_sub_action_from_args(&json!({"action": "ls"})),
+            Ok(GitWorktreeSubAction::List)
+        );
+    }
+
+    #[test]
+    fn nested_action_parsers_reject_missing_wrong_type_and_cross_parent_values() {
+        for args in [json!({}), json!({"action": "worktree"})] {
+            let error = git_worktree_sub_action_from_args(&args).unwrap_err();
+            assert!(error.contains("requires non-empty string field `sub_action`"));
+            assert!(error.contains(GIT_WORKTREE_SUB_ACTIONS_DISPLAY));
+        }
+
+        let wrong_type =
+            git_worktree_sub_action_from_args(&json!({"action": "worktree", "sub_action": 7}))
+                .unwrap_err();
+        assert!(wrong_type.contains("must be a string"));
+
+        let wrong_parent =
+            git_stash_sub_action_from_args(&json!({"action": "stash", "sub_action": "enter"}))
+                .unwrap_err();
+        assert!(wrong_parent.contains("unknown git stash sub_action 'enter'"));
+    }
+
+    #[test]
+    fn nested_action_mutation_contract_marks_only_lists_read_only() {
+        assert!(!GitStashSubAction::List.mutates_workspace());
+        assert!(!GitWorktreeSubAction::List.mutates_workspace());
+        assert!(GitStashSubAction::Push.mutates_workspace());
+        assert!(GitWorktreeSubAction::Enter.mutates_workspace());
     }
 }

--- a/crates/astra-tools/src/lib.rs
+++ b/crates/astra-tools/src/lib.rs
@@ -666,12 +666,6 @@ pub const APPROVAL_REQUIRED_TOOLS: &[&str] = &[
     "rollback_database_snapshots",
 ];
 
-fn git_stash_sub_action_requires_approval(args: &Value) -> bool {
-    args.get("sub_action")
-        .and_then(Value::as_str)
-        .is_some_and(|action| matches!(action, "push" | "save" | "apply" | "pop" | "drop"))
-}
-
 /// Returns `true` if this exact tool invocation requires user approval.
 pub fn tool_requires_approval(tool_name: &str, args: &Value) -> bool {
     match tool_name {
@@ -682,7 +676,8 @@ pub fn tool_requires_approval(tool_name: &str, args: &Value) -> bool {
                 | crate::git_tool_contract::GitAction::RevertCommit
                 | crate::git_tool_contract::GitAction::Push => true,
                 crate::git_tool_contract::GitAction::Stash => {
-                    git_stash_sub_action_requires_approval(args)
+                    crate::git_tool_contract::git_stash_sub_action_from_args(args)
+                        .is_ok_and(|action| action.mutates_workspace())
                 }
                 crate::git_tool_contract::GitAction::Status
                 | crate::git_tool_contract::GitAction::Diff

--- a/crates/astra-tools/src/schemas.rs
+++ b/crates/astra-tools/src/schemas.rs
@@ -1456,7 +1456,7 @@ fn all_tool_schemas_core() -> Vec<Value> {
                         },
                         "path": {
                             "type": "string",
-                            "description": "Repository-relative file or directory path. Used by: diff (one filter only), log, blame, checkout_file, contributors. For a diff over more than one path, use `paths`; never concatenate multiple paths into this string."
+                            "description": "File, directory, or worktree path. Repository-relative for diff (one filter only), log, blame, checkout_file, and contributors; used as the worktree target for worktree(remove). For a diff over more than one path, use `paths`; never concatenate multiple paths into this string."
                         },
                         "paths": {
                             "type": "array",
@@ -1526,7 +1526,7 @@ fn all_tool_schemas_core() -> Vec<Value> {
                         },
                         "sub_action": {
                             "type": "string",
-                            "description": "Sub-operation for multi-mode actions. Used by: stash (push/save/pop/apply/drop/list), worktree (add/list/remove)."
+                            "description": "Sub-operation for multi-mode actions. Used by: stash (push/apply/pop/list/drop), worktree (enter/exit/add/list/remove). worktree enter/add require branch; remove requires path."
                         },
                         "index": {
                             "type": "integer",
@@ -1542,7 +1542,28 @@ fn all_tool_schemas_core() -> Vec<Value> {
                         },
                         "branch": {
                             "type": "string",
-                            "description": "Target branch name. Used by: push (required)."
+                            "description": "Target branch name. Required by: push, worktree(enter), and worktree(add)."
+                        },
+                        "new_branch": {
+                            "type": "boolean",
+                            "description": "For worktree(add), create branch when true (default); attach an existing branch when false."
+                        },
+                        "force": {
+                            "type": "boolean",
+                            "description": "For worktree(remove), pass --force. Default false."
+                        },
+                        "delete_branch": {
+                            "type": "boolean",
+                            "description": "For worktree(remove), also delete the associated branch after removal. Default false."
+                        },
+                        "exit_action": {
+                            "type": "string",
+                            "enum": ["keep", "remove"],
+                            "description": "For worktree(exit), keep or remove the session worktree. Default keep."
+                        },
+                        "discard_changes": {
+                            "type": "boolean",
+                            "description": "For worktree(exit, exit_action=remove), allow discarding worktree changes. Default false."
                         },
                         "force_with_lease": {
                             "type": "boolean",
@@ -1564,6 +1585,10 @@ fn all_tool_schemas_core() -> Vec<Value> {
                         "checkout_file": ["path", "ref"],
                         "worktree": ["sub_action"],
                         "push": ["remote", "branch"]
+                    },
+                    "x-astra-per-action-sub-actions": {
+                        "stash": crate::git_tool_contract::GIT_STASH_SUB_ACTIONS,
+                        "worktree": crate::git_tool_contract::GIT_WORKTREE_SUB_ACTIONS
                     }
                 }
             }

--- a/crates/astra-turn-core/src/tool/categories/mod.rs
+++ b/crates/astra-turn-core/src/tool/categories/mod.rs
@@ -714,7 +714,15 @@ pub fn classify(name: &str, args: Option<&serde_json::Value>) -> ToolClassificat
                 if args
                     .and_then(|a| a.get("sub_action"))
                     .and_then(|v| v.as_str())
-                    .is_some_and(|action| matches!(action, "list" | "show")) =>
+                    .is_some_and(|action| action == "list") =>
+            {
+                ToolIdempotency::PureRead
+            }
+            Some("worktree")
+                if args
+                    .and_then(|a| a.get("sub_action"))
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|action| matches!(action, "list" | "ls")) =>
             {
                 ToolIdempotency::PureRead
             }
@@ -898,6 +906,7 @@ mod tests {
         assert_eq!(worktree_list.category, ToolCategory::ReadOnly);
         assert!(!worktree_list.approval_required);
         assert!(worktree_list.parallelizable);
+        assert_eq!(worktree_list.idempotency, ToolIdempotency::PureRead);
 
         let worktree_add = classify(
             "git",

--- a/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -5965,6 +5965,7 @@ pub(crate) fn pending_terminal_completion_action_for_work_state(
     if active_work_attempt
         || workspace_observation_is_quarantined(state)
         || has_bound_workspace_completion_evidence(state)
+        || has_successful_terminal_task_action(state)
         || !super::lifecycle::unfinished_parallel_agent_ids(state).is_empty()
     {
         return None;
@@ -5974,6 +5975,14 @@ pub(crate) fn pending_terminal_completion_action_for_work_state(
         WorkspaceMutationIntent::Unknown | WorkspaceMutationIntent::MayMutate
     )
     .then_some(CompletionAction::CompletionTaskAction)
+}
+
+fn has_successful_terminal_task_action(state: &AgenticLoopState) -> bool {
+    state.stall.tool_call_records.iter().any(|record| {
+        record.was_executed()
+            && record.ok
+            && tool_is_terminal_completion_task_action(record.name.trim())
+    })
 }
 
 /// Match a raw canonical provider tool call against a typed completion action.
@@ -9929,6 +9938,30 @@ mod tests {
                 pending_terminal_completion_action_for_work_state(&uncertain, false),
                 Some(CompletionAction::CompletionTaskAction),
                 "intent={intent:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_completion_action_does_not_repeat_a_successful_task_action() {
+        for intent in [
+            astra_config::user_profile::WorkspaceMutationIntent::Unknown,
+            astra_config::user_profile::WorkspaceMutationIntent::MayMutate,
+        ] {
+            let mut state = make_state();
+            state.turn_intent = Some(
+                astra_config::user_profile::TurnIntent::default().with_workspace_mutation(intent),
+            );
+            state.stall.tool_call_records.push(executed_record(
+                "bash",
+                true,
+                Some(r#"{"command":"git worktree list"}"#),
+            ));
+
+            assert_eq!(
+                pending_terminal_completion_action_for_work_state(&state, false),
+                None,
+                "intent={intent:?}: a successful task-facing action already spent the fallback obligation"
             );
         }
     }

--- a/crates/runtime/src/turn/agentic_loop/execution_phase.rs
+++ b/crates/runtime/src/turn/agentic_loop/execution_phase.rs
@@ -123,6 +123,16 @@ fn terminal_completion_disposition(
     let active_work_attempt = state.runtime_tool_executor.as_deref().is_some_and(
         crate::server::runtime_tool_executor::RuntimeToolExecutor::has_active_primary_work_attempt,
     );
+    // A successful generic task action may spend the one terminal fallback
+    // obligation, but it is still progress evidence rather than typed proof
+    // that an Unknown/MayMutate user goal completed. Keep the closing text
+    // boundary resumably incomplete in that case. Explicit ReadOnly intent
+    // and concrete mutation/verification receipts retain their existing
+    // completion authority.
+    let generic_task_action_spent = matches!(
+        workspace_mutation_intent(state),
+        WorkspaceMutationIntent::Unknown | WorkspaceMutationIntent::MayMutate
+    ) && has_successful_terminal_task_action(state);
     let bounded_synthesis_authorized = !active_work_attempt
         && !workspace_observation_is_quarantined(state)
         && state
@@ -131,6 +141,7 @@ fn terminal_completion_disposition(
             .foreground_fanout_pagination
             .is_none()
         && super::lifecycle::unfinished_parallel_agent_ids(state).is_empty()
+        && !generic_task_action_spent
         && pending_terminal_completion_action_for_work_state(state, false).is_none();
     if bounded_synthesis_authorized {
         return TerminalCompletionDisposition::RoundSliceTextDelivery;
@@ -15455,6 +15466,32 @@ mod tests {
             terminal_completion_disposition(&generic_action, false),
             TerminalCompletionDisposition::RoundSliceIncomplete,
             "a generic action proves execution, not completion of the user goal"
+        );
+
+        let mut spent_generic_action = make_state();
+        spent_generic_action.budget_wrapup_injected = true;
+        spent_generic_action.hooks.completion_settlement.text_only = true;
+        spent_generic_action
+            .hooks
+            .completion_settlement
+            .wrapup_origin = Some(super::super::host::BudgetWrapupOrigin::RoundSlice);
+        spent_generic_action
+            .stall
+            .tool_call_records
+            .push(executed_record(
+                "bash",
+                true,
+                Some(r#"{"command":"git worktree list"}"#),
+            ));
+        assert_eq!(
+            pending_terminal_completion_action_for_work_state(&spent_generic_action, false),
+            None,
+            "the successful action must not manufacture another terminal tool allowance"
+        );
+        assert_eq!(
+            terminal_completion_disposition(&spent_generic_action, false),
+            TerminalCompletionDisposition::RoundSliceIncomplete,
+            "spending the generic fallback proves progress, not goal completion"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fix the Git executor deadlock where `action="worktree"` was incorrectly validated as a worktree sub-action instead of reading `sub_action`.
- Centralize nested Git action parsing/validation for `worktree` and `stash`, and align schemas, approval, mutation leases, and idempotency classification.
- Preserve complete server-owned tool outcome aggregates in both interactive and one-shot journals so remote failures are not reported as zero.
- Avoid demanding a duplicate terminal task action after a successful task-facing action; retain fail-closed behavior for failed, rejected, or control-plane calls.
- Add a permanent DeepSeek Flash harness case for the documented worktree-list contract.

## Verification

- Targeted Git, schema, harness, journal, commit, and completion-action tests pass.
- `make format-check` passes.
- Strict Clippy passes for `astra-cli` and `astra-runtime`.
- Real `deepseek-v4-flash` harness: `git_worktree_list_contract` passed 1/1 with the exact `action=worktree`, `sub_action=list` request and `WORKTREE_LIST_OK`.
- Latest release build: `09bf4af99857b60878614bc974772a87b9756a4c` (`git_dirty=false`).

## Session evidence

The referenced session showed two deterministic Git failures with valid arguments, plus a journal/audit mismatch (`audit` counted 5 failures while the local digest counted 0). The raw audit also showed successful cleanup being marked incomplete because the completion fallback required an unnecessary extra task action. These cases are covered by the changes above.
