### PR TITLE
fix(release): handle absent build options under nounset

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -85,11 +85,11 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
         run: |
           set -euo pipefail
-          feature_args=()
+          set --
           if [ -n "${RELEASE_FEATURES}" ]; then
-            feature_args=(--features "${RELEASE_FEATURES}")
+            set -- --features "${RELEASE_FEATURES}"
           fi
-          cargo build --release --locked --no-default-features "${feature_args[@]}" \
+          cargo build --release --locked --no-default-features "$@" \
             --manifest-path Cargo.toml --target "${{ matrix.target }}" \
             -p astra-cli --bin astra \
             -p astra-edge --bin astra-edge

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,13 @@ ARG DEBIAN_MIRROR
 WORKDIR /app
 
 RUN set -eux; \
-    if [ -n "${CARGO_REGISTRY}" ]; then \
+    if [ -n "${CARGO_REGISTRY:-}" ]; then \
         mkdir -p "${CARGO_HOME}"; \
         printf '[source.crates-io]\nreplace-with = "mirror"\n[source.mirror]\nregistry = "%s"\n' "${CARGO_REGISTRY}" > "${CARGO_HOME}/config.toml"; \
     fi
 
 RUN set -eux; \
-    if [ -n "${DEBIAN_MIRROR}" ]; then \
+    if [ -n "${DEBIAN_MIRROR:-}" ]; then \
         mirror="${DEBIAN_MIRROR%/}"; \
         case "${mirror}" in http://*|https://*) ;; *) mirror="https://${mirror}" ;; esac; \
         find /etc/apt -type f \( -name 'sources.list' -o -name '*.sources' \) -print0 \
@@ -102,7 +102,7 @@ RUN set -eux; \
         find /etc/apt -type f \( -name 'sources.list' -o -name '*.sources' \) -print0 \
             | xargs -0 -r sed -i -E "s#${from_regex}#${to_base}#g"; \
     }; \
-    if [ -n "${DEBIAN_MIRROR}" ]; then \
+    if [ -n "${DEBIAN_MIRROR:-}" ]; then \
         mirror="${DEBIAN_MIRROR%/}"; \
         case "${mirror}" in http://*|https://*) ;; *) mirror="https://${mirror}" ;; esac; \
         mirror_host="${mirror#http://}"; \
@@ -114,7 +114,7 @@ RUN set -eux; \
     fi; \
     apt-get update; \
     apt-get install -y --no-install-recommends ca-certificates; \
-    if [ -n "${DEBIAN_MIRROR}" ]; then \
+    if [ -n "${DEBIAN_MIRROR:-}" ]; then \
         if [ "${mirror}" != "${bootstrap_mirror}" ]; then \
             replace_apt_sources "https?://${mirror_host_regex}" "${mirror}"; \
             apt-get update; \

--- a/scripts/ci/test_release_build_shells.py
+++ b/scripts/ci/test_release_build_shells.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Execute release shell entrypoints with build/network commands stubbed out."""
+
+import os
+from pathlib import Path
+import re
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class ReleaseShellTests(unittest.TestCase):
+    def test_client_arguments_with_and_without_features(self):
+        workflow = (ROOT / ".github/workflows/release-binaries.yml").read_text()
+        step = workflow.split("      - name: Build client candidates\n", 1)[1]
+        script = step.split("        run: |\n", 1)[1].split("\n      - name:", 1)[0]
+        script = "\n".join(line[10:] for line in script.splitlines())
+        script = script.replace("${{ matrix.target }}", "test-target")
+        # POSIX positional parameters also work on macOS's Bash 3.2.
+        # Run that portion under sh as well as bash to guard portability.
+        for shell in ("bash", "sh"):
+            for features in ("", "astra-cli/release-vendored-openssl"):
+                with self.subTest(shell=shell, features=features):
+                    body = script if shell == "bash" else script.replace("set -euo pipefail", "set -eu")
+                    result = subprocess.run(
+                        [shell, "-c", 'cargo() { printf "%s\\n" "$@"; };\n' + body],
+                        env={**os.environ, "RELEASE_FEATURES": features},
+                        capture_output=True, text=True,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    expected = ["build", "--release", "--locked", "--no-default-features"]
+                    if features:
+                        expected += ["--features", features]
+                    expected += ["--manifest-path", "Cargo.toml", "--target", "test-target",
+                                 "-p", "astra-cli", "--bin", "astra",
+                                 "-p", "astra-edge", "--bin", "astra-edge"]
+                    self.assertEqual(result.stdout.splitlines(), expected)
+
+    def test_docker_optional_mirrors_unset_and_empty(self):
+        dockerfile = (ROOT / "Dockerfile").read_text().replace("\\\n", "")
+        commands = re.findall(r"^RUN (set -eux;.*)$", dockerfile, re.MULTILINE)
+        commands = [command for command in commands
+                    if "CARGO_REGISTRY" in command or "DEBIAN_MIRROR" in command]
+        self.assertEqual(len(commands), 3)
+        stubs = '\n'.join(f'{name}() {{ :; }}' for name in
+                          ("apt_get", "rm", "groupadd", "useradd"))
+        for empty in (False, True):
+            env = {key: value for key, value in os.environ.items()
+                   if key not in ("CARGO_REGISTRY", "DEBIAN_MIRROR")}
+            if empty:
+                env.update(CARGO_REGISTRY="", DEBIAN_MIRROR="")
+            for command in commands:
+                with self.subTest(empty=empty, command=command[:70]):
+                    result = subprocess.run(
+                        ["sh", "-c", stubs + '\n' + command.replace("apt-get", "apt_get")], env=env,
+                        capture_output=True, text=True,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/validate_repository.py
+++ b/scripts/ci/validate_repository.py
@@ -70,6 +70,7 @@ def main() -> None:
         Path("scripts/ops/test_production_env_contract.sh"),
         Path("scripts/ci/test_release_contract.sh"),
         Path("scripts/ci/test_release_manifest_contract.sh"),
+        Path("scripts/ci/test_release_build_shells.py"),
         Path("scripts/ci/test_sccache_fallback.sh"),
     ]
     for contract_script in contract_scripts:


### PR DESCRIPTION
## Summary

Release run 33921299597 fails before compilation on macOS because Bash rejects an empty feature array under `set -u`. Both server platforms also fail because an omitted optional `DEBIAN_MIRROR` build argument is read as a required variable; the builder has the same issue for `CARGO_REGISTRY`.

Use positional arguments for optional client features and unset-safe expansion for optional Docker registry/mirror checks. Configured options retain their existing behavior.

## Change type

- [x] Bug fix
- [x] Build, CI, or maintenance

## User and compatibility impact

Restores the default public release build path with no mirror settings and no macOS-specific Cargo features. No runtime, schema, or version changes.

## Architecture and complexity delta

N/A. Existing release workflow and Dockerfile remain the build owners.

## Verification

- `python3 scripts/ci/test_release_build_shells.py`: passed. Executes extracted workflow commands in bash/sh and checks exact Cargo arguments with and without features. Executes all three optional Docker setup blocks under sh with both unset and empty mirror variables; package-management commands are stubbed.
- `make release-check VERSION=0.2.0`: passed, including the new shell regression tests.
- `git diff --check`: passed.
- Complete cross-platform builds have not been rerun locally. macOS Bash 3.2 execution still needs the release runner; the replacement uses POSIX positional parameters.
- Database verification: not applicable.

## Release continuation

After merge, start a new Release Astra run from updated main for 0.2.0 with recovery disabled, provided the version tag remains absent. Rerunning the old failed build would reuse its broken source SHA. Do not manually create the tag.
