### PR TITLE
fix(release): allow main to advance after candidate selection

### DIFF
--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -50,16 +50,24 @@ Publication is deliberately ordered:
 7. update stable rolling Docker tags.
 
 The protected publication job uses the built-in `GITHUB_TOKEN`. Immediately
-before creating a new tag, it requires the selected source to still be the
-current `main` head. If `main` advanced during builds or approval, publication
-stops before creating a tag or versioned Docker manifest. Start a new normal
-release run from current `main`; rerunning the old candidates cannot fix this.
+before creating a new tag, it fetches the default branch and requires the
+selected source to remain reachable from `main`. Normal merges during builds
+or approval do not invalidate the candidates: the tag still points to the
+exact source selected at preflight, and publication reuses its verified
+artifacts. If the source is no longer reachable or branch history cannot be
+fetched, publication stops before creating a tag or versioned Docker manifest.
 
-This check is not an atomic lock on `main`: a concurrent update can still cause
-GitHub to reject tag creation. Existing-tag recovery remains available, but
-does not promise to overcome GitHub workflow-permission restrictions on a
-historical source. If recovery encounters that restriction, stop and inspect
-the partial publication; never move the immutable tag or overwrite its assets.
+Reachability only proves that the selected source belongs to `main` history;
+it does not prove that it still represents the branch's current intent. A
+reverted commit remains an ancestor. Before approving publication or rerunning
+older candidates, maintainers must confirm that the selected source has not
+been reverted or superseded by a decision to abandon that release.
+
+This check is not an atomic lock on `main`. GitHub token permissions and tag
+rulesets still apply, including workflow-permission restrictions on a
+historical source. If GitHub rejects tag creation or existing-tag recovery,
+inspect the error and any partial publication; never move the immutable tag
+or overwrite its assets.
 
 The GitHub Release is not published until the exact Docker version exists. If
 a late step fails, rerun the failed jobs from the same Actions run so its

--- a/scripts/ci/test_release_build_shells.py
+++ b/scripts/ci/test_release_build_shells.py
@@ -491,29 +491,29 @@ esac
                                  "-p", "astra-edge", "--bin", "astra-edge"]
                     self.assertEqual(result.stdout.splitlines(), expected)
 
-    def test_release_tag_creation_requires_current_head(self):
+    def test_release_tag_creation_requires_default_branch_ancestry(self):
         script = ROOT / "scripts/reconcile-release-tag.sh"
         with tempfile.TemporaryDirectory() as directory:
             fixture = Path(directory)
