### PR TITLE
fix(ci): make sdk check name mergify-safe

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -99,7 +99,9 @@ jobs:
         run: make audit
 
   sdk:
-    name: "@astra/sdk (typecheck, test+coverage, build)"
+    # Mergify reserves a leading '@' for GitHub-App-qualified check names.
+    # Keep this required check name literal and unambiguous for queue injection.
+    name: "Astra SDK (typecheck, test+coverage, build)"
     needs: scope
     if: ${{ !cancelled() && (needs.scope.result != 'success' || needs.scope.outputs.sdk == 'true') }}
     runs-on: ubuntu-latest

--- a/docs/guides/repository-automation.md
+++ b/docs/guides/repository-automation.md
@@ -74,6 +74,19 @@ Keep the following `main` branch-protection invariants aligned with the queue:
   complete reviewed queue merges;
 - administrators do not use bypass as the normal delivery path.
 
+Required check names must not begin with `@`. Mergify uses that prefix for a
+GitHub-App-qualified check (`@github-actions/<check-name>`), so a required
+workflow job named `@astra/sdk ...` cannot be matched by the injected branch
+protection condition even when GitHub reports the check as successful. The SDK
+job is therefore named `Astra SDK (typecheck, test+coverage, build)`.
+
+When this name changes, update the required status-check list in `main`
+branch protection in the same maintenance window: remove
+`@astra/sdk (typecheck, test+coverage, build)` and add
+`Astra SDK (typecheck, test+coverage, build)`. Keep the old entry until the new
+workflow check has appeared once, then remove it so a missing legacy check does
+not block every pull request.
+
 After changing the Mergify installation or branch protection, verify the
 effective state rather than relying on the settings form:
 

--- a/scripts/ci/validate_repository.py
+++ b/scripts/ci/validate_repository.py
@@ -113,6 +113,16 @@ def main() -> None:
             ".github/workflows/static-checks.yml: CI must validate workflow semantics "
             "with the repository-pinned actionlint version"
         )
+    if 'name: "Astra SDK (typecheck, test+coverage, build)"' not in static_checks:
+        errors.append(
+            ".github/workflows/static-checks.yml: the SDK required check must use "
+            "the Mergify-safe name Astra SDK (typecheck, test+coverage, build)"
+        )
+    if 'name: "@astra/sdk (typecheck, test+coverage, build)"' in static_checks:
+        errors.append(
+            ".github/workflows/static-checks.yml: required check names must not "
+            "start with @, which Mergify reserves for App-qualified checks"
+        )
 
     release_controller = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     container_candidates = Path(


### PR DESCRIPTION
## Summary

Mergify could not queue approved PR #725 even though its GitHub Actions SDK check was green. The required check was named `@astra/sdk (typecheck, test+coverage, build)`. Mergify reserves a leading `@` for GitHub-App-qualified checks, so its injected branch-protection condition treated that check as an invalid/unmatched qualifier and left the PR waiting indefinitely.

Rename the workflow job to `Astra SDK (typecheck, test+coverage, build)`, which remains a stable required check while avoiding the reserved syntax. Add a repository validator guard so the old name cannot return silently, and document the one-time branch-protection migration.

After this PR is merged and the new check has appeared once, update `main` branch protection: remove `@astra/sdk (typecheck, test+coverage, build)` and add `Astra SDK (typecheck, test+coverage, build)`. Keep the old entry until the new check has completed once; removing it first would weaken the protection gate, while retaining it permanently would block every PR after the rename.

## User impact

Approved PRs can enter the existing serial Mergify queue and be merged after the required checks pass. Queue policy, approval requirements, branch protection, and CI coverage remain unchanged. No runtime, API, storage, release, or credential changes are included.

## Verification

- `python3 -m unittest discover -s scripts/ci -p 'test_*.py'` — 57 tests pass
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/static-checks.yml` — pass
- repository validator with the pre-existing local macOS execution-lease contract excluded — pass
- `git diff --check` — pass

## Related observation

The failure was reproduced on PR #725: Mergify's queue status showed only the SDK check condition unsatisfied, while the GitHub check and all other queue conditions were successful. This PR does not auto-close or modify #725.
