### PR TITLE
fix(ci): map IDC environment secrets into reusable candidate jobs

### DIFF
--- a/.github/workflows/build_push_to_idc.yml
+++ b/.github/workflows/build_push_to_idc.yml
@@ -143,6 +143,11 @@ jobs:
       matrix_json: ${{ needs.settings.outputs.matrix }}
       source_ref: ${{ needs.settings.outputs.source_ref }}
       source_sha: ${{ needs.settings.outputs.source_sha }}
+    # Enumerate the names so the reusable jobs can resolve their Environment
+    # secrets. The caller has no Environment; do not add repository copies.
+    secrets:
+      IDC_REGISTRY_USERNAME: ${{ secrets.IDC_REGISTRY_USERNAME }}
+      IDC_REGISTRY_PASSWORD: ${{ secrets.IDC_REGISTRY_PASSWORD }}
 
   stage:
     name: Assemble verified IDC manifest

--- a/.github/workflows/idc-container-candidates.yml
+++ b/.github/workflows/idc-container-candidates.yml
@@ -30,6 +30,13 @@ on:
         description: JSON platform build matrix
         required: true
         type: string
+    # Values come from idc-publication after each job enters the Environment.
+    # They may be empty in the caller; the runtime credential guard is required.
+    secrets:
+      IDC_REGISTRY_USERNAME:
+        required: false
+      IDC_REGISTRY_PASSWORD:
+        required: false
 
 env:
   IMAGE_NAME: ${{ inputs.candidate_image }}

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -141,6 +141,12 @@ as secrets in the `idc-publication` Environment; its deployment branch policy
 normally admits only `main`. Do not keep copies as repository or organization
 secrets.
 
+The reusable IDC candidate workflow declares both credential names, and its
+caller explicitly maps them. Keep that mapping even though the values are
+stored only in `idc-publication`: without it, the reusable jobs receive empty
+credentials. The secrets are optional at the call boundary because the caller
+does not enter the Environment; the build job checks them before use.
+
 The workflow copies the established release topology: native GitHub-hosted
 runners build each selected platform by digest and run the existing all-in-one
 smoke test. Candidates and build caches stay in the IDC-only

--- a/scripts/ci/test_release_build_shells.py
+++ b/scripts/ci/test_release_build_shells.py
@@ -385,24 +385,46 @@ esac
         self.assertIn("source_ref=" + revisions["base"], result.stdout)
 
     def test_idc_registry_credentials_are_required_before_build(self):
-        script = workflow_run_script(
-            ".github/workflows/build_push_to_idc.yml",
-            "Require IDC registry credentials",
-        )
-        for missing in ("IDC_REGISTRY_USERNAME", "IDC_REGISTRY_PASSWORD"):
-            with self.subTest(missing=missing):
-                env = {
-                    **os.environ,
-                    "IDC_REGISTRY_USERNAME": "release-user",
-                    "IDC_REGISTRY_PASSWORD": "release-password",
-                    missing: "",
-                }
-                result = subprocess.run(
-                    ["bash", "-c", script], env=env, capture_output=True, text=True
-                )
-                self.assertNotEqual(result.returncode, 0)
-                self.assertIn("Missing required IDC credential: " + missing, result.stdout)
-                self.assertNotIn("release-password", result.stdout + result.stderr)
+        for workflow in ("build_push_to_idc.yml", "idc-container-candidates.yml"):
+            script = workflow_run_script(
+                f".github/workflows/{workflow}", "Require IDC registry credentials"
+            )
+            for missing in (None, "IDC_REGISTRY_USERNAME", "IDC_REGISTRY_PASSWORD"):
+                with self.subTest(workflow=workflow, missing=missing):
+                    env = {
+                        **os.environ,
+                        "IDC_REGISTRY_USERNAME": "release-user",
+                        "IDC_REGISTRY_PASSWORD": "release-password",
+                    }
+                    if missing:
+                        env[missing] = ""
+                    result = subprocess.run(
+                        ["bash", "-c", script], env=env, capture_output=True, text=True
+                    )
+                    if missing:
+                        self.assertNotEqual(result.returncode, 0)
+                        self.assertIn("Missing required IDC credential: " + missing, result.stdout)
+                    else:
+                        self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertNotIn("release-password", result.stdout + result.stderr)
+
+    def test_idc_environment_secrets_are_mapped_across_workflow_call(self):
+        caller = (ROOT / ".github/workflows/build_push_to_idc.yml").read_text()
+        reusable = (ROOT / ".github/workflows/idc-container-candidates.yml").read_text()
+        call = caller.split("\n  candidates:\n", 1)[1].split("\n  stage:\n", 1)[0]
+        declaration = reusable.split("\nenv:\n", 1)[0]
+        names = {"IDC_REGISTRY_USERNAME", "IDC_REGISTRY_PASSWORD"}
+        mapped = set(re.findall(r"^      (IDC_REGISTRY_\w+):", call, re.MULTILINE))
+        self.assertEqual(mapped, names)
+        self.assertNotIn("secrets: inherit", call)
+        for name in names:
+            # A name must be mapped as well as declared for GitHub to inject an
+            # Environment-only secret. A declaration alone still resolves empty.
+            self.assertIn(f"{name}: ${{{{ secrets.{name} }}}}", call)
+            self.assertIn(f"      {name}:\n        required: false", declaration)
+        for job in ("build", "smoke"):
+            block = reusable.split(f"\n  {job}:\n", 1)[1].split("\n  smoke:\n", 1)[0]
+            self.assertIn("    environment: idc-publication\n", block)
 
     def test_idc_rejects_non_main_controller(self):
         result, _ = self.run_idc_settings(GITHUB_REF="refs/heads/moi-dev")


