### PR TITLE
ci(moi-dev): publish snapshots directly to IDC

### DIFF
--- a/.github/workflows/publish-idc-snapshot.yml
+++ b/.github/workflows/publish-idc-snapshot.yml
@@ -1,0 +1,233 @@
+name: Publish moi-dev IDC Snapshot
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: 'Commit SHA reachable from moi-dev to build (for example e5547ff)'
+        required: true
+        default: e5547ffae43391aa068069889863070898a4ca4e
+        type: string
+      image_tag:
+        description: 'New immutable IDC image tag to publish'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-idc-snapshot-${{ inputs.image_tag }}
+  cancel-in-progress: false
+
+env:
+  IDC_REGISTRY: shanghai.idc.matrixorigin.cn:30019
+  IDC_IMAGE_NAME: shanghai.idc.matrixorigin.cn:30019/mocloud/astra
+
+jobs:
+  resolve:
+    name: Resolve moi-dev Source
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.source.outputs.source_sha }}
+      image_tag: ${{ steps.source.outputs.image_tag }}
+      matrix: ${{ steps.source.outputs.matrix }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: moi-dev
+          fetch-depth: 0
+
+      - name: Validate source and target tag
+        id: source
+        shell: bash
+        env:
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+
+          source_sha="${INPUT_SOURCE_SHA//[[:space:]]/}"
+          image_tag="${INPUT_IMAGE_TAG//[[:space:]]/}"
+
+          if [[ ! "${source_sha}" =~ ^[0-9A-Fa-f]{7,40}$ ]]; then
+            echo "source_sha must be a 7- to 40-character Git commit SHA" >&2
+            exit 1
+          fi
+          if ! git rev-parse --verify --quiet "${source_sha}^{commit}" >/dev/null; then
+            echo "source_sha does not resolve to a commit: ${source_sha}" >&2
+            exit 1
+          fi
+          source_sha="$(git rev-parse "${source_sha}^{commit}")"
+          if ! git merge-base --is-ancestor "${source_sha}" origin/moi-dev; then
+            echo "source_sha must be reachable from origin/moi-dev: ${source_sha}" >&2
+            exit 1
+          fi
+
+          if [[ ! "${image_tag}" =~ ^[0-9A-Za-z_][0-9A-Za-z_.-]{0,127}$ ]]; then
+            echo "Invalid image tag: ${image_tag}" >&2
+            echo "A tag must start with a letter, digit, or underscore; contain only letters, digits, underscores, periods, and dashes; and be at most 128 characters." >&2
+            exit 1
+          fi
+          case "${image_tag}" in
+            latest|buildcache|buildcache-*)
+              echo "Reserved image tag: ${image_tag}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
+          echo "image_tag=${image_tag}" >> "${GITHUB_OUTPUT}"
+          echo 'matrix={"include":[{"platform":"linux/amd64","runner":"ubuntu-latest","slug":"linux-amd64"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm","slug":"linux-arm64"}]}' >> "${GITHUB_OUTPUT}"
+
+  build:
+    name: Build ${{ matrix.platform }}
+    needs: resolve
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.resolve.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          fetch-depth: 1
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IDC_REGISTRY }}
+          username: ${{ secrets.IDC_REGISTRY_USERNAME }}
+          password: ${{ secrets.IDC_REGISTRY_PASSWORD }}
+
+      - uses: docker/build-push-action@v6
+        id: build
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IDC_IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.revision=${{ needs.resolve.outputs.source_sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.resolve.outputs.image_tag }}
+          build-args: |
+            IMAGE_VERSION=${{ needs.resolve.outputs.image_tag }}
+            IMAGE_REVISION=${{ needs.resolve.outputs.source_sha }}
+            IMAGE_BRANCH=moi-dev
+          # Keep caches in the selected target registry: this workflow never
+          # authenticates to or publishes an image to Docker Hub.
+          cache-from: type=registry,ref=${{ env.IDC_IMAGE_NAME }}:buildcache-${{ matrix.slug }}
+          cache-to: type=registry,ref=${{ env.IDC_IMAGE_NAME }}:buildcache-${{ matrix.slug }},mode=max
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          provenance: mode=max
+          sbom: true
+
+      - name: Export digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish IDC Manifest
+    needs:
+      - resolve
+      - build
+    runs-on: amd64-mo-shanghai-dind
+    timeout-minutes: 45
+    env:
+      http_proxy: http://proxy-service.proxy.svc.cluster.local:8001
+      https_proxy: http://proxy-service.proxy.svc.cluster.local:8001
+      no_proxy: .local,.cn,.gitee.com,.tencent.com,.tencentyun.com,.aliyun.com,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,localhost,127.0.0.0/8,.qq.com,169.254.0.0/16,.myqcloud.com,.matrixone.tech,.aliyuncs.com,.digicert.com,.microsoft.com,.visualstudio.com,.symcb.com,0.0.0.0
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Install crane
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          curl -fsSL \
+            -o "${RUNNER_TEMP}/go-containerregistry.tar.gz" \
+            "https://github.com/google/go-containerregistry/releases/download/v0.20.6/go-containerregistry_Linux_x86_64.tar.gz"
+          tar -xzf "${RUNNER_TEMP}/go-containerregistry.tar.gz" -C "${RUNNER_TEMP}/bin" crane
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+          "${RUNNER_TEMP}/bin/crane" version
+
+      - name: Create immutable IDC manifest
+        shell: bash
+        working-directory: /tmp/digests
+        env:
+          IMAGE_TAG: ${{ needs.resolve.outputs.image_tag }}
+          TARGET_IMAGE: ${{ env.IDC_IMAGE_NAME }}
+          IDC_USERNAME: ${{ secrets.IDC_REGISTRY_USERNAME }}
+          IDC_PASSWORD: ${{ secrets.IDC_REGISTRY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          printf '%s' "${IDC_PASSWORD}" | crane auth login "${IDC_REGISTRY}" -u "${IDC_USERNAME}" --password-stdin
+
+          target_ref="${TARGET_IMAGE}:${IMAGE_TAG}"
+          probe_error="$(mktemp)"
+          if crane manifest "${target_ref}" >/dev/null 2>"${probe_error}"; then
+            echo "Refusing to overwrite existing IDC image tag: ${target_ref}" >&2
+            exit 1
+          fi
+          if ! grep -Eqi 'MANIFEST_UNKNOWN|NAME_UNKNOWN|not found' "${probe_error}"; then
+            echo "Unable to confirm whether IDC image tag already exists: ${target_ref}" >&2
+            cat "${probe_error}" >&2
+            exit 1
+          fi
+
+          digests=(*)
+          if [ "${#digests[@]}" -ne 2 ]; then
+            echo "Expected exactly two platform digests, found ${#digests[@]}" >&2
+            exit 1
+          fi
+
+          manifest_args=()
+          for digest in "${digests[@]}"; do
+            if [[ ! "${digest}" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "Invalid image digest artifact: ${digest}" >&2
+              exit 1
+            fi
+            manifest_args+=(--manifest "${TARGET_IMAGE}@sha256:${digest}")
+          done
+          crane index append --docker-empty-base --tag "${target_ref}" "${manifest_args[@]}"
+
+          manifest="$(crane manifest "${target_ref}")"
+          platforms="$(jq -r '.manifests[]?.platform | "\(.os)/\(.architecture)"' <<< "${manifest}" | sort)"
+          linux_platforms="$(awk '/^linux\// { print }' <<< "${platforms}")"
+          expected_platforms=$'linux/amd64\nlinux/arm64'
+          if [ "${linux_platforms}" != "${expected_platforms}" ]; then
+            echo "Published manifest does not contain exactly linux/amd64 and linux/arm64:" >&2
+            printf '%s\n' "${platforms}" >&2
+            exit 1
+          fi
+          if awk '$0 != "" && $0 != "linux/amd64" && $0 != "linux/arm64" && $0 != "unknown/unknown" { exit 1 }' <<< "${platforms}"; then
+            :
+          else
+            echo "Published manifest contains an unexpected platform:" >&2
+            printf '%s\n' "${platforms}" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [x] build / ci (build or CI changes)

## Which issue(s) this PR fixes

N/A (manual `moi-dev` image publication workflow; no tracking issue was supplied)

## What this PR does / why we need it

Adds the manually dispatched `Publish moi-dev IDC Snapshot` workflow for the
specific need to build a commit reachable from `moi-dev` and publish it only to
`shanghai.idc.matrixorigin.cn:30019/mocloud/astra`.

- The operator supplies a commit SHA and a new immutable IDC tag. The requested
  `e5547ffae43391aa068069889863070898a4ca4e` is the default source SHA.
- It builds native `linux/amd64` and `linux/arm64` images directly into IDC by
  digest, then creates and validates a two-platform IDC manifest.
- It does not authenticate to Docker Hub, reference a Docker Hub image, or copy
  a Docker Hub manifest.
- It rejects non-`moi-dev` commits, malformed or reserved tags, existing final
  IDC tags, missing digest artifacts, and a manifest missing either expected
  Linux platform or carrying any unexpected platform. OCI provenance/SBOM
  attestation manifests (`unknown/unknown`) remain intact.

## Architecture and complexity delta

- Canonical owner changed or extended: a separate manual CI workflow owns the
  one-off `moi-dev` IDC-only snapshot path; the existing release workflow keeps
  its Docker Hub release and IDC mirror contract unchanged.
- Existing implementations/callers searched: `.github/workflows/release-docker.yml`
  and the historical IDC release commits. The new workflow preserves its native
  per-architecture digest build and IDC-runner manifest assembly pattern.
- Superseded code, states, tables, shims, and self-only tests removed: N/A; this
  adds a distinct manual publication path and does not alter release aliases or
  existing publication behavior.
- Net code/state/table delta: one GitHub Actions workflow; no application code,
  image schema, database, or runtime state change.
- If parallel implementations remain, the external boundary and retirement
  condition: `release-docker.yml` remains the formal release workflow. This
  workflow is only for explicit `moi-dev` snapshot requests and publishes a
  caller-provided immutable IDC tag.

## Production wiring and verification

- Public product entrypoint exercised: manual `workflow_dispatch` form accepts
  `source_sha` and `image_tag`; source validation was checked against
  `e5547ffae43391aa068069889863070898a4ca4e`, which is reachable from
  `origin/moi-dev`.
- Unhappy paths exercised: static review verifies fail-closed checks for an
  invalid source SHA, a source outside `moi-dev`, malformed/reserved tags,
  existing final tag, wrong digest count, invalid digest file, and an invalid
  final platform set. The platform check was also evaluated against the
  existing `20260904-e5547ff` IDC manifest: it accepts its expected amd64 and
  arm64 images plus provenance/SBOM attestations, while rejecting any other
  platform.
- Database schema/query/transaction/migration verified against a real database,
  or `N/A` with reason: N/A; CI workflow-only change.
- `git diff --check`: passed.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -ignore 'label "amd64-mo-shanghai-dind" is unknown' .github/workflows/publish-idc-snapshot.yml`: passed. The ignored diagnostic is the repository's existing private IDC runner label, also used by `release-docker.yml`.
- A live image publication is intentionally not run from this PR branch: it is a
  registry write and requires an explicit, unused IDC tag after the workflow is
  available on `moi-dev`.
