### PR TITLE
chore(release): prepare Astra 0.2.0

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -3,7 +3,7 @@
 
 # ── Published images / ingress ─────────────────────────────────────────────
 # Pin an immutable release tag or digest. Do not deploy `latest` in production.
-ASTRA_IMAGE=matrixorigin/astra:0.1.0
+ASTRA_IMAGE=matrixorigin/astra:0.2.0
 NGINX_IMAGE=nginx:1.30.4-alpine
 ASTRA_PUBLIC_BIND_ADDRESS=0.0.0.0
 ASTRA_PUBLIC_HTTP_PORT=80

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use Astra, please cite the ContextPipe paper and this software."
 title: Astra
 type: software
-version: 0.1.0
+version: 0.2.0
 authors:
   - name: MatrixOrigin
 repository-code: "https://github.com/matrixorigin/Astra"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "astra-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-config",
  "astra-core",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "astra-config"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "astra-turn-types",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "astra-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "astra-credentials"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dirs",
  "fs2",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "astra-edge"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "astra-credentials",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "astra-harness"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-turn-core",
  "serde",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "astra-logging"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "astra-mcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-turn-types",
  "chrono",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "astra-memoria"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-turn-types",
  "async-trait",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "astra-messaging"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-text-utils",
  "astra-turn-types",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "astra-pipeline"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "astra-services",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "astra-plan"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "astra-services",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "astra-prompts"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "chrono",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "astra-runtime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-config",
  "astra-core",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "astra-runtime-env"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "async-trait",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "astra-sandbox"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "astra-skills",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "astra-server-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "astra-services",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "astra-services"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-config",
  "astra-core",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "astra-skills"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "astra-pipeline",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "astra-sync-protocol"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "hmac",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "astra-test-harness"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "astra-credentials",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "astra-text-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dirs",
  "serde",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "astra-thin-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "astra-runtime-env",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "astra-tools"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "astra-memoria",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "astra-turn-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-core",
  "astra-messaging",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "astra-turn-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astra-prompts",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Makefile
+++ b/Makefile
@@ -534,7 +534,34 @@ release-check:
 	@scripts/validate-release-version.sh "$(VERSION)"
 	@python3 scripts/ci/validate_repository.py
 	@echo "✅ Release metadata, installer, artifacts, and workflow contracts are consistent"
-	@echo "   Commit and merge the reviewed version changes, then run Release Astra from main."
+	@echo "   Commit and merge the reviewed version changes, then run make release-publish VERSION=$(VERSION) from main."
+
+.PHONY: release-publish
+release-publish:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "❌ VERSION is required, for example: make release-publish VERSION=0.2.0"; \
+		exit 1; \
+	fi
+	@scripts/validate-release-version.sh "$(VERSION)"
+	@command -v gh >/dev/null 2>&1 || { echo "❌ GitHub CLI (gh) is required to start a release"; exit 1; }
+	@gh auth status -h github.com >/dev/null 2>&1 || { echo "❌ Authenticate gh with permission to dispatch repository workflows"; exit 1; }
+	@default_branch="$$(gh repo view matrixorigin/Astra --json defaultBranchRef --jq '.defaultBranchRef.name')"; \
+	if [ "$$(git branch --show-current)" != "$$default_branch" ]; then \
+		echo "❌ Run release-publish from $$default_branch after the release PR merges"; \
+		exit 1; \
+	fi; \
+	if ! git diff --quiet || ! git diff --cached --quiet; then \
+		echo "❌ Commit or stash local changes before starting a release"; \
+		exit 1; \
+	fi; \
+	git fetch origin "$$default_branch"; \
+	if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse "origin/$$default_branch")" ]; then \
+		echo "❌ Local $$default_branch is not at origin/$$default_branch; fast-forward it before starting a release"; \
+		exit 1; \
+	fi
+	@gh workflow run release.yml --repo matrixorigin/Astra --ref main \
+		-f version="$(VERSION)" -f recover_existing_tag=false
+	@echo "✅ Release Astra started for $(VERSION). Candidate builds run before the protected release approval."
 
 # ============================================================================
 # Compose Stack Deployment

