### PR TITLE
fix(release): wait for Memoria HTTP readiness

### DIFF
--- a/deployment/all-in-one/docker-compose.deps.yml
+++ b/deployment/all-in-one/docker-compose.deps.yml
@@ -81,9 +81,15 @@ services:
     networks:
       - mo-net
     healthcheck:
-      # The current Memoria image does not ship curl/wget; keep this process
-      # check until the image can self-probe http://localhost:8100/health.
-      test: ["CMD-SHELL", "grep -aq 'memoria' /proc/1/cmdline"]
+      # The Memoria image has Bash but no curl/wget. Probe the real HTTP
+      # boundary so dependents start only after the listener is ready.
+      test:
+        [
+          "CMD",
+          "bash",
+          "-c",
+          "exec 3<>/dev/tcp/127.0.0.1/8100 && printf 'GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 && head -n 1 <&3 | grep -qE '^HTTP/1\\.[01] 200 '",
+        ]
       interval: 15s
       timeout: 5s
       retries: 6

--- a/deployment/all-in-one/docker-compose.yml
+++ b/deployment/all-in-one/docker-compose.yml
@@ -151,9 +151,16 @@ services:
     networks:
       - mo-net
     healthcheck:
-      # The current Memoria image does not ship curl/wget; keep this process
-      # check until the image can self-probe http://localhost:8100/health.
-      test: ["CMD-SHELL", "grep -aq 'memoria' /proc/1/cmdline"]
+      # The Memoria image has Bash but no curl/wget. Probe the real HTTP
+      # boundary so Compose does not treat a process that has not bound its
+      # listener yet as ready.
+      test:
+        [
+          "CMD",
+          "bash",
+          "-c",
+          "exec 3<>/dev/tcp/127.0.0.1/8100 && printf 'GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 && head -n 1 <&3 | grep -qE '^HTTP/1\\.[01] 200 '",
+        ]
       interval: 15s
       timeout: 5s
       retries: 8

--- a/scripts/ci/validate_repository.py
+++ b/scripts/ci/validate_repository.py
@@ -289,14 +289,28 @@ def main() -> None:
                 f"must be immutable ({dependency_image})"
             )
 
-    stack_compose = Path("deployment/all-in-one/docker-compose.yml").read_text(
-        encoding="utf-8"
-    )
+    stack_compose_path = Path("deployment/all-in-one/docker-compose.yml")
+    stack_compose = stack_compose_path.read_text(encoding="utf-8")
     for image_variable in ("ASTRA_IMAGE", "MEMORIA_IMAGE", "MATRIXONE_IMAGE"):
         if f"${{{image_variable}:-" in stack_compose:
             errors.append(
                 "deployment/all-in-one/docker-compose.yml: released stack must require "
                 f"the compatibility pin for {image_variable} instead of silently falling back"
+            )
+
+    for compose_path in (
+        stack_compose_path,
+        Path("deployment/all-in-one/docker-compose.deps.yml"),
+    ):
+        compose = compose_path.read_text(encoding="utf-8")
+        if (
+            "/dev/tcp/127.0.0.1/8100" not in compose
+            or "GET /health HTTP/1.1" not in compose
+            or "/proc/1/cmdline" in compose
+        ):
+            errors.append(
+                f"{compose_path}: Memoria healthcheck must probe its HTTP readiness "
+                "boundary instead of only checking that the process exists"
             )
 
     makefile = Path("Makefile").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- replace the Memoria process-only Compose healthcheck with a real HTTP `/health` probe
- apply the same readiness contract to all-in-one and development dependency stacks
- add a repository contract preventing process-only healthchecks from returning

## Root cause

Release run 33923420611 built all artifacts and server images successfully, but both server candidate verification jobs ran `make stack-verify` immediately after Compose declared the stack healthy. The Memoria healthcheck only inspected `/proc/1/cmdline`, so it reported healthy before port 8100 was listening. Astra consequently observed `memoria: unavailable` on both amd64 and arm64.

## Verification

- `make release-check VERSION=0.2.0`
- `python3 scripts/ci/validate_repository.py`
- Docker Compose config validation for both stack definitions
- exact Bash HTTP probe executed successfully inside a real Memoria container
- `git diff --check`

## Release impact

After merge, dispatch a fresh v0.2.0 release from the new main SHA; rerunning the failed workflow would rebuild the old source revision.