### PR TITLE
fix(lease): explicitly release Darwin session locks

### DIFF
--- a/crates/services/src/session_journal.rs
+++ b/crates/services/src/session_journal.rs
@@ -2112,6 +2112,17 @@ impl SessionExecutionLease {
     }
 }
 
+impl Drop for SessionExecutionLease {
+    fn drop(&mut self) {
+        // Do not rely solely on closing the descriptor to release the lock.
+        // Darwin runners can retain the advisory flock across the failed
+        // contender's descriptor lifetime, which makes a lease appear active
+        // after its owner has been dropped. Explicitly unlock before File's
+        // destructor closes the descriptor so the next turn can be admitted.
+        let _ = <std::fs::File as fs2::FileExt>::unlock(&self._file);
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn acquire_execution_kernel_authority(
     owner_scope: &OwnerScope,


### PR DESCRIPTION
## Summary

The 0.2.2 release candidate exposed a Darwin-only lease lifecycle failure: after a contender was rejected and the owning `SessionExecutionLease` was dropped, the next acquisition still returned `Conflict` on the arm64 macOS runner.

- Explicitly unlock the session lease file in `SessionExecutionLease::Drop`.
- Preserve the existing Linux kernel authority and file-lock fences.
- Keep the macOS runtime contract fail-closed for competing processes while admitting the next turn after lease drop.

## Verification

- Reproduced the failure with `cargo test --locked --no-default-features --manifest-path Cargo.toml -p astra-services --lib macos_session_execution_lease -- --nocapture`.
- The same four Darwin lease tests pass after the fix.
- `cargo fmt --check --all` and `git diff --check` pass.

The failure was observed in Release Astra run 34037875375 while building the `aarch64-apple-darwin` candidate; no release should be published from that incomplete run.