### PR TITLE
chore(release): prepare Astra 0.2.3

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -3,7 +3,7 @@
 
 # ── Published images / ingress ─────────────────────────────────────────────
 # Pin an immutable release tag or digest. Do not deploy `latest` in production.
-ASTRA_IMAGE=matrixorigin/astra:0.2.2
+ASTRA_IMAGE=matrixorigin/astra:0.2.3
 NGINX_IMAGE=nginx:1.30.4-alpine
 ASTRA_PUBLIC_BIND_ADDRESS=0.0.0.0
 ASTRA_PUBLIC_HTTP_PORT=80

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use Astra, please cite the ContextPipe paper and this software."
 title: Astra
 type: software
-version: 0.2.2
+version: 0.2.3
 authors:
   - name: MatrixOrigin
 repository-code: "https://github.com/matrixorigin/Astra"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "astra-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-config",
  "astra-core",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "astra-config"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "astra-turn-types",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "astra-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "astra-credentials"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "dirs",
  "fs2",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "astra-edge"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "astra-credentials",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "astra-harness"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-turn-core",
  "serde",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "astra-logging"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "astra-mcp"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-turn-types",
  "chrono",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "astra-memoria"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-turn-types",
  "async-trait",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "astra-messaging"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-text-utils",
  "astra-turn-types",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "astra-pipeline"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "astra-services",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "astra-plan"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "astra-services",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "astra-prompts"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "chrono",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "astra-runtime"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-config",
  "astra-core",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "astra-runtime-env"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "async-trait",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "astra-sandbox"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "astra-skills",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "astra-server-types"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "astra-services",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "astra-services"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-config",
  "astra-core",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "astra-skills"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "astra-pipeline",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "astra-sync-protocol"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "hmac",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "astra-test-harness"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "astra-credentials",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "astra-text-utils"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "dirs",
  "serde",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "astra-thin-client"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "astra-runtime-env",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "astra-tools"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "astra-memoria",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "astra-turn-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-core",
  "astra-messaging",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "astra-turn-types"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "astra-prompts",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/deployment/all-in-one/.env.example
+++ b/deployment/all-in-one/.env.example
@@ -15,7 +15,7 @@
 # These three images are one tested compatibility set. Release PRs update the
 # Astra version and deliberately advance dependency digests only after the
 # all-in-one candidate smoke passes on AMD64 and ARM64.
-ASTRA_IMAGE=matrixorigin/astra:0.2.2
+ASTRA_IMAGE=matrixorigin/astra:0.2.3
 MEMORIA_IMAGE=matrixorigin/memoria@sha256:9075cb57c0304197d906d1fdb6c71cbeb1e000153ab5fe3b766ddcd0134e8478
 MATRIXONE_IMAGE=matrixorigin/matrixone@sha256:c95d1b468e3fc5f4f2b377da14f4601e7efefa6eb143758636d60114a5bbb436
 

--- a/deployment/kubernetes/chart/Chart.yaml
+++ b/deployment/kubernetes/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: astra-engine
 description: Enterprise agent runtime with auditable context and execution
 type: application
-version: 0.2.2
-appVersion: "0.2.2"
+version: 0.2.3
+appVersion: "0.2.3"

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astra/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@astra/sdk",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astra/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "description": "TypeScript SDK for Astra — streaming chat, tool execution, and WebSocket support",
   "homepage": "https://github.com/matrixorigin/Astra#readme",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astra-web",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astra-web",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@astra/sdk": "file:../packages/sdk",
         "@floating-ui/core": "1.8.0",
@@ -55,7 +55,7 @@
     },
     "../packages/sdk": {
       "name": "@astra/sdk",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astra-web",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "scripts": {
     "dev": "../scripts/dev/run-web-dev.sh",


### PR DESCRIPTION
## Summary

- Prepare the Rust workspace, TypeScript SDK, and Web application for Astra 0.2.3.
- Update the Helm chart version and appVersion to 0.2.3.
- Update example Astra image tags to 0.2.3 while preserving the pinned MatrixOne and Memoria compatibility digests.

## Related issue

N/A

## Change type

- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor or performance improvement
- [ ] Test
- [x] Build, CI, or maintenance

## User and compatibility impact

No runtime behavior, API, configuration, or database compatibility changes. This PR only prepares release metadata for 0.2.3.

## Architecture and complexity delta

- Canonical owner changed or extended: N/A
- Existing implementations and callers searched: N/A
- Superseded code, states, tables, shims, or self-only tests removed: N/A
- If parallel implementations remain, their boundary and retirement condition: N/A

## Verification

- Commands and results:
  - `make release-prepare VERSION=0.2.3` — passed
  - `scripts/validate-release-version.sh 0.2.3` — passed
  - `git diff --check` — passed
  - `make release-check VERSION=0.2.3` — release metadata validation passed; the existing `scripts/dev/test_edge_process_contract.sh` contract test failed locally on macOS when its immediate `ps` lookup returned no command for the fixture process
- Public entrypoint exercised: N/A; metadata-only change
- Unhappy paths exercised: N/A; metadata-only change
- Database verification: N/A; no database changes

## Final checklist

- [x] No behavior test was added because this is a metadata-only release preparation.
- [x] No public or design documentation update is required because no contract changed.
- [x] I checked the diff for credentials, private URLs, customer data, generated files, and other sensitive information.
- [x] The PR title follows the repository conventional commit format.