### PR TITLE
fix(session): read created session before committing

### DIFF
--- a/crates/services/src/auth/session.rs
+++ b/crates/services/src/auth/session.rs
@@ -358,7 +358,7 @@ impl DatabaseSessionService {
 
     async fn fetch_session_for_user(
         &self,
-        pool: &sqlx::Pool<MySql>,
+        executor: impl sqlx::Executor<'_, Database = MySql>,
         session_id: &str,
         user_id: &str,
     ) -> Result<Option<SessionRecord>, (StatusCode, Json<ErrorResponse>)> {
@@ -372,7 +372,7 @@ impl DatabaseSessionService {
         )
         .bind(session_id)
         .bind(user_id)
-        .fetch_optional(pool)
+        .fetch_optional(executor)
         .await
         .map_err(internal_error)?
         .map(session_record_from_row)
@@ -495,12 +495,15 @@ impl SessionService for DatabaseSessionService {
         .execute(&mut *tx)
         .await
         .map_err(internal_error)?;
-        tx.commit().await.map_err(internal_error)?;
-
+        // Read our own insert in the same transaction. A new pooled transaction
+        // can use an older MatrixOne snapshot and miss a successfully committed
+        // session. Keep database-generated fields, but only return after commit
+        // succeeds so a commit failure cannot be reported as successful creation.
         let record = self
-            .fetch_session_for_user(&pool, &session_id, &user_id)
+            .fetch_session_for_user(&mut *tx, &session_id, &user_id)
             .await?
             .ok_or_else(|| internal_error("failed to read created session"))?;
+        tx.commit().await.map_err(internal_error)?;
         let details = serde_json::json!({
             "title": record.title,
             "agent_id": record.agent_id,

--- a/crates/services/tests/services_db_integration.rs
+++ b/crates/services/tests/services_db_integration.rs
@@ -65,6 +65,65 @@ async fn setup_pool_and_settings() -> (SharedPool, MatrixOneSettings) {
     common::setup_pool_and_settings().await
 }
 
+#[tokio::test]
+#[ignore = "requires live MatrixOne (ASTRA_TEST_DB_IT=1)"]
+async fn session_creation_returns_database_fields_and_commits_before_success() {
+    let (shared, settings) = setup_pool_and_settings().await;
+    let pool = shared.get().clone();
+    let user_id = format!("session-create-it-{}", Uuid::new_v4());
+    let service = DatabaseSessionService::new(settings).with_pool(shared);
+    let metadata = serde_json::Map::from_iter([("marker".into(), serde_json::json!(user_id))]);
+    let record = service
+        .create_session(
+            user_id.clone(),
+            astra_services::auth::session::SessionCreateRequestData {
+                title: Some("Session creation visibility".into()),
+                agent_id: Some("test-agent".into()),
+                metadata: Some(metadata.clone()),
+            },
+        )
+        .await
+        .expect("create session and commit");
+
+    // Check the actual database values, including generated timestamps, rather
+    // than accepting a response synthesized from the request before commit.
+    let row = sqlx::query(
+        "SELECT title, agent_id, status, event_count, \
+         DATE_FORMAT(created_at, '%Y-%m-%dT%H:%i:%s') AS created_at, \
+         DATE_FORMAT(updated_at, '%Y-%m-%dT%H:%i:%s') AS updated_at \
+         FROM agent_sessions WHERE session_id = ? AND user_id = ?",
+    )
+    .bind(&record.session_id)
+    .bind(&user_id)
+    .fetch_one(&pool)
+    .await
+    .expect("session must be committed after successful creation");
+    assert_eq!(record.user_id, user_id);
+    assert_eq!(record.metadata, metadata);
+    assert_eq!(record.title.as_deref(), Some(row.get::<&str, _>("title")));
+    assert_eq!(
+        record.agent_id.as_deref(),
+        Some(row.get::<&str, _>("agent_id"))
+    );
+    assert_eq!(record.status, row.get::<String, _>("status"));
+    assert_eq!(record.event_count, row.get::<i64, _>("event_count"));
+    assert_eq!(record.created_at, row.get::<String, _>("created_at"));
+    assert_eq!(record.updated_at, Some(row.get::<String, _>("updated_at")));
+    assert_eq!(record.ended_at, None);
+
+    for table in [
+        "agent_sessions",
+        "agent_session_lifecycle_fences",
+        "auth_audit_logs",
+    ] {
+        sqlx::query(&format!("DELETE FROM {table} WHERE user_id = ?"))
+            .bind(&user_id)
+            .execute(&pool)
+            .await
+            .expect("clean up test-owned rows");
+    }
+}
+
 async fn cleanup_skills_by_ids(pool: &sqlx::Pool<sqlx::MySql>, ids: &[String]) {
     for id in ids {
         let _ = sqlx::query("DELETE FROM skills_registry WHERE skill_id = ?")

--- a/crates/services/tests/services_db_integration.rs
+++ b/crates/services/tests/services_db_integration.rs
@@ -93,7 +93,10 @@ async fn session_creation_returns_database_generated_fields_after_commit() {
     assert_eq!(record.event_count, 0);
     chrono::NaiveDateTime::parse_from_str(&record.created_at, "%Y-%m-%dT%H:%M:%S")
         .expect("database-generated creation timestamp");
-    assert_eq!(record.updated_at.as_deref(), Some(record.created_at.as_str()));
+    assert_eq!(
+        record.updated_at.as_deref(),
+        Some(record.created_at.as_str())
+    );
     assert_eq!(record.ended_at, None);
 
     // Do not verify persistence with an immediate pooled SELECT: its snapshot

--- a/crates/services/tests/services_db_integration.rs
+++ b/crates/services/tests/services_db_integration.rs
@@ -67,7 +67,7 @@ async fn setup_pool_and_settings() -> (SharedPool, MatrixOneSettings) {
 
 #[tokio::test]
 #[ignore = "requires live MatrixOne (ASTRA_TEST_DB_IT=1)"]
-async fn session_creation_returns_database_fields_and_commits_before_success() {
+async fn session_creation_returns_database_generated_fields_after_commit() {
     let (shared, settings) = setup_pool_and_settings().await;
     let pool = shared.get().clone();
     let user_id = format!("session-create-it-{}", Uuid::new_v4());
@@ -85,31 +85,20 @@ async fn session_creation_returns_database_fields_and_commits_before_success() {
         .await
         .expect("create session and commit");
 
-    // Check the actual database values, including generated timestamps, rather
-    // than accepting a response synthesized from the request before commit.
-    let row = sqlx::query(
-        "SELECT title, agent_id, status, event_count, \
-         DATE_FORMAT(created_at, '%Y-%m-%dT%H:%i:%s') AS created_at, \
-         DATE_FORMAT(updated_at, '%Y-%m-%dT%H:%i:%s') AS updated_at \
-         FROM agent_sessions WHERE session_id = ? AND user_id = ?",
-    )
-    .bind(&record.session_id)
-    .bind(&user_id)
-    .fetch_one(&pool)
-    .await
-    .expect("session must be committed after successful creation");
     assert_eq!(record.user_id, user_id);
     assert_eq!(record.metadata, metadata);
-    assert_eq!(record.title.as_deref(), Some(row.get::<&str, _>("title")));
-    assert_eq!(
-        record.agent_id.as_deref(),
-        Some(row.get::<&str, _>("agent_id"))
-    );
-    assert_eq!(record.status, row.get::<String, _>("status"));
-    assert_eq!(record.event_count, row.get::<i64, _>("event_count"));
-    assert_eq!(record.created_at, row.get::<String, _>("created_at"));
-    assert_eq!(record.updated_at, Some(row.get::<String, _>("updated_at")));
+    assert_eq!(record.title.as_deref(), Some("Session creation visibility"));
+    assert_eq!(record.agent_id.as_deref(), Some("test-agent"));
+    assert_eq!(record.status, "active");
+    assert_eq!(record.event_count, 0);
+    chrono::NaiveDateTime::parse_from_str(&record.created_at, "%Y-%m-%dT%H:%M:%S")
+        .expect("database-generated creation timestamp");
+    assert_eq!(record.updated_at.as_deref(), Some(record.created_at.as_str()));
     assert_eq!(record.ended_at, None);
+
+    // Do not verify persistence with an immediate pooled SELECT: its snapshot
+    // may predate the commit. The separate transaction contract test guards the
+    // read-before-commit ordering; this test checks the database-decoded result.
 
     for table in [
         "agent_sessions",

--- a/crates/services/tests/session_create_transaction_contract.rs
+++ b/crates/services/tests/session_create_transaction_contract.rs
@@ -1,0 +1,44 @@
+// A healthy single-node database does not reliably reproduce a stale pooled
+// snapshot. Guard the transaction boundary explicitly, independently of database
+// timing. This is a source contract, not a cross-CN fault-injection test.
+fn reads_insert_before_committing(source: &str) -> bool {
+    let source: String = source
+        .lines()
+        .map(|line| line.split("//").next().unwrap_or_default())
+        .flat_map(str::chars)
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let Some((_, implementation)) =
+        source.split_once("implSessionServiceforDatabaseSessionService{")
+    else {
+        return false;
+    };
+    let Some((create, _)) = implementation.split_once("asyncfnlist_sessions(") else {
+        return false;
+    };
+    let insert = create.find(".execute(&mut*tx).await.map_err(internal_error)?;");
+    let read = create.find(".fetch_session_for_user(&mut*tx,&session_id,&user_id)");
+    let commit = create.find("tx.commit().await.map_err(internal_error)?;");
+    let returned = create.find("Ok(record)");
+    matches!((insert, read, commit, returned), (Some(i), Some(r), Some(c), Some(o)) if i < r && r < c && c < o)
+        && !create.contains(".fetch_session_for_user(&pool,")
+}
+
+const SOURCE: &str = include_str!("../src/auth/session.rs");
+
+#[test]
+fn session_creation_reads_its_insert_and_propagates_commit_failure() {
+    assert!(reads_insert_before_committing(SOURCE));
+}
+
+#[test]
+fn transaction_contract_rejects_pooled_read_and_ignored_commit_error() {
+    assert!(!reads_insert_before_committing(&SOURCE.replace(
+        ".fetch_session_for_user(&mut *tx, &session_id, &user_id)",
+        ".fetch_session_for_user(&pool, &session_id, &user_id)",
+    )));
+    assert!(!reads_insert_before_committing(&SOURCE.replace(
+        "tx.commit().await.map_err(internal_error)?;",
+        "let _ = tx.commit().await;",
+    )));
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] fix (bug fix)

## Which issue(s) this PR fixes

No linked issue. Equivalent fixes are proposed for `moi-dev` (#736) and `main` (#737).

## What this PR does / why we need it

Session creation commits its INSERT and then reads through the pool. On MatrixOne, a new transaction can use an older snapshot and return no row, causing `failed to read created session` even though creation succeeded.

Read the complete session record inside the INSERT transaction, then commit before returning success. This preserves database-generated fields and propagates commit failures. Add an English explanation, a live-database test of the returned fields, and an offline source-contract check of the transaction ordering.

## Architecture and complexity delta

- Canonical owner extended: `DatabaseSessionService::create_session`.
- Existing implementations/callers searched: session creation, session lookup, deletion and update callers, and existing service integration tests.
- Reuse `fetch_session_for_user` with a SQLx executor so both the pool and creation transaction use the same query and decoder.
- Remove the post-commit lookup from creation. No new schema, migrations, state, retries, or parallel implementation.

## Production wiring and verification

- Public product entrypoint: QA `/chat/stream` failure traced to session creation; fixed product flow has not been exercised locally.
- `cargo check -p astra-services --test services_db_integration --offline --locked` passed on the updated `moi-dev` change; not rerun on `main`.
- Two offline transaction-contract tests passed using `rustc --test`. They guard INSERT -> transaction-local read -> fallible commit -> success, and reject pooled-read / ignored-commit-error mutations. These are source checks, not database fault injection.
- Cherry-pick onto `main` completed without conflicts; `git diff --check` passed. Fixed the review follow-up assertion formatting reported by CI; `cargo fmt --all -- --check` now passes on both branches.
- Unhappy-path review: lookup/decoding errors return before commit; commit errors propagate before success and audit logging. No fault-injection test was run.
- Live MatrixOne integration test added but not executed locally. It checks returned fields without an immediate pooled persistence query, which could itself see a stale snapshot. A controlled cross-CN stale-snapshot scenario and an independent causally guaranteed persistence assertion remain unverified; the source-contract test is not claimed as a substitute for either.