+            remote = fixture / "remote"
+            checkout = fixture / "checkout"
+
+            def git(*args, cwd=remote):
+                return subprocess.run(
+                    ["git", *args], cwd=cwd, check=True,
+                    capture_output=True, text=True,
+                ).stdout.strip()
+
+            remote.mkdir()
+            git("init", "--initial-branch=main")
+            git("config", "user.name", "Release Test")
+            git("config", "user.email", "release-test@example.invalid")
+            git("-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "source")
+            source_sha = git("rev-parse", "HEAD")
+            git("clone", str(remote), str(checkout), cwd=fixture)
             fake_bin = fixture / "bin"
             fake_bin.mkdir()
             calls = fixture / "calls"
-            (fake_bin / "git").write_text(
-                """#!/bin/sh
-set -eu
-printf '%s\\n' "git $*" >> "${ASTRA_TEST_CALLS}"
-case "$*" in
-  "ls-remote origin refs/tags/"*) exit 0 ;;
-  "ls-remote origin refs/heads/main")
-    printf '%s\\trefs/heads/main\\n' "${ASTRA_TEST_DEFAULT_SHA}"
-    ;;
-  "fetch --no-tags origin refs/heads/main:refs/remotes/origin/main") exit 0 ;;
-  "merge-base --is-ancestor verified-source-sha new-main-sha") exit 0 ;;
-  *) exit 2 ;;
-esac
-""",
-                encoding="utf-8",
-            )
             (fake_bin / "gh").write_text(
                 """#!/bin/sh
 set -eu
@@ -525,54 +525,83 @@ case "$*" in
   "api --method POST repos/matrixorigin/Astra/git/refs "*) exit 0 ;;
   "api repos/matrixorigin/Astra/git/tags/owned-tag-object")
     printf '{"object":{"sha":"%s"},"message":"Astra v0.2.2\\\\n\\\\nRelease-Run: https://github.com/matrixorigin/Astra/actions/runs/123"}\\n' \
-      'verified-source-sha'
+      "${SOURCE_SHA}"
     ;;
   *) exit 2 ;;
 esac
 """,
                 encoding="utf-8",
             )
-            (fake_bin / "git").chmod(0o755)
             (fake_bin / "gh").chmod(0o755)
             env = {
                 **os.environ,
                 "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
                 "ASTRA_TEST_CALLS": str(calls),
-                "ASTRA_TEST_DEFAULT_SHA": "verified-source-sha",
-                "SOURCE_SHA": "verified-source-sha",
+                "SOURCE_SHA": source_sha,
                 "GITHUB_SERVER_URL": "https://github.com",
             }
-            result = subprocess.run(
-                [
-                    str(script),
-                    "create",
-                    "matrixorigin/Astra",
-                    "v0.2.2",
-                    "verified-source-sha",
-                    "123",
-                    "main",
-                    "",
-                ],
-                env=env,
-                capture_output=True,
-                text=True,
-            )
-            self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertEqual(result.stdout, "owned-tag-object\n")
-            recorded_calls = calls.read_text(encoding="utf-8")
-            self.assertIn("gh api --method POST repos/matrixorigin/Astra/git/tags", recorded_calls)
-            self.assertIn("gh api --method POST repos/matrixorigin/Astra/git/refs", recorded_calls)
 
-            calls.write_text("")
-            stale = subprocess.run(
-                [str(script), "create", "matrixorigin/Astra", "v0.2.2",
-                 "verified-source-sha", "123", "main", ""],
-                env={**env, "ASTRA_TEST_DEFAULT_SHA": "new-main-sha"},
-                capture_output=True, text=True,
-            )
-            self.assertNotEqual(stale.returncode, 0)
-            self.assertIn("Start a new normal release run", stale.stderr)
-            self.assertNotIn("gh ", calls.read_text())
+            def create(selected_source=source_sha):
+                calls.write_text("")
+                return subprocess.run(
+                    [str(script), "create", "matrixorigin/Astra", "v0.2.2",
+                     selected_source, "123", "main", ""],
+                    cwd=checkout, env=env, capture_output=True, text=True,
+                )
+
+            for advanced in (False, True):
+                with self.subTest(advanced=advanced):
+                    if advanced:
+                        git("-c", "commit.gpgsign=false", "commit", "--allow-empty",
+                            "-m", "main advances while candidates build")
+                    result = create()
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout, "owned-tag-object\n")
+                    recorded = calls.read_text()
+                    self.assertIn(f"-f object={source_sha}", recorded)
+                    self.assertIn("gh api --method POST repos/matrixorigin/Astra/git/refs", recorded)
+
+            with self.subTest(source="missing"):
+                result = create("0" * 40)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("is not present as a commit", result.stderr)
+                self.assertEqual(calls.read_text(), "")
+
+            with self.subTest(source="ahead of main"):
+                git("checkout", "--detach", "FETCH_HEAD", cwd=checkout)
+                git("-c", "user.name=Release Test", "-c",
+                    "user.email=release-test@example.invalid", "-c",
+                    "commit.gpgsign=false", "commit", "--allow-empty",
+                    "-m", "unmerged source", cwd=checkout)
+                result = create(git("rev-parse", "HEAD", cwd=checkout))
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("is no longer reachable from main", result.stderr)
+                self.assertEqual(calls.read_text(), "")
+
+            with self.subTest(history="shallow"):
+                shallow_file = checkout / ".git" / "shallow"
+                shallow_file.write_text(source_sha + "\n")
+                try:
+                    result = create()
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("requires a complete checkout", result.stderr)
+                    self.assertEqual(calls.read_text(), "")
+                finally:
+                    shallow_file.unlink()
+
+            git("checkout", "--orphan", "replacement")
+            git("-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "unrelated history")
+            git("branch", "-f", "main", "HEAD")
+            result = create()
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("is no longer reachable from main", result.stderr)
+            self.assertEqual(calls.read_text(), "")
+
+            git("branch", "-D", "main")
+            result = create()
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Could not fetch", result.stderr)
+            self.assertEqual(calls.read_text(), "")
 
     def test_release_tag_creation_is_idempotent_for_the_same_run(self):
         script = ROOT / "scripts/reconcile-release-tag.sh"

--- a/scripts/ci/validate_repository.py
+++ b/scripts/ci/validate_repository.py
@@ -198,7 +198,9 @@ def main() -> None:
         encoding="utf-8"
     )
     for required in (
-        "is no longer the current ${default_branch} head",
+        'git fetch --no-tags origin "refs/heads/${default_branch}"',
+        'git merge-base --is-ancestor "${source_sha}" FETCH_HEAD',
+        "is no longer reachable from ${default_branch}",
         "No tag was created",
         "Release-Run:",
         'gh api --method POST "repos/${repository}/git/tags"',
@@ -207,7 +209,7 @@ def main() -> None:
     ):
         if required not in release_tag_reconciler:
             errors.append(
-                "scripts/reconcile-release-tag.sh: missing current-head or immutable "
+                "scripts/reconcile-release-tag.sh: missing source-ancestry or immutable "
                 f"ownership contract ({required})"
             )
 

