### PR TITLE
fix(sandbox): consume find predicate operands

### DIFF
--- a/crates/astra-sandbox/src/bash_ast.rs
+++ b/crates/astra-sandbox/src/bash_ast.rs
@@ -129,6 +129,9 @@ fn command_words(node: Node<'_>, source: &str) -> Option<Vec<CommandWord>> {
 /// every other dynamic spelling is kept conservative because unquoted field
 /// splitting, arrays, `$@`, or substitutions can change command boundaries.
 fn dynamic_word_may_split(node: Node<'_>, source: &str) -> bool {
+    if node.kind() == "raw_string" {
+        return false;
+    }
     if node.kind() != "string" {
         return true;
     }
@@ -1150,6 +1153,17 @@ fn resolve_find_commands(
             continue;
         };
         expression_started |= is_find_expression_start(argument);
+        let operand_count = find_predicate_operand_count(argument);
+        if operand_count > 0 {
+            index += 1;
+            for _ in 0..operand_count {
+                let Ok(next) = consume_single_argv(words, index) else {
+                    return DestructiveCommandResolution::Ambiguous;
+                };
+                index = next;
+            }
+            continue;
+        }
         if !matches!(argument, "-exec" | "-execdir" | "-ok" | "-okdir") {
             index += 1;
             continue;
@@ -1179,6 +1193,19 @@ fn resolve_find_commands(
 
 fn is_find_expression_start(argument: &str) -> bool {
     argument.starts_with('-') || matches!(argument, "!" | "(" | ")" | ",")
+}
+
+fn find_predicate_operand_count(argument: &str) -> usize {
+    match argument {
+        "-fprintf" => 2,
+        "-name" | "-iname" | "-path" | "-ipath" | "-wholename" | "-iwholename" | "-regex"
+        | "-iregex" | "-lname" | "-ilname" | "-type" | "-xtype" | "-size" | "-user" | "-group"
+        | "-uid" | "-gid" | "-perm" | "-inum" | "-links" | "-samefile" | "-newer" | "-anewer"
+        | "-cnewer" | "-amin" | "-atime" | "-cmin" | "-ctime" | "-mmin" | "-mtime" | "-used"
+        | "-fstype" | "-maxdepth" | "-mindepth" | "-regextype" | "-printf" | "-fprint"
+        | "-fprint0" | "-fls" => 1,
+        _ => 0,
+    }
 }
 
 fn command_basename(raw: &str) -> String {
@@ -1493,6 +1520,20 @@ mod tests {
             fixture.to_string_lossy()
         );
         assert_eq!(std::fs::read(&fixture).expect("read fixture"), b"unchanged");
+        for name in ["example.rs", "-exec", "dd"] {
+            std::fs::write(temp_dir.path().join(name), b"unchanged").unwrap();
+            let pattern = if name == "example.rs" { "*.rs" } else { name };
+            let output = Command::new("sh")
+                .args(["-c", "find . -name \"$1\" -print", "sh", pattern])
+                .current_dir(temp_dir.path())
+                .output()
+                .expect("run find pattern probe");
+            assert!(output.status.success());
+            assert_eq!(
+                String::from_utf8_lossy(&output.stdout).trim(),
+                format!("./{name}")
+            );
+        }
     }
 
     #[test]

--- a/crates/astra-tools/src/shell_ops.rs
+++ b/crates/astra-tools/src/shell_ops.rs
@@ -5229,6 +5229,24 @@ printf 'probe.txt:1:needle\n'
     }
 
     #[test]
+    fn validate_execute_bash_preserves_find_operand_boundaries() {
+        for predicate in ["-name", "-iname", "-path", "-ipath", "-regex", "-iregex"] {
+            for pattern in ["\"$pattern\"", "'-exec'", "'dd'", "'*.rs'"] {
+                let command = format!("find . {predicate} {pattern} -print");
+                assert!(validate_execute_bash_command(&command).is_ok(), "{command}");
+            }
+        }
+        for command in [
+            "find . -name $pattern -print",
+            "find . -name",
+            "find . -name '*.rs' \"$pred\" truncate -s 0 owned.db \\;",
+            "find . -name '-exec' -exec truncate -s 0 owned.db \\;",
+        ] {
+            assert!(validate_execute_bash_command(command).is_err(), "{command}");
+        }
+    }
+
+    #[test]
     fn validate_execute_bash_rejects_ambiguous_dispatcher_options() {
         for command in [
             "timeout --future-option 5 dd if=/dev/zero of=/dev/sda",


### PR DESCRIPTION
## What type of PR is this?

- [x] fix (bug fix)

## Which issue(s) this PR fixes

N/A. Synchronizes the find operand fix from #697 to moi-dev after #713 merged.

## What this PR does / why we need it

Ordinary searches such as `find . -name "$pattern" -print` were rejected, and `-name '-exec'` was mistaken for a child command. The existing AST resolver now consumes known predicate operands as data using the shared single-argv consumer. Missing or split-capable operands and dynamic predicate injection remain rejected.

The moi-dev parser additionally preserves the single-argv nature of single-quoted strings, including wildcard patterns. No raw-text scanner is restored.

## Architecture and complexity delta

- Canonical owner changed or extended: astra-sandbox Bash AST dispatcher resolver.
- Existing implementations/callers searched: find resolution, single-argv consumer, literal word parsing, public execute_bash validator.
- Superseded code, states, tables, shims, and self-only tests removed: none.
- Net code/state/table delta: two existing Rust files; no protocol or persistence changes.
- If parallel implementations remain, the external boundary and retirement condition: no new parallel implementation.

## Production wiring and verification

- Public product entrypoint exercised: execute_bash validator; quoted name/path/regex patterns including literal -exec, missing operands, splitting, and real child dispatch.
- Unhappy paths exercised: split-capable pattern arguments, missing arguments, dynamic predicates and destructive children after valid patterns.
- Verification: targeted astra-tools tests, astra-sandbox lib tests, strict Clippy. The Linux GNU probe also covers wildcard and command-shaped pattern data.
- Database verification: N/A; in-memory parsing only.