--- a/deployment/all-in-one/.env.example
+++ b/deployment/all-in-one/.env.example
@@ -15,7 +15,7 @@
 # These three images are one tested compatibility set. Release PRs update the
 # Astra version and deliberately advance dependency digests only after the
 # all-in-one candidate smoke passes on AMD64 and ARM64.
-ASTRA_IMAGE=matrixorigin/astra:0.1.0
+ASTRA_IMAGE=matrixorigin/astra:0.2.0
 MEMORIA_IMAGE=matrixorigin/memoria@sha256:9075cb57c0304197d906d1fdb6c71cbeb1e000153ab5fe3b766ddcd0134e8478
 MATRIXONE_IMAGE=matrixorigin/matrixone@sha256:c95d1b468e3fc5f4f2b377da14f4601e7efefa6eb143758636d60114a5bbb436
 

--- a/deployment/kubernetes/README.md
+++ b/deployment/kubernetes/README.md
@@ -72,7 +72,7 @@ helm upgrade --install astra ./chart \
   --namespace astra \
   --set api.existingSecret=astra-runtime \
   --set api.image.repository=registry.example.com/platform/astra \
-  --set api.image.tag=0.1.0
+  --set api.image.tag=0.2.0
 ```
 
 For an immutable deployment, set `api.image.digest` to a `sha256:...` digest;

--- a/deployment/kubernetes/chart/Chart.yaml
+++ b/deployment/kubernetes/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: astra-engine
 description: Enterprise agent runtime with auditable context and execution
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -155,12 +155,18 @@ release commit; it does not modify files, create tags, or publish data.
 
 ## Publish
 
-1. Open **Actions → Release Astra → Run workflow**.
-2. Select `main` in the branch selector.
-3. Enter the version without a leading `v`, for example `0.2.0`.
-4. Leave **recover existing tag** disabled for a new release.
-5. Wait for the client and server candidate matrices to pass.
-6. Review the preflight summary and approve the single `release` Environment
+1. Fast-forward a clean local `main` checkout to the merged release commit.
+2. Start the protected workflow:
+
+   ```bash
+   make release-publish VERSION=0.2.0
+   ```
+
+   The command validates the synchronized version metadata, requires a clean
+   checkout at the exact `origin/main` SHA, and dispatches **Release Astra**
+   with recovery disabled. It does not create a tag locally.
+3. Wait for the client and server candidate matrices to pass.
+4. Review the preflight summary and approve the single `release` Environment
    gate for the publication job.
 
 Do not create the tag manually. The workflow creates `vX.Y.Z` as an annotated

--- a/docs/reference/makefile-commands.md
+++ b/docs/reference/makefile-commands.md
@@ -65,9 +65,11 @@
 | --- | --- |
 | `make release-prepare VERSION=X.Y.Z` | Safely synchronize release versions without committing, tagging, building, or publishing |
 | `make release-check VERSION=X.Y.Z` | Read-only preflight for synchronized versions, installer/archive unhappy paths, repository workflow contracts, and documentation links |
+| `make release-publish VERSION=X.Y.Z` | From a clean local `main` equal to `origin/main`, dispatch the protected Release Astra workflow with recovery disabled |
 
 Publication itself is owned by the protected **Release Astra** GitHub workflow;
-neither Make target creates a tag or publishes an artifact. `release-prepare`
+the publish target only dispatches it, and the workflow creates the tag and
+artifacts after its candidate checks and Environment approval. `release-prepare`
 refuses to overwrite existing version-file edits and leaves MatrixOne/Memoria
 digest changes for deliberate maintainer review.
 

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astra/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@astra/sdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astra/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "description": "TypeScript SDK for Astra — streaming chat, tool execution, and WebSocket support",
   "homepage": "https://github.com/matrixorigin/Astra#readme",

--- a/scripts/ci/validate_repository.py
+++ b/scripts/ci/validate_repository.py
@@ -302,6 +302,8 @@ def main() -> None:
     for required in (
         "release-prepare:",
         'scripts/prepare-release-version.py "$(VERSION)"',
+        "release-publish:",
+        "gh workflow run release.yml --repo matrixorigin/Astra --ref main",
         "stack-start: stack-env",
         "$(MAKE) stack-up",
         "$(MAKE) stack-verify",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astra-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astra-web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@astra/sdk": "file:../packages/sdk",
         "@floating-ui/core": "1.8.0",
@@ -55,7 +55,7 @@
     },
     "../packages/sdk": {
       "name": "@astra/sdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astra-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "../scripts/dev/run-web-dev.sh",


### PR DESCRIPTION
## Summary

Prepare Astra 0.2.0 by synchronizing the Rust workspace and lockfile, SDK/Web manifests and lockfiles, citation, Helm chart, deployment image defaults, and Kubernetes private-registry example. Add `make release-publish VERSION=0.2.0` as the guarded post-merge entrypoint for the protected release workflow. The release includes the merged git nested-action contract and runtime failure/budget settlement fixes from #705.

## Related issue

Release preparation; follows #705.

## Change type

- [x] Build, CI, or maintenance

## User and compatibility impact

Client version output and deployment defaults advance from 0.1.0 to 0.2.0. This PR changes version metadata only, with no new runtime behavior or database migrations. MatrixOne and Memoria digest pins remain the existing compatibility set; candidate runtime smoke checks are required before publication. The unified release publishes CLI/Edge archives for Linux and macOS AMD64/ARM64 and a Linux AMD64/ARM64 server image. Native Windows, npm SDK publication, and Helm registry publication are not provided by this workflow.

## Architecture and complexity delta

N/A: uses the existing release preparation script and unified release workflow.

## Verification

- Passed: `make release-prepare VERSION=0.2.0` and `make release-check VERSION=0.2.0`.
- Passed: `cargo metadata --locked --offline --no-deps --format-version 1` and `git diff --check`.
- Passed: `bash scripts/ci/test_release_contract.sh`, `bash scripts/ci/test_release_manifest_contract.sh`, and `python3 scripts/ci/test_prepare_release_version.py` (3 tests).
- Passed: `make release-publish VERSION=0.2.0` rejects this unmerged feature branch before dispatching a workflow, proving the main-branch guard.
- Full `make check` / `make test-offline` have not been rerun locally for this metadata-only change; required PR CI must pass before merge. Release candidate binary and container smoke tests have not run yet.
- Database verification: not applicable to this metadata-only change.

## Publication prerequisites

The organization exposes both Docker Hub secret names to this repository; credential validity still needs candidate CI verification. The `release` Environment is now configured with XuPeng-SH as required reviewer, main-only deployment, and `ASTRA_RELEASE_ENVIRONMENT_GUARD`. Self-review is allowed so the maintainer can dispatch and approve the release. The active `immutable-release-tags` ruleset prohibits updates, deletions, and force pushes to `v*` tags with no bypass actors. New tag creation remains allowed, matching the existing workflow; actual tag creation still needs release-run verification.

After review, CI, and merge, dispatch `release.yml` from `main` with `version=0.2.0` and `recover_existing_tag=false`. The workflow creates the immutable tag after candidate verification. No tag or release has been created by this PR.

- [x] Configure the `release` Environment with maintainer approval and main-only deployment.
- [x] Set the Environment secret `ASTRA_RELEASE_ENVIRONMENT_GUARD=configured`.
- [x] Protect `v*` tags while permitting new tag creation by the release workflow.
- [ ] Verify annotated tag creation in the actual release run.
- [ ] Pass required PR CI and review, then merge the version commit.
- [ ] Pass all client and server release candidate checks before approving publication.

## Final checklist

- [x] Existing release contract tests cover this metadata-only change.
- [x] No public command or contract change requiring documentation updates.
- [x] Diff checked for credentials and unrelated changes.
- [x] Conventional Commit PR title.
