### PR TITLE
fix(sandbox): preserve child shell risks through dispatchers

### DIFF
--- a/crates/astra-sandbox/src/bash_ast.rs
+++ b/crates/astra-sandbox/src/bash_ast.rs
@@ -52,7 +52,7 @@ fn collect_simple_commands(node: Node<'_>, source: &str, commands: &mut Vec<Vec<
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum CommandWord {
     Literal(String),
     Dynamic {
@@ -1041,7 +1041,6 @@ fn resolve_xargs_command(
 ) -> DestructiveCommandResolution {
     const OPTIONS_WITH_VALUE: &[&str] = &[
         "-E",
-        "-I",
         "-L",
         "-n",
         "--max-args",
@@ -1055,8 +1054,8 @@ fn resolve_xargs_command(
         "-d",
         "--delimiter",
     ];
-    const LONG_OPTIONS_WITH_OPTIONAL_INLINE_VALUE: &[&str] = &["--eof", "--replace", "--max-lines"];
-    const OPTIONS_WITH_ATTACHED_VALUE: &[&str] = &["-E", "-I", "-L", "-n", "-P", "-s", "-a", "-d"];
+    const LONG_OPTIONS_WITH_OPTIONAL_INLINE_VALUE: &[&str] = &["--eof", "--max-lines"];
+    const OPTIONS_WITH_ATTACHED_VALUE: &[&str] = &["-E", "-L", "-n", "-P", "-s", "-a", "-d"];
     const FLAGS: &[&str] = &[
         "-0",
         "--null",
@@ -1072,6 +1071,7 @@ fn resolve_xargs_command(
     ];
     const TERMINAL_FLAGS: &[&str] = &["--help", "--version"];
 
+    let mut replacement = None;
     let mut index = 0;
     while let Some(word) = words.get(index) {
         let Some(argument) = word.literal() else {
@@ -1087,6 +1087,27 @@ fn resolve_xargs_command(
         let option = argument.split_once('=').map_or(argument, |(name, _)| name);
         if TERMINAL_FLAGS.contains(&argument) {
             return DestructiveCommandResolution::Safe;
+        }
+        if argument == "-I" {
+            let Some(value) = words.get(index + 1).and_then(CommandWord::literal) else {
+                return DestructiveCommandResolution::Ambiguous;
+            };
+            replacement = Some(value);
+            index += 2;
+            continue;
+        }
+        if let Some(value) = argument
+            .strip_prefix("-I")
+            .filter(|value| !value.is_empty())
+        {
+            replacement = Some(value);
+            index += 1;
+            continue;
+        }
+        if option == "--replace" {
+            replacement = Some(argument.split_once('=').map_or("{}", |(_, value)| value));
+            index += 1;
+            continue;
         }
         if LONG_OPTIONS_WITH_OPTIONAL_INLINE_VALUE.contains(&option) {
             index += 1;
@@ -1119,8 +1140,35 @@ fn resolve_xargs_command(
     if index == words.len() {
         DestructiveCommandResolution::Safe
     } else {
-        resolve_destructive_command(&words[index..], shell_depth)
+        match replacement {
+            Some(marker) => resolve_replaced_command(&words[index..], marker, shell_depth),
+            None => resolve_destructive_command(&words[index..], shell_depth),
+        }
     }
+}
+
+/// Replacement preserves argv boundaries but not literal contents. Reuse the
+/// normal resolver so data arguments stay allowed while executable/script and
+/// option boundaries must still be statically known.
+fn resolve_replaced_command(
+    words: &[CommandWord],
+    marker: &str,
+    shell_depth: usize,
+) -> DestructiveCommandResolution {
+    if marker.is_empty() {
+        return DestructiveCommandResolution::Ambiguous;
+    }
+    let replaced: Vec<_> = words
+        .iter()
+        .map(|word| match word.literal() {
+            Some(value) if value.contains(marker) => CommandWord::Dynamic {
+                may_split: false,
+                proven_find_path: false,
+            },
+            _ => word.clone(),
+        })
+        .collect();
+    resolve_destructive_command(&replaced, shell_depth)
 }
 
 fn resolve_find_commands(
@@ -1172,7 +1220,7 @@ fn resolve_find_commands(
         {
             return DestructiveCommandResolution::Ambiguous;
         }
-        match resolve_destructive_command(&words[command_start..command_end], shell_depth) {
+        match resolve_replaced_command(&words[command_start..command_end], "{}", shell_depth) {
             DestructiveCommandResolution::Safe => {}
             DestructiveCommandResolution::ChildRisks(risks) => child_risks.extend(risks),
             result => return result,
@@ -1191,6 +1239,12 @@ fn is_find_expression_start(argument: &str) -> bool {
 }
 
 fn find_predicate_operand_count(argument: &str) -> usize {
+    if let Some(suffix) = argument.strip_prefix("-newer") {
+        let bytes = suffix.as_bytes();
+        if bytes.len() == 2 && b"acmB".contains(&bytes[0]) && b"acmBt".contains(&bytes[1]) {
+            return 1;
+        }
+    }
     match argument {
         "-fprintf" => 2,
         "-name" | "-iname" | "-path" | "-ipath" | "-wholename" | "-iwholename" | "-regex"

--- a/crates/astra-sandbox/src/bash_ast.rs
+++ b/crates/astra-sandbox/src/bash_ast.rs
@@ -253,20 +253,11 @@ fn analyze_bash_risks_ast_inner(command: &str, shell_depth: usize) -> Vec<Comman
                     ctx.push(CommandRisk::RemoteCodeExecution);
                 }
                 DestructiveCommandResolution::Safe => {}
-            }
-            match nested_shell_script(&words) {
-                NestedShellScript::Script(script) if shell_depth < 16 => {
-                    // Quoted `sh -c` input is a new shell program, unlike
-                    // heredoc input to Python/Node. Parse it as Bash so a real
-                    // destructive command cannot hide behind a shell wrapper.
-                    for risk in analyze_bash_risks_ast_inner(script, shell_depth + 1) {
+                DestructiveCommandResolution::ChildRisks(risks) => {
+                    for risk in risks {
                         ctx.push(risk);
                     }
                 }
-                NestedShellScript::Script(_) | NestedShellScript::Ambiguous => {
-                    ctx.push(CommandRisk::RemoteCodeExecution);
-                }
-                NestedShellScript::None => {}
             }
         }
         let mut cursor = node.walk();
@@ -417,6 +408,7 @@ const DESTRUCTIVE_COMMANDS: &[&str] = &[
 enum DestructiveCommandResolution {
     Safe,
     Destructive(String),
+    ChildRisks(Vec<CommandRisk>),
     Ambiguous,
 }
 
@@ -449,11 +441,8 @@ fn resolve_destructive_command(
         }
         NestedShellScript::Script(script) => {
             let nested_risks = analyze_bash_risks_ast_inner(script, shell_depth + 1);
-            if let Some(name) = nested_risks.into_iter().find_map(|risk| match risk {
-                CommandRisk::DestructiveCommand(name) => Some(name),
-                _ => None,
-            }) {
-                return DestructiveCommandResolution::Destructive(name);
+            if !nested_risks.is_empty() {
+                return DestructiveCommandResolution::ChildRisks(nested_risks);
             }
         }
         NestedShellScript::Ambiguous => return DestructiveCommandResolution::Ambiguous,
@@ -1140,6 +1129,7 @@ fn resolve_find_commands(
 ) -> DestructiveCommandResolution {
     let mut index = 0;
     let mut expression_started = false;
+    let mut child_risks = Vec::new();
     while index < words.len() {
         let Some(argument) = words[index].literal() else {
             // Quoting proves one argv entry, but not that its value is a path:
@@ -1184,11 +1174,16 @@ fn resolve_find_commands(
         }
         match resolve_destructive_command(&words[command_start..command_end], shell_depth) {
             DestructiveCommandResolution::Safe => {}
+            DestructiveCommandResolution::ChildRisks(risks) => child_risks.extend(risks),
             result => return result,
         }
         index = command_end + 1;
     }
-    DestructiveCommandResolution::Safe
+    if child_risks.is_empty() {
+        DestructiveCommandResolution::Safe
+    } else {
+        DestructiveCommandResolution::ChildRisks(child_risks)
+    }
 }
 
 fn is_find_expression_start(argument: &str) -> bool {

--- a/crates/astra-sandbox/src/bash_ast.rs
+++ b/crates/astra-sandbox/src/bash_ast.rs
@@ -315,10 +315,13 @@ fn nested_shell_script(words: &[CommandWord]) -> NestedShellScript<'_> {
         let Some(argument) = word.literal() else {
             return NestedShellScript::Ambiguous;
         };
-        if argument == "--"
-            || argument == "-"
-            || (!argument.starts_with('-') && !argument.starts_with('+'))
-        {
+        if argument == "--" || argument == "-" {
+            return match words.get(argument_index + 1) {
+                Some(CommandWord::Dynamic { .. }) => NestedShellScript::Ambiguous,
+                _ => NestedShellScript::None,
+            };
+        }
+        if !argument.starts_with('-') && !argument.starts_with('+') {
             return NestedShellScript::None;
         }
 
@@ -1142,7 +1145,16 @@ fn resolve_xargs_command(
     } else {
         match replacement {
             Some(marker) => resolve_replaced_command(&words[index..], marker, false, shell_depth),
-            None => resolve_destructive_command(&words[index..], shell_depth),
+            None => {
+                // Input supplies an unknown argv suffix, not just data: it can
+                // complete an unfinished launcher or shell option boundary.
+                let mut child = words[index..].to_vec();
+                child.push(CommandWord::Dynamic {
+                    may_split: true,
+                    proven_find_path: false,
+                });
+                resolve_destructive_command(&child, shell_depth)
+            }
         }
     }
 }

--- a/crates/astra-sandbox/src/bash_ast.rs
+++ b/crates/astra-sandbox/src/bash_ast.rs
@@ -1141,7 +1141,7 @@ fn resolve_xargs_command(
         DestructiveCommandResolution::Safe
     } else {
         match replacement {
-            Some(marker) => resolve_replaced_command(&words[index..], marker, shell_depth),
+            Some(marker) => resolve_replaced_command(&words[index..], marker, false, shell_depth),
             None => resolve_destructive_command(&words[index..], shell_depth),
         }
     }
@@ -1153,6 +1153,7 @@ fn resolve_xargs_command(
 fn resolve_replaced_command(
     words: &[CommandWord],
     marker: &str,
+    replace_executable: bool,
     shell_depth: usize,
 ) -> DestructiveCommandResolution {
     if marker.is_empty() {
@@ -1160,11 +1161,14 @@ fn resolve_replaced_command(
     }
     let replaced: Vec<_> = words
         .iter()
-        .map(|word| match word.literal() {
-            Some(value) if value.contains(marker) => CommandWord::Dynamic {
-                may_split: false,
-                proven_find_path: false,
-            },
+        .enumerate()
+        .map(|(index, word)| match word.literal() {
+            Some(value) if (replace_executable || index > 0) && value.contains(marker) => {
+                CommandWord::Dynamic {
+                    may_split: false,
+                    proven_find_path: false,
+                }
+            }
             _ => word.clone(),
         })
         .collect();
@@ -1220,7 +1224,8 @@ fn resolve_find_commands(
         {
             return DestructiveCommandResolution::Ambiguous;
         }
-        match resolve_replaced_command(&words[command_start..command_end], "{}", shell_depth) {
+        match resolve_replaced_command(&words[command_start..command_end], "{}", true, shell_depth)
+        {
             DestructiveCommandResolution::Safe => {}
             DestructiveCommandResolution::ChildRisks(risks) => child_risks.extend(risks),
             result => return result,

--- a/crates/astra-tools/src/shell_ops.rs
+++ b/crates/astra-tools/src/shell_ops.rs
@@ -5229,6 +5229,38 @@ printf 'probe.txt:1:needle\n'
     }
 
     #[test]
+    fn validate_execute_bash_preserves_xargs_appended_argv() {
+        assert!(
+            validate_execute_bash_command("printf '%s\\0' truncate -s 0 fixture | xargs -0 env")
+                .is_err()
+        );
+        for child in [
+            "sh",
+            "env",
+            "env sh",
+            "timeout 5 env",
+            "sh --",
+            "sh -c",
+            "busybox sh",
+        ] {
+            let command = format!("printf '%s\\0' -c 'truncate -s 0 fixture' | xargs -0 {child}");
+            assert!(
+                validate_execute_bash_command(&command).is_err(),
+                "{command}"
+            );
+        }
+        for child in [
+            "printf '%s'",
+            "env printf '%s'",
+            "sh -c 'printf %s \"$1\"' sh",
+            "env sh -c 'printf ok'",
+        ] {
+            let command = format!("printf input | xargs {child}");
+            assert!(validate_execute_bash_command(&command).is_ok(), "{command}");
+        }
+    }
+
+    #[test]
     fn validate_execute_bash_preserves_dispatch_replacement_boundaries() {
         assert!(
             validate_execute_bash_command("printf input | xargs -Ish sh -c 'printf ok'").is_ok()

--- a/crates/astra-tools/src/shell_ops.rs
+++ b/crates/astra-tools/src/shell_ops.rs
@@ -5229,6 +5229,30 @@ printf 'probe.txt:1:needle\n'
     }
 
     #[test]
+    fn validate_execute_bash_preserves_dispatched_shell_risks() {
+        for (script, allowed) in [
+            ("printf hello", true),
+            ("tool=truncate; \"$tool\" -s 0 fixture", false),
+            ("eval \"$code\"", false),
+            ("truncate -s 0 fixture", false),
+        ] {
+            for command in [
+                format!("sh -c '{script}'"),
+                format!("printf x | xargs sh -c '{script}'"),
+                format!("find . -exec sh -c '{script}' \\;"),
+                format!("printf x | xargs env sh -c '{script}'"),
+                format!("find . -exec sh -c 'printf hello > out' \\; -exec sh -c '{script}' \\;"),
+            ] {
+                assert_eq!(
+                    validate_execute_bash_command(&command).is_ok(),
+                    allowed,
+                    "{command}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn validate_execute_bash_preserves_find_operand_boundaries() {
         for predicate in ["-name", "-iname", "-path", "-ipath", "-regex", "-iregex"] {
             for pattern in ["\"$pattern\"", "'-exec'", "'dd'", "'*.rs'"] {

--- a/crates/astra-tools/src/shell_ops.rs
+++ b/crates/astra-tools/src/shell_ops.rs
@@ -5230,6 +5230,9 @@ printf 'probe.txt:1:needle\n'
 
     #[test]
     fn validate_execute_bash_preserves_dispatch_replacement_boundaries() {
+        assert!(
+            validate_execute_bash_command("printf input | xargs -Ish sh -c 'printf ok'").is_ok()
+        );
         for option in [
             "-I{}",
             "-I {}",

--- a/crates/astra-tools/src/shell_ops.rs
+++ b/crates/astra-tools/src/shell_ops.rs
@@ -5229,6 +5229,63 @@ printf 'probe.txt:1:needle\n'
     }
 
     #[test]
+    fn validate_execute_bash_preserves_dispatch_replacement_boundaries() {
+        for option in [
+            "-I{}",
+            "-I {}",
+            "--replace",
+            "--replace={}",
+            "-ITOKEN",
+            "--replace=TOKEN",
+        ] {
+            let marker = if option.contains("TOKEN") {
+                "TOKEN"
+            } else {
+                "{}"
+            };
+            for (child, allowed) in [
+                (format!("sh -c '{marker}'"), false),
+                (format!("env sh -c 'printf ok; {marker}'"), false),
+                (format!("printf '%s' '{marker}'"), true),
+                (format!("sh -c 'printf %s \"$1\"' sh '{marker}'"), true),
+            ] {
+                let command = format!("printf input | xargs {option} {child}");
+                assert_eq!(
+                    validate_execute_bash_command(&command).is_ok(),
+                    allowed,
+                    "{command}"
+                );
+            }
+        }
+        for (child, allowed) in [
+            ("sh -c '{}'", false),
+            ("sh -c 'printf ok; {}'", false),
+            ("printf '%s' '{}'", true),
+            ("sh -c 'printf %s \"$1\"' sh '{}'", true),
+        ] {
+            let command = format!("find . -exec {child} \\;");
+            assert_eq!(
+                validate_execute_bash_command(&command).is_ok(),
+                allowed,
+                "{command}"
+            );
+        }
+        for predicate in ["-neweram", "-newermm", "-newerBa"] {
+            let command = format!("find . {predicate} '-exec' -print");
+            assert!(validate_execute_bash_command(&command).is_ok(), "{command}");
+        }
+        assert!(validate_execute_bash_command("find . -newermt '2026-01-01' -print").is_ok());
+        for command in [
+            "find . -neweram $reference -print",
+            "find . -neweram",
+            "find . -neweram '-exec' -exec truncate -s 0 fixture \\;",
+            "printf input | xargs -I \"$marker\" sh -c '{}'",
+        ] {
+            assert!(validate_execute_bash_command(command).is_err(), "{command}");
+        }
+    }
+
+    #[test]
     fn validate_execute_bash_preserves_dispatched_shell_risks() {
         for (script, allowed) in [
             ("printf hello", true),


### PR DESCRIPTION
## Summary

Preserve all child-shell risks through the shared AST dispatcher resolver. Dynamic executables and eval must be rejected consistently for direct sh -c, xargs and find -exec. Accumulate risks across multiple find children, and remove duplicate direct-shell analysis. Port of the latest #697 review fix, following merged #732.

Also models xargs/find replacement placeholders as dynamic argv contents using the existing resolver, preserving ordinary data arguments while rejecting replaced executable/script boundaries. Recognizes find -newerXY reference operand arity to avoid treating reference filenames as predicates.

## Related issue

Non-replacement xargs includes an unknown appended argv suffix in child resolution, so input cannot complete an unchecked shell or launcher boundary. Ordinary data consumers and fully specified literal shell scripts remain supported.

#697 review thread discussion_r3965226784.

## Change type

- [x] Bug fix
- [x] Test

## User and compatibility impact

Closes a classification bypass through supported dispatchers. Benign printf scripts remain allowed. No API, configuration, database or migration changes. OS sandbox boundaries are unchanged.

## Architecture and complexity delta

- Canonical owner changed or extended: astra-sandbox AST dispatcher resolver.
- Existing implementations and callers searched: nested shell analysis, find/xargs/launcher recursion, public execute_bash validator.
- Superseded code removed: duplicate direct-shell recursive analysis.
- No parallel implementation, fallback or raw-text scanning added.

## Verification

- Commands: cargo test -p astra-tools --lib validate_execute_bash; cargo test -p astra-sandbox --lib; cargo clippy -p astra-sandbox -p astra-tools --all-targets -- -D warnings; cargo fmt --all; git diff --check.
- Public entrypoint: execute_bash validator; direct shell, xargs, xargs/env, find and multiple find children.
- Unhappy paths: dynamic executable, eval and literal truncate. Benign printf controls remain allowed.
- Database verification: N/A, in-memory analysis only.
- Results: 16 public validator tests and 153 sandbox tests passed; strict all-targets Clippy passed. Full repository gates were not run; targeted checks cover the two changed files.

## Final checklist

- [x] Added public entrypoint regression tests.
- [x] No public contract or documentation changes needed.
- [x] Checked diff scope and sensitive information.
- [x] Conventional Commit title.