### PR DESCRIPTION
## Summary

The manual IDC run [34302092803](https://github.com/matrixorigin/Astra/actions/runs/34302092803) stopped before checkout because both registry credentials resolved to empty strings, although both secrets already existed in the protected `idc-publication` Environment. The reusable workflow call did not enumerate either secret.

Explicitly map the two IDC credential names and declare them in the reusable workflow. The declarations are optional at the call boundary because the caller has no Environment; the existing build-time guard still rejects either missing credential. Build and smoke jobs continue resolving the actual values from `idc-publication`. No repository/organization secret copies or blanket secret inheritance are introduced.

## Related issue

Failure linked above.

## Change type

- [x] Bug fix
- [x] Documentation
- [x] Test
- [x] Build, CI, or maintenance

## User and compatibility impact

Existing IDC Environment secrets remain valid. After merge, start a fresh `build_push_to_idc` run from the latest `main`. Runner selection, image verification, registry destinations, and Environment branch restrictions remain unchanged.

## Architecture and complexity delta

N/A to runtime architecture. Changes the existing IDC caller/callee secret contract. Reviewed the IDC and release workflows, release shell tests, and MatrixOne CI image-build action; no parallel publication path is added.

## Verification

- A live [GitHub Actions probe](https://github.com/loveRhythm1990/Astra/actions/runs/34302460976) used only a synthetic Environment secret in a temporary fork Environment. Direct job: present; reusable job without declaration/mapping: missing; declaration alone: missing; declaration plus explicit mapping: present. Only presence was printed. The temporary Environment and its synthetic secret were deleted after the run.
- `python3 scripts/ci/test_release_build_shells.py`: 17 tests passed, including caller/callee mapping coverage and success/missing-username/missing-password cases for both credential guards.
- `actionlint .github/workflows/build_push_to_idc.yml .github/workflows/idc-container-candidates.yml`: passed.
- `git diff --check`: passed.
- `python3 scripts/ci/validate_repository.py`: its only reported failure on local macOS was the unchanged `scripts/dev/test_edge_process_contract.sh` fixture (`/bin/sleep` copied to `astra-edge` was killed by signal 9). The same failure reproduces in the untouched original checkout. The PR Linux run subsequently passed the complete `Validate repository metadata and documentation` step: https://github.com/matrixorigin/Astra/actions/runs/34302677529/job/102312783507 .
- The real IDC build/publish has not been rerun with this change: its Environment only admits `main`, and this branch has not been merged. Database verification is not applicable.

## Final checklist

- [x] Tests cover the owning workflow contract and missing-credential paths.
- [x] Release documentation explains the Environment-only secret mapping.
- [x] Diff contains no credentials, private endpoints, or raw logs.
- [x] Conventional Commit title.