--- a/scripts/reconcile-release-tag.sh
+++ b/scripts/reconcile-release-tag.sh
@@ -39,17 +39,28 @@ if [ -z "${remote_tag_object}" ]; then
         exit 1
     fi
 
-    current_default_sha="$(
-        git ls-remote origin "refs/heads/${default_branch}" |
-            awk 'NR == 1 { print $1 }'
-    )"
-    if [ -z "${current_default_sha}" ]; then
-        echo "Could not resolve the current ${default_branch} head before creating ${source_tag}." >&2
+    # Refresh ancestry without changing the source selected and verified by this run.
+    if ! git fetch --no-tags origin "refs/heads/${default_branch}"; then
+        echo "Could not fetch the current ${default_branch} history before creating ${source_tag}." >&2
         exit 1
     fi
-    if [ "${current_default_sha}" != "${source_sha}" ]; then
-        echo "Release source ${source_sha} is no longer the current ${default_branch} head (${current_default_sha})." >&2
-        echo "No tag was created. Start a new normal release run from the current default branch; do not rerun these stale candidates." >&2
+    if ! git cat-file -e "${source_sha}^{commit}" 2>/dev/null; then
+        echo "Release source ${source_sha} is not present as a commit in this checkout." >&2
+        exit 1
+    fi
+    if [ "$(git rev-parse --is-shallow-repository)" != "false" ]; then
+        echo "Release ancestry verification requires a complete checkout (fetch-depth: 0)." >&2
+        exit 1
+    fi
+    ancestry_status=0
+    git merge-base --is-ancestor "${source_sha}" FETCH_HEAD || ancestry_status=$?
+    if [ "${ancestry_status}" -gt 1 ]; then
+        echo "Could not verify release source ancestry (git exit ${ancestry_status})." >&2
+        exit 1
+    fi
+    if [ "${ancestry_status}" -eq 1 ]; then
+        echo "Release source ${source_sha} is no longer reachable from ${default_branch}." >&2
+        echo "No tag was created. Inspect the branch history before starting a new release run." >&2
         exit 1
     fi
 
@@ -63,7 +74,7 @@ if [ -z "${remote_tag_object}" ]; then
             --jq .sha
     )"; then
         echo "GitHub refused to create ${source_tag}." >&2
-        echo "Check the publication token permissions and tag ruleset. If the default branch advanced, start a new normal release run." >&2
+        echo "Check the publication token permissions and tag ruleset, including workflow-permission restrictions for this source." >&2
         exit 1
     fi
     if ! gh api --method POST "repos/${repository}/git/refs" \


### PR DESCRIPTION
## Summary

Release candidates currently become unpublishable when `main` advances during builds or approval, even though their source and artifacts have already been selected and verified. Refresh `main` at tag creation and require the pinned source to remain its ancestor, so normal merges do not invalidate those candidates. Tags still point to the original verified SHA.

Reject missing source commits, shallow checkouts, fetch failures, and unreachable sources before publication. Require both fetch and ancestry checks in the repository contract, and document that maintainers must confirm older candidates have not been reverted or abandoned.

## Related issue

Failure: https://github.com/matrixorigin/Astra/actions/runs/34336315642/job/102444671085

## Change type

- [x] Bug fix
- [x] Documentation
- [x] Test
- [x] Build, CI, or maintenance

## User and compatibility impact

New release runs can publish their verified source after normal `main` advancement. Preflight source selection, Environment approval, immutable tag ownership, and artifact verification remain in place. Old runs still use their original controller revision. GitHub token permissions and tag rulesets still apply.

## Architecture and complexity delta

N/A to runtime architecture. Extends the canonical `scripts/reconcile-release-tag.sh` implementation used by the release workflow. Inspected preflight selection, publication checkout and recovery callers, repository contracts, and release documentation. Replaces the current-head equality check; introduces no parallel release path.

## Verification

- `python3 scripts/ci/test_release_build_shells.py`: 17 tests passed on the final implementation.
- `shellcheck scripts/reconcile-release-tag.sh`: passed.
- `git diff --check`: passed.
- The tag script entrypoint is exercised with real temporary Git repositories and a stubbed GitHub API. Cases cover unchanged and advanced `main`, pinned tag source, source ahead of `main`, missing objects, shallow history, rewritten history, fetch failure, and existing same-run tag idempotency. Rejected ancestry cases assert no GitHub API calls.
- Local review reported `validate_repository.py` failures in the Edge process fixture (macOS SIGKILL) and the release tar-root contract, and reproduced both on the clean base with this patch removed. Full repository validation is therefore not claimed green locally; required CI must pass before merge.
- Live publication was not performed. Database verification is not applicable.

## Final checklist

- [x] Tests cover the owning script and unhappy paths.
- [x] Release documentation reflects the changed contract and recovery boundary.
- [x] Diff reviewed for credentials, private URLs, customer data, generated files, and sensitive information.
- [x] Conventional Commit title.
