### PR TITLE
fix(runtime): resolve temperature and thinking policies for model inference

### DIFF
--- a/crates/astra-turn-core/src/thinking_config.rs
+++ b/crates/astra-turn-core/src/thinking_config.rs
@@ -67,6 +67,20 @@ fn default_effort() -> ThinkingEffort {
 }
 
 impl ThinkingConfig {
+    /// Final OpenAI-chat emission shared with the model probe's wire contract.
+    /// This is deliberately independent of model names and endpoint heuristics.
+    pub fn apply_openai_protocol(
+        &self,
+        body: &mut Value,
+        protocol: astra_core::model_wire::thinking::ThinkingProtocol,
+    ) {
+        let effort = match self {
+            Self::Adaptive { effort } => Some(effort_str(*effort)),
+            _ => None,
+        };
+        protocol.apply(body, self.is_enabled(), effort);
+    }
+
     pub fn is_off(&self) -> bool {
         matches!(self, Self::Off)
     }
@@ -589,55 +603,26 @@ fn provider_uses_budget_thinking(provider: Option<&str>) -> bool {
 
 /// Returns `true` if the provider string alone identifies a DashScope endpoint.
 pub fn provider_may_think_natively(provider: &str) -> bool {
-    let p = provider.to_ascii_lowercase();
-    p.contains("dashscope") || p.contains("aliyun") || p.contains("alibaba")
+    astra_core::model_wire::thinking::is_dashscope_provider(provider)
 }
 
 /// Returns `true` if the endpoint needs `enable_thinking` flag.
 /// Checks both provider string and base_url since many configs use
 /// `provider: "openai"` with a DashScope base_url.
 pub fn needs_dashscope_thinking_flag(provider: &str, base_url: &str) -> bool {
-    if provider_may_think_natively(provider) {
-        return true;
-    }
-    let u = base_url.to_ascii_lowercase();
-    u.contains("dashscope") || u.contains("aliyun")
+    astra_core::model_wire::thinking::canonical_thinking_protocol(provider, base_url, "")
+        == astra_core::model_wire::thinking::ThinkingProtocol::EnableThinking
 }
 
-/// Return the native thinking control for an admitted OpenAI-compatible route.
-///
-/// Matching is deliberately limited to provider protocol identifiers and the
-/// parsed endpoint authority.  Model names and user text are never consulted.
+/// Compatibility projection for callers without a concrete upstream model.
+/// The shared adapter registry is the only endpoint-protocol owner.
 pub fn openai_thinking_control(provider: &str, base_url: &str) -> OpenAiThinkingControl {
-    if needs_dashscope_thinking_flag(provider, base_url) {
-        return OpenAiThinkingControl::EnableThinkingFlag;
+    use astra_core::model_wire::thinking::{ThinkingProtocol, canonical_thinking_protocol};
+    match canonical_thinking_protocol(provider, base_url, "") {
+        ThinkingProtocol::EnableThinking => OpenAiThinkingControl::EnableThinkingFlag,
+        ThinkingProtocol::ThinkingObject => OpenAiThinkingControl::ThinkingObject,
+        _ => OpenAiThinkingControl::None,
     }
-    if is_deepseek_endpoint(provider, base_url) {
-        return OpenAiThinkingControl::ThinkingObject;
-    }
-    OpenAiThinkingControl::None
-}
-
-fn is_deepseek_endpoint(provider: &str, base_url: &str) -> bool {
-    let provider = provider.trim().to_ascii_lowercase();
-    if provider == "deepseek" || provider.starts_with("deepseek-") {
-        return true;
-    }
-    let authority = base_url
-        .trim()
-        .strip_prefix("https://")
-        .or_else(|| base_url.trim().strip_prefix("http://"))
-        .and_then(|rest| rest.split('/').next())
-        .unwrap_or_default()
-        .split('@')
-        .next_back()
-        .unwrap_or_default()
-        .split(':')
-        .next()
-        .unwrap_or_default()
-        .trim_end_matches('.')
-        .to_ascii_lowercase();
-    authority == "api.deepseek.com" || authority.ends_with(".deepseek.com")
 }
 
 /// Strip `<think>...</think>` XML tags from model output, returning only

--- a/crates/core/src/model_wire.rs
+++ b/crates/core/src/model_wire.rs
@@ -2,6 +2,8 @@
 //! Keep this below services/runtime so probes cannot invent a second contract.
 use serde_json::{Value, json};
 
+pub mod thinking;
+
 /// Apply a caller-bounded output budget to Anthropic Messages or OpenAI-style
 /// chat completions. Bedrock Converse has a separate inferenceConfig shape.
 /// Thinking-budget policy belongs to the caller, not this serialization helper.

--- a/crates/core/src/model_wire/thinking.rs
+++ b/crates/core/src/model_wire/thinking.rs
@@ -1,0 +1,258 @@
+//! One OpenAI-chat thinking wire contract for probes and inference.
+//! Unknown protocol is not evidence that reasoning is disabled.
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThinkingProtocol {
+    #[default]
+    Unknown,
+    EnableThinking,
+    ThinkingObject,
+    ReasoningEffort,
+    /// Moonshot's binary toggle, without an additional effort field. Sampling
+    /// capability is independent of the toggle and is not inferred here.
+    Moonshot,
+}
+
+impl ThinkingProtocol {
+    pub const REVISION: u32 = 1;
+
+    pub fn can_disable(self) -> bool {
+        matches!(
+            self,
+            Self::EnableThinking | Self::ThinkingObject | Self::Moonshot
+        )
+    }
+
+    /// Apply known protocols *after* generic overrides. Unknown preserves the
+    /// existing assembly contract. `effort` is canonical low/medium/high/max.
+    pub fn apply(self, body: &mut Value, enabled: bool, effort: Option<&str>) {
+        // Unknown is absence of adapter knowledge, not authority to erase
+        // established provider behavior or explicit administrator overrides.
+        if self == Self::Unknown {
+            return;
+        }
+        let Some(object) = body.as_object_mut() else {
+            return;
+        };
+        for key in ["thinking", "enable_thinking", "reasoning_effort"] {
+            object.remove(key);
+        }
+        match self {
+            Self::Unknown => {}
+            Self::EnableThinking => {
+                body["enable_thinking"] = json!(enabled);
+            }
+            Self::ThinkingObject | Self::Moonshot => {
+                body["thinking"] = json!({"type": if enabled { "enabled" } else { "disabled" }});
+                if self == Self::ThinkingObject
+                    && enabled
+                    && let Some(effort) = effort
+                {
+                    body["reasoning_effort"] = json!(effort);
+                }
+            }
+            Self::ReasoningEffort if enabled => {
+                if let Some(effort) = effort {
+                    body["reasoning_effort"] = json!(effort);
+                }
+            }
+            Self::ReasoningEffort => {}
+        }
+    }
+}
+
+/// Maintained adapter defaults, never substring matching arbitrary URLs.
+/// Explicit per-Offering protocol configuration takes precedence at admission.
+pub fn canonical_thinking_protocol(
+    provider: &str,
+    base_url: &str,
+    model: &str,
+) -> ThinkingProtocol {
+    let url = reqwest::Url::parse(base_url).ok();
+    let host = url.as_ref().and_then(|url| url.host_str()).unwrap_or("");
+    let host = host.trim_end_matches('.');
+    let provider = provider.trim().to_ascii_lowercase();
+    if matches!(provider.as_str(), "anthropic" | "bedrock") {
+        return ThinkingProtocol::Unknown; // Those adapters own their native envelopes.
+    }
+    if provider == "deepseek"
+        || provider.starts_with("deepseek-")
+        || host == "api.deepseek.com"
+        || host.ends_with(".deepseek.com")
+    {
+        return ThinkingProtocol::ThinkingObject;
+    }
+    if is_dashscope_provider(&provider)
+        || host == "dashscope.aliyuncs.com"
+        || host.ends_with(".dashscope.aliyuncs.com")
+        || host == "dashscope-intl.aliyuncs.com"
+        || host == "dashscope-us.aliyuncs.com"
+    {
+        return ThinkingProtocol::EnableThinking;
+    }
+    // https://platform.kimi.com/docs/guide/kimi-k2-6-quickstart
+    // Do not infer protocol from a Kimi model name on an unrelated gateway.
+    if matches!(host, "api.moonshot.cn" | "api.moonshot.ai")
+        && url.as_ref().is_some_and(|u| u.scheme() == "https" && u.port_or_known_default() == Some(443) && u.path().trim_end_matches('/') == "/v1")
+        // K3 toggle is covered by the opt-in real-provider contract, rather
+        // than extrapolated from its name (verified 2026-09-09).
+        && matches!(model, "kimi-k2.5" | "kimi-k2.6" | "kimi-k3")
+    {
+        return ThinkingProtocol::Moonshot;
+    }
+    if provider == "openai" && (host == "api.openai.com" || base_url.is_empty()) {
+        return ThinkingProtocol::ReasoningEffort;
+    }
+    ThinkingProtocol::Unknown
+}
+
+/// Preserve the established provider-alias contract in one owner.
+pub fn is_dashscope_provider(provider: &str) -> bool {
+    let provider = provider.to_ascii_lowercase();
+    provider.contains("dashscope") || provider.contains("aliyun") || provider.contains("alibaba")
+}
+
+/// Shared main/auxiliary Offering temperature configuration. Protocol-specific
+/// adapters still own native restrictions; a thinking toggle is not a sampling
+/// capability and must not invent one.
+pub fn configured_temperature(
+    overrides: Option<&serde_json::Map<String, Value>>,
+    fixed: Option<f64>,
+) -> Result<Option<f64>, String> {
+    let configured = overrides
+        .and_then(|o| o.get("temperature"))
+        .map(|value| {
+            value.as_f64().ok_or_else(|| {
+                "request_body_overrides.temperature must be a finite non-negative number"
+                    .to_string()
+            })
+        })
+        .transpose()?;
+    for (source, value) in [
+        ("request_body_overrides.temperature", configured),
+        ("fixed_temperature", fixed),
+    ] {
+        if value.is_some_and(|v| !v.is_finite() || v < 0.0) {
+            return Err(format!("{source} must be a finite non-negative number"));
+        }
+    }
+    match (configured, fixed) {
+        (Some(configured), Some(fixed)) if configured != fixed => Err(format!(
+            "request_body_overrides.temperature ({configured}) conflicts with fixed_temperature ({fixed})"
+        )),
+        (Some(value), _) => Ok(Some(value)),
+        (None, fixed) => Ok(fixed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toggle_preserves_explicit_sampling_in_both_modes() {
+        for enabled in [false, true] {
+            let mut body = json!({"temperature":0.7,"top_p":0.9,"presence_penalty":0.1,"frequency_penalty":0.2});
+            let original = body.clone();
+            ThinkingProtocol::Moonshot.apply(&mut body, enabled, Some("low"));
+            for key in [
+                "temperature",
+                "top_p",
+                "presence_penalty",
+                "frequency_penalty",
+            ] {
+                assert_eq!(body[key], original[key]);
+            }
+            assert!(body.get("reasoning_effort").is_none());
+        }
+    }
+
+    #[test]
+    fn unknown_preserves_existing_controls_and_dashscope_aliases_agree() {
+        let mut body = json!({"reasoning_effort":"high","enable_thinking":false,"thinking":{"type":"enabled"}});
+        let original = body.clone();
+        ThinkingProtocol::Unknown.apply(&mut body, true, Some("low"));
+        assert_eq!(body, original);
+        for provider in ["dashscope-intl", "alibaba-cloud", "aliyun"] {
+            assert_eq!(
+                canonical_thinking_protocol(provider, "https://gateway.example/v1", "m"),
+                ThinkingProtocol::EnableThinking
+            );
+        }
+    }
+
+    #[test]
+    fn shared_temperature_checks_explicit_conflicts_only() {
+        assert_eq!(configured_temperature(None, Some(0.6)).unwrap(), Some(0.6));
+        let values = json!({"temperature":0.7});
+        assert_eq!(
+            configured_temperature(values.as_object(), None).unwrap(),
+            Some(0.7)
+        );
+        assert!(configured_temperature(values.as_object(), Some(0.6)).is_err());
+        assert!(configured_temperature(None, Some(f64::NAN)).is_err());
+    }
+
+    #[test]
+    fn canonical_contract_rejects_gateway_name_and_url_spoofing() {
+        for url in [
+            "https://api.moonshot.cn.evil.test/v1",
+            "https://api.moonshot.cn@evil.test/v1",
+            "https://evil.test/api.moonshot.cn/v1",
+            "https://api.moonshot.cn:8443/v1",
+            "https://api.moonshot.cn/proxy",
+        ] {
+            assert_eq!(
+                canonical_thinking_protocol("openai-compatible", url, "kimi-k2.6"),
+                ThinkingProtocol::Unknown
+            );
+        }
+        assert_eq!(
+            canonical_thinking_protocol(
+                "openai-compatible",
+                "https://api.moonshot.cn/v1",
+                "unknown"
+            ),
+            ThinkingProtocol::Unknown
+        );
+        assert_eq!(
+            canonical_thinking_protocol(
+                "openai-compatible",
+                "https://api.moonshot.cn/v1",
+                "kimi-k2.6"
+            ),
+            ThinkingProtocol::Moonshot
+        );
+    }
+
+    #[test]
+    fn controls_are_exclusive_and_unknown_emits_nothing() {
+        for protocol in [
+            ThinkingProtocol::EnableThinking,
+            ThinkingProtocol::ThinkingObject,
+            ThinkingProtocol::Moonshot,
+            ThinkingProtocol::ReasoningEffort,
+        ] {
+            let mut body = json!({"thinking": {}, "enable_thinking": true, "reasoning_effort": "max", "temperature": 0});
+            protocol.apply(&mut body, false, None);
+            assert!(body.get("reasoning_effort").is_none());
+            assert_eq!(
+                body.get("enable_thinking").is_some(),
+                protocol == ThinkingProtocol::EnableThinking
+            );
+            assert_eq!(
+                body.get("thinking").is_some(),
+                matches!(
+                    protocol,
+                    ThinkingProtocol::ThinkingObject | ThinkingProtocol::Moonshot
+                )
+            );
+            if protocol == ThinkingProtocol::Moonshot {
+                assert_eq!(body["temperature"], 0);
+            }
+        }
+    }
+}

--- a/crates/core/src/model_wire/thinking.rs
+++ b/crates/core/src/model_wire/thinking.rs
@@ -37,11 +37,23 @@ impl ThinkingProtocol {
         let Some(object) = body.as_object_mut() else {
             return;
         };
-        for key in ["thinking", "enable_thinking", "reasoning_effort"] {
+        for key in [
+            "thinking",
+            "enable_thinking",
+            "reasoning_effort",
+            "reasoning",
+        ] {
             object.remove(key);
         }
+        if let Some(config) = object
+            .get_mut("output_config")
+            .and_then(Value::as_object_mut)
+        {
+            config.remove("effort");
+            config.remove("reasoning_effort");
+        }
         match self {
-            Self::Unknown => {}
+            Self::Unknown => unreachable!("unknown protocols preserve the body above"),
             Self::EnableThinking => {
                 body["enable_thinking"] = json!(enabled);
             }
@@ -62,6 +74,33 @@ impl ThinkingProtocol {
             Self::ReasoningEffort => {}
         }
     }
+}
+
+/// Transitional zero-temperature defaults apply only to maintained native
+/// endpoint contracts, never a provider label attached to an arbitrary gateway.
+/// Other deployments (including Bedrock gateways) need an explicit capability.
+pub fn canonical_zero_temperature(provider: &str, base_url: &str) -> bool {
+    let expected = match provider {
+        "openai" => "api.openai.com",
+        "anthropic" => "api.anthropic.com",
+        "deepseek" => "api.deepseek.com",
+        _ => return false,
+    };
+    // Only OpenAI has an implicit endpoint in the summary transport.
+    if base_url.is_empty() {
+        return provider == "openai";
+    }
+    let Ok(url) = reqwest::Url::parse(base_url) else {
+        return false;
+    };
+    url.scheme() == "https"
+        && url.host_str() == Some(expected)
+        && url.port_or_known_default() == Some(443)
+        && url.username().is_empty()
+        && url.password().is_none()
+        && url.query().is_none()
+        && url.fragment().is_none()
+        && matches!(url.path().trim_end_matches('/'), "" | "/v1")
 }
 
 /// Maintained adapter defaults, never substring matching arbitrary URLs.
@@ -153,6 +192,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn zero_temperature_requires_native_endpoint_authority() {
+        assert!(canonical_zero_temperature(
+            "openai",
+            "https://api.openai.com/v1"
+        ));
+        for url in [
+            "https://api.openai.com.evil.test/v1",
+            "http://api.openai.com/v1",
+            "https://api.openai.com:8443/v1",
+            "https://api.openai.com/proxy",
+            "https://api.openai.com/v1?gateway=1",
+            "https://user@api.openai.com/v1",
+            "https://api.moonshot.cn/v1",
+        ] {
+            assert!(!canonical_zero_temperature("openai", url), "{url}");
+        }
+    }
+
+    #[test]
     fn toggle_preserves_explicit_sampling_in_both_modes() {
         for enabled in [false, true] {
             let mut body = json!({"temperature":0.7,"top_p":0.9,"presence_penalty":0.1,"frequency_penalty":0.2});
@@ -236,8 +294,12 @@ mod tests {
             ThinkingProtocol::Moonshot,
             ThinkingProtocol::ReasoningEffort,
         ] {
-            let mut body = json!({"thinking": {}, "enable_thinking": true, "reasoning_effort": "max", "temperature": 0});
+            let mut body = json!({"thinking": {}, "enable_thinking": true, "reasoning_effort": "max", "reasoning": {"effort":"high"}, "output_config":{"effort":"high", "reasoning_effort":"high", "format":"json"}, "temperature": 0});
             protocol.apply(&mut body, false, None);
+            assert!(body.get("reasoning").is_none());
+            assert!(body["output_config"].get("effort").is_none());
+            assert!(body["output_config"].get("reasoning_effort").is_none());
+            assert_eq!(body["output_config"]["format"], "json");
             assert!(body.get("reasoning_effort").is_none());
             assert_eq!(
                 body.get("enable_thinking").is_some(),

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 default = ["harness"]
 # Enables deterministic provider and edge-callback controls for full-stack tests.
 e2e-hooks = ["astra-services/e2e-hooks"]
+# Paid checks are not part of the generic ignored/MatrixOne CI lane.
+live-provider-tests = []
 # Enables OTLP trace export via `astra-logging` (build with `--features otel`).
 otel = ["astra-logging/otel"]
 # Observation + verification harness (zero cost when disabled).

--- a/crates/runtime/src/memory_hooks/inference.rs
+++ b/crates/runtime/src/memory_hooks/inference.rs
@@ -70,6 +70,8 @@ where
 /// Server-only direct-provider implementation of [`MemoryInferencePort`].
 #[derive(Clone)]
 pub(crate) struct DirectMemoryInferenceClient {
+    pub(crate) fixed_temperature: Option<f64>,
+    pub(crate) thinking_protocol: Option<astra_core::model_wire::thinking::ThinkingProtocol>,
     pub(crate) base_url: String,
     pub(crate) api_key: String,
     pub(crate) model_name: String,
@@ -84,6 +86,8 @@ pub(crate) struct DirectMemoryInferenceClient {
 impl DirectMemoryInferenceClient {
     fn execution_route(&self) -> LlmExecutionRoute<'_> {
         LlmExecutionRoute {
+            fixed_temperature: self.fixed_temperature,
+            thinking_protocol: self.thinking_protocol,
             model_name: &self.model_name,
             wire_model_name: self.wire_model_name.as_deref(),
             api_key: &self.api_key,
@@ -159,6 +163,8 @@ impl MemoryInferencePort for DurableMemoryInferenceClient {
             )
         })?;
         let direct = DirectMemoryInferenceClient {
+            fixed_temperature: execution.fixed_temperature,
+            thinking_protocol: execution.thinking_protocol,
             base_url: execution.base_url.clone(),
             api_key: execution.api_key.clone(),
             model_name: execution.model_name.clone(),
@@ -255,6 +261,8 @@ mod tests {
 
     fn direct_client() -> DirectMemoryInferenceClient {
         DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: "https://api.example.com/v1".into(),
             api_key: "sk-test".into(),
             model_name: "qwen-flash".into(),

--- a/crates/runtime/src/memory_hooks/relevance.rs
+++ b/crates/runtime/src/memory_hooks/relevance.rs
@@ -487,6 +487,8 @@ mod tests {
     #[tokio::test]
     async fn filter_memories_empty_input_returns_empty() {
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: "http://nonexistent:9999".into(),
             api_key: "key".into(),
             model_name: "model".into(),
@@ -504,6 +506,8 @@ mod tests {
     #[tokio::test]
     async fn filter_memories_unreachable_server_uses_lexical_fallback() {
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: "http://127.0.0.1:1".into(),
             api_key: "key".into(),
             model_name: "model".into(),
@@ -561,6 +565,8 @@ mod tests {
         let captured = Arc::new(Mutex::new(None));
         let base = spawn_mock_completions(captured.clone(), "[0]").await;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: base,
             api_key: "k".into(),
             model_name: "qwen3.5-flash".into(),
@@ -586,6 +592,8 @@ mod tests {
         let captured = Arc::new(Mutex::new(None));
         let base = spawn_mock_completions(captured.clone(), "[0]").await;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: base,
             api_key: "k".into(),
             model_name: "gpt-4o-mini".into(),
@@ -611,6 +619,8 @@ mod tests {
         let captured = Arc::new(Mutex::new(None));
         let base = spawn_mock_completions(captured.clone(), "<think>reasoning</think>[0, 2]").await;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: base,
             api_key: "k".into(),
             model_name: "m".into(),
@@ -631,6 +641,8 @@ mod tests {
         let captured = Arc::new(Mutex::new(None));
         let base = spawn_mock_completions(captured.clone(), "<think>[0, 1]</think>").await;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: base,
             api_key: "k".into(),
             model_name: "m".into(),
@@ -657,6 +669,8 @@ mod tests {
         let captured = Arc::new(Mutex::new(None));
         let base = spawn_mock_completions(captured.clone(), "[1]").await;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: base,
             api_key: "k".into(),
             model_name: "m".into(),
@@ -677,6 +691,8 @@ mod tests {
         let captured = Arc::new(Mutex::new(None));
         let base = spawn_mock_completions(captured.clone(), "[]").await;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: base,
             api_key: "k".into(),
             model_name: "m".into(),
@@ -700,6 +716,8 @@ mod tests {
         let captured = Arc::new(Mutex::new(None));
         let base = spawn_mock_completions(captured.clone(), "[0]").await;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: base,
             api_key: "k".into(),
             model_name: "m".into(),

--- a/crates/runtime/src/server/completions.rs
+++ b/crates/runtime/src/server/completions.rs
@@ -359,6 +359,8 @@ mod tests {
                     fallback_chain: Vec::new(),
                     tags: Vec::new(),
                     request_body_overrides: None,
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     prompt_cache_capability: None,
                     thinking_capability: None,
                     context_window: Some(32_000),

--- a/crates/runtime/src/server/model_execution_admission.rs
+++ b/crates/runtime/src/server/model_execution_admission.rs
@@ -143,6 +143,8 @@ mod tests {
                     fallback_chain: Vec::new(),
                     tags: Vec::new(),
                     request_body_overrides: None,
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     prompt_cache_capability: None,
                     thinking_capability: None,
                     context_window: Some(128_000),

--- a/crates/runtime/src/server/run/lifecycle/tests.rs
+++ b/crates/runtime/src/server/run/lifecycle/tests.rs
@@ -1412,6 +1412,8 @@ fn test_resolved_model_offering_at(base_url: &str) -> astra_services::ResolvedMo
             fallback_chain: Vec::new(),
             tags: Vec::new(),
             request_body_overrides: None,
+            fixed_temperature: None,
+            thinking_protocol: None,
             prompt_cache_capability: None,
             thinking_capability: None,
             context_window: Some(128_000),

--- a/crates/runtime/src/server/server_loop_host.rs
+++ b/crates/runtime/src/server/server_loop_host.rs
@@ -57,7 +57,7 @@ use crate::turn::agentic_loop::host::{
     complete_turn_phase, interaction_scoped_tool_restrictions,
 };
 use crate::turn::llm::client::{
-    LlmCall, LlmCallResult, LlmCancel, LlmExecutionRoute, LlmStreamUpdate, OwnedLlmExecutionRoute,
+    LlmCall, LlmCallResult, LlmCancel, LlmStreamUpdate, OwnedLlmExecutionRoute,
     call_llm_and_collect_with_stream_callback,
     call_llm_and_collect_with_stream_callback_and_budget,
     call_llm_and_collect_with_stream_callback_and_budget_and_no_tool_choice,
@@ -1697,6 +1697,9 @@ struct ResolvedTurnLlmConfig {
     /// Probe-derived fact used by bounded auxiliary calls. This is carried
     /// from model admission rather than inferred from a provider/model name.
     thinking_capability: Option<astra_services::models::ThinkingCapability>,
+    /// Mode-independent fixed temperature resolved at model admission.
+    fixed_temperature: Option<f64>,
+    thinking_protocol: Option<astra_core::model_wire::thinking::ThinkingProtocol>,
     fallback_chain: Vec<String>,
     header_overrides: HashMap<String, String>,
     request_body_overrides: Option<Map<String, Value>>,
@@ -1719,6 +1722,8 @@ impl ResolvedTurnLlmConfig {
             base_url: self.base_url.clone(),
             provider: self.provider.clone(),
             thinking_capability: self.thinking_capability,
+            fixed_temperature: self.fixed_temperature,
+            thinking_protocol: self.thinking_protocol,
             header_overrides: self.header_overrides.clone(),
             request_body_overrides: self.request_body_overrides.clone(),
             completions_url_override: self.completions_url_override.clone(),
@@ -1953,6 +1958,8 @@ async fn resolve_llm_model_for_turn(
                 execution.cache_capability,
             ),
             thinking_capability: execution.thinking_capability,
+            fixed_temperature: execution.fixed_temperature,
+            thinking_protocol: execution.thinking_protocol,
             fallback_chain: Vec::new(),
             header_overrides: execution.header_overrides.clone(),
             request_body_overrides: execution.request_body_overrides.clone(),
@@ -1975,6 +1982,8 @@ async fn resolve_llm_model_for_turn(
             resolved.prompt_cache_capability,
         ),
         thinking_capability: resolved.thinking_capability,
+        fixed_temperature: resolved.fixed_temperature,
+        thinking_protocol: resolved.thinking_protocol,
         fallback_chain: resolved.fallback_chain,
         header_overrides: HashMap::new(),
         request_body_overrides: resolved.request_body_overrides,
@@ -7524,6 +7533,8 @@ impl ServerAgenticLoopHost {
             fallback_chain: Vec::new(),
             cache_capability: self.mock_cache_capability,
             thinking_capability: None,
+            fixed_temperature: None,
+            thinking_protocol: None,
             header_overrides: HashMap::new(),
             request_body_overrides: None,
             completions_url_override: None,
@@ -13112,23 +13123,13 @@ impl AgenticLoopHost for ServerAgenticLoopHost {
                             }
                         }
                     };
+                    let execution_route = llm_cfg.execution_route();
                     let call = LlmCall {
                         purpose: state.inference_purpose,
                         messages: attempt_llm_messages,
                         tools: &final_tools,
                         cache_capability: Some(cache_cap),
-                        route: LlmExecutionRoute {
-                            model_name: &llm_cfg.model_name,
-                            wire_model_name: llm_cfg.wire_model_name.as_deref(),
-                            api_key: &llm_cfg.api_key,
-                            base_url: &llm_cfg.base_url,
-                            provider: &llm_cfg.provider,
-                            header_overrides: (!llm_cfg.header_overrides.is_empty())
-                                .then_some(&llm_cfg.header_overrides),
-                            request_body_overrides: llm_cfg.request_body_overrides.as_ref(),
-                            completions_url_override: llm_cfg.completions_url_override.as_deref(),
-                            request_timeout: llm_cfg.request_timeout,
-                        },
+                        route: execution_route.borrowed(),
                         max_output_tokens: Some(effective_max_output),
                         temperature: None,
                         has_fallback,
@@ -16565,6 +16566,8 @@ mod tests {
             provider: "openai".to_string(),
             cache_capability: None,
             thinking_capability: None,
+            fixed_temperature: None,
+            thinking_protocol: None,
             fallback_chain: Vec::new(),
             header_overrides: HashMap::new(),
             request_body_overrides: None,
@@ -22911,6 +22914,8 @@ mod tests {
             fallback_chain: Vec::new(),
             cache_capability: None,
             thinking_capability: None,
+            fixed_temperature: None,
+            thinking_protocol: None,
             header_overrides: HashMap::new(),
             request_body_overrides: None,
             completions_url_override: None,
@@ -29440,6 +29445,8 @@ mod tests {
                 fallback_chain: vec!["legacy-model-name".to_string()],
                 tags: Vec::new(),
                 request_body_overrides: None,
+                fixed_temperature: None,
+                thinking_protocol: None,
                 prompt_cache_capability: None,
                 thinking_capability: None,
                 context_window: Some(64_000),
@@ -30875,6 +30882,8 @@ mod tests {
                 base_url: "https://api.openai.com/v1".to_string(),
                 provider: "openai".to_string(),
                 thinking_capability: None,
+                fixed_temperature: None,
+                thinking_protocol: None,
                 header_overrides: forwarded,
                 request_body_overrides: None,
                 completions_url_override: Some(format!("http://{addr}/gateway/chat/completions")),

--- a/crates/runtime/src/session_memory/runner.rs
+++ b/crates/runtime/src/session_memory/runner.rs
@@ -2345,6 +2345,8 @@ mod tests {
 
         let memoria = Arc::new(CapturingMemoria::default()) as Arc<dyn MemoriaPort>;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: format!("{server_url}/v1"),
             api_key: "test-key".to_string(),
             model_name: "selector-openai".to_string(),
@@ -2398,6 +2400,8 @@ mod tests {
 
         let memoria = Arc::new(CapturingMemoria::default()) as Arc<dyn MemoriaPort>;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: format!("{server_url}/v1"),
             api_key: "test-key".to_string(),
             model_name: "selector-openai".to_string(),
@@ -2464,6 +2468,8 @@ mod tests {
         ];
         let memoria = Arc::new(CapturingMemoria::default()) as Arc<dyn MemoriaPort>;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: format!("{server_url}/v1"),
             api_key: "test-key".to_string(),
             model_name: "selector-openai".to_string(),
@@ -2538,6 +2544,8 @@ mod tests {
         ];
         let memoria = Arc::new(CapturingMemoria::default()) as Arc<dyn MemoriaPort>;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: format!("{server_url}/v1"),
             api_key: "test-key".to_string(),
             model_name: "selector-openai".to_string(),
@@ -2613,6 +2621,8 @@ mod tests {
         ];
         let memoria = Arc::new(CapturingMemoria::default()) as Arc<dyn MemoriaPort>;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: format!("{server_url}/v1"),
             api_key: "test-key".to_string(),
             model_name: "selector-openai".to_string(),
@@ -2668,6 +2678,8 @@ mod tests {
 
         let memoria = Arc::new(CapturingMemoria::default()) as Arc<dyn MemoriaPort>;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: server_url,
             api_key: "anthropic-key".to_string(),
             model_name: "deepseek-v4-flash-anthropic".to_string(),
@@ -2721,6 +2733,8 @@ mod tests {
 
         let memoria = Arc::new(CapturingMemoria::default()) as Arc<dyn MemoriaPort>;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: server_url,
             api_key: "bedrock-key".to_string(),
             model_name: "anthropic.claude".to_string(),
@@ -2771,6 +2785,8 @@ mod tests {
 
         let memoria = Arc::new(FailingMemoria) as Arc<dyn MemoriaPort>;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: format!("{server_url}/v1"),
             api_key: "test-key".to_string(),
             model_name: "selector-openai".to_string(),
@@ -2834,6 +2850,8 @@ mod tests {
 
         let memoria = Arc::new(CapturingMemoria::default()) as Arc<dyn MemoriaPort>;
         let params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: format!("{server_url}/v1"),
             api_key: "test-key".to_string(),
             model_name: "selector-openai".to_string(),
@@ -2904,6 +2922,8 @@ mod tests {
 
         let memoria = Arc::new(CapturingMemoria::default()) as Arc<dyn MemoriaPort>;
         let first = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: format!("{failing_url}/v1"),
             api_key: "test-key".to_string(),
             model_name: "selector-openai-1".to_string(),
@@ -2915,6 +2935,8 @@ mod tests {
             request_timeout: None,
         };
         let second = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: format!("{success_url}/v1"),
             api_key: "test-key".to_string(),
             model_name: "selector-openai-2".to_string(),

--- a/crates/runtime/src/session_memory/service.rs
+++ b/crates/runtime/src/session_memory/service.rs
@@ -2213,6 +2213,8 @@ mod tests {
         )
         .await;
         let selector = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: format!("{server_url}/v1"),
             api_key: "test-key".to_string(),
             model_name: "semantic-selector".to_string(),
@@ -3109,6 +3111,8 @@ mod tests {
         // empty. We degrade to the deterministic rule-fallback path and
         // persist a session-memory snapshot instead of skipping the whole run.
         let selector_params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: "https://nope.invalid".to_string(),
             api_key: "k".to_string(),
             model_name: "cheap-selector".to_string(),
@@ -3189,6 +3193,8 @@ mod tests {
         )
         .await;
         let first = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: "https://nope.invalid".to_string(),
             api_key: "k".to_string(),
             model_name: "selector-first".to_string(),
@@ -3200,6 +3206,8 @@ mod tests {
             request_timeout: None,
         };
         let second = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: format!("{failing_url}/v1"),
             model_name: "selector-second".to_string(),
             ..first.clone()
@@ -3456,6 +3464,8 @@ mod tests {
         // the test).
         let memoria = Arc::new(CapturingMemoria::default());
         let selector_params = DirectMemoryInferenceClient {
+            fixed_temperature: None,
+            thinking_protocol: None,
             base_url: "https://nope.invalid".to_string(),
             api_key: "k".to_string(),
             model_name: "cheap-selector-leak".to_string(),

--- a/crates/runtime/src/turn/llm/client.rs
+++ b/crates/runtime/src/turn/llm/client.rs
@@ -3504,7 +3504,7 @@ fn apply_admitted_openai_protocol(
     // The legacy OpenAI effort serializer removes temperature for Adaptive.
     // A binary toggle is not that contract: restore explicit sampling only,
     // never manufacture a default or infer a mode-specific allowed value.
-    if protocol == astra_core::model_wire::thinking::ThinkingProtocol::Moonshot
+    if protocol.can_disable()
         && let Some(value) = temperature
             .map(|value| json!(value))
             .or_else(|| overrides.and_then(|o| o.get("temperature")).cloned())
@@ -4701,14 +4701,15 @@ async fn call_llm_and_collect_with_total_budget(
         has_fallback,
         thinking,
     } = call;
+    let configured_temperature = astra_core::model_wire::thinking::configured_temperature(
+        route.request_body_overrides,
+        route.fixed_temperature,
+    )
+    .map_err(|message| {
+        astra_core::ClassifiedError::new(astra_core::ErrorKind::ContractViolation, message)
+    })?;
     let temperature = if route.fixed_temperature.is_some() {
-        astra_core::model_wire::thinking::configured_temperature(
-            route.request_body_overrides,
-            route.fixed_temperature,
-        )
-        .map_err(|message| {
-            astra_core::ClassifiedError::new(astra_core::ErrorKind::ContractViolation, message)
-        })?
+        configured_temperature
     } else {
         temperature
     };
@@ -7010,14 +7011,15 @@ async fn call_llm_nonstream_with_attempt_observer_and_tool_choice(
         has_fallback: _,
         thinking,
     } = call;
+    let configured_temperature = astra_core::model_wire::thinking::configured_temperature(
+        route.request_body_overrides,
+        route.fixed_temperature,
+    )
+    .map_err(|message| {
+        astra_core::ClassifiedError::new(astra_core::ErrorKind::ContractViolation, message)
+    })?;
     let temperature = if route.fixed_temperature.is_some() {
-        astra_core::model_wire::thinking::configured_temperature(
-            route.request_body_overrides,
-            route.fixed_temperature,
-        )
-        .map_err(|message| {
-            astra_core::ClassifiedError::new(astra_core::ErrorKind::ContractViolation, message)
-        })?
+        configured_temperature
     } else {
         temperature
     };
@@ -7729,6 +7731,27 @@ mod tests {
                     None,
                 ),
                 (ThinkingProtocol::Unknown, ThinkingConfig::Off, Some(0.7)),
+                (
+                    ThinkingProtocol::EnableThinking,
+                    ThinkingConfig::Adaptive {
+                        effort: astra_turn_core::thinking_config::ThinkingEffort::High,
+                    },
+                    Some(0.7),
+                ),
+                (
+                    ThinkingProtocol::ThinkingObject,
+                    ThinkingConfig::Adaptive {
+                        effort: astra_turn_core::thinking_config::ThinkingEffort::High,
+                    },
+                    Some(0.7),
+                ),
+                (
+                    ThinkingProtocol::ReasoningEffort,
+                    ThinkingConfig::Adaptive {
+                        effort: astra_turn_core::thinking_config::ThinkingEffort::High,
+                    },
+                    Some(0.7),
+                ),
             ] {
                 let mut overrides = json!({"top_p":0.9,"presence_penalty":0.1});
                 if protocol == ThinkingProtocol::Unknown && thinking.is_enabled() {
@@ -7793,12 +7816,74 @@ mod tests {
                 }
                 if thinking.is_enabled() && protocol == ThinkingProtocol::Unknown {
                     assert_eq!(body["reasoning_effort"], "medium");
+                } else if protocol == ThinkingProtocol::ReasoningEffort {
+                    assert!(
+                        body.get("temperature").is_none(),
+                        "native effort restrictions remain authoritative"
+                    );
                 } else {
                     assert_eq!(body["temperature"], 0.7);
                 }
+                if protocol == ThinkingProtocol::EnableThinking {
+                    assert_eq!(body["enable_thinking"], true);
+                    assert!(body.get("reasoning_effort").is_none());
+                }
             }
         }
-        assert_eq!(captured.lock().unwrap().len(), 8);
+        assert_eq!(captured.lock().unwrap().len(), 14);
+        // Validate generic overrides even without fixed_temperature, in both
+        // public transports, before any request can reach the provider.
+        for streaming in [false, true] {
+            for invalid in [json!(-0.1), json!("NaN"), Value::Null] {
+                let route = OwnedLlmExecutionRoute {
+                    model_name: "fixture".into(),
+                    wire_model_name: None,
+                    api_key: "fixture".into(),
+                    base_url: base.clone(),
+                    provider: "openai".into(),
+                    thinking_capability: None,
+                    fixed_temperature: None,
+                    thinking_protocol: None,
+                    header_overrides: HashMap::new(),
+                    request_body_overrides: json!({"temperature":invalid}).as_object().cloned(),
+                    completions_url_override: None,
+                    request_timeout: None,
+                };
+                let call = LlmCall {
+                    purpose: astra_turn_types::InferencePurpose::PrimaryAgent,
+                    messages: &[],
+                    tools: &[],
+                    cache_capability: None,
+                    route: route.borrowed(),
+                    max_output_tokens: Some(128),
+                    temperature: None,
+                    has_fallback: false,
+                    thinking: &ThinkingConfig::Off,
+                };
+                let result = if streaming {
+                    call_llm_and_collect_with_stream_callback_and_no_tool_choice(
+                        call,
+                        LlmCancel::None,
+                        None,
+                        None,
+                    )
+                    .await
+                } else {
+                    call_llm_nonstream(
+                        global_llm_client(),
+                        call,
+                        std::time::Duration::from_secs(10),
+                    )
+                    .await
+                };
+                assert!(result.unwrap_err().message.contains("finite non-negative"));
+            }
+        }
+        assert_eq!(
+            captured.lock().unwrap().len(),
+            14,
+            "invalid overrides must not reach provider I/O"
+        );
         server.abort();
     }
 

--- a/crates/runtime/src/turn/llm/client.rs
+++ b/crates/runtime/src/turn/llm/client.rs
@@ -862,6 +862,8 @@ pub(crate) type LlmStreamCallback<'a> = dyn FnMut(LlmStreamUpdate) + Send + 'a;
 /// credential and request headers, so its custom `Debug` only exposes
 /// non-secret routing facts.
 pub(crate) struct LlmExecutionRoute<'a> {
+    pub fixed_temperature: Option<f64>,
+    pub thinking_protocol: Option<astra_core::model_wire::thinking::ThinkingProtocol>,
     pub model_name: &'a str,
     pub wire_model_name: Option<&'a str>,
     pub api_key: &'a str,
@@ -880,6 +882,8 @@ impl<'a> LlmExecutionRoute<'a> {
     #[must_use]
     pub(crate) fn from_admitted(execution: &'a astra_services::AdmittedModelExecution) -> Self {
         Self {
+            fixed_temperature: execution.fixed_temperature,
+            thinking_protocol: execution.thinking_protocol,
             model_name: &execution.model_name,
             wire_model_name: execution.wire_model_name.as_deref(),
             api_key: &execution.api_key,
@@ -909,6 +913,9 @@ pub(crate) struct OwnedLlmExecutionRoute {
     /// Capability established at model admission. Auxiliary callers may use
     /// it to select a compatible bounded-reasoning request, never a heuristic.
     pub thinking_capability: Option<astra_services::models::ThinkingCapability>,
+    /// Mode-independent fixed temperature admitted with the Offering.
+    pub fixed_temperature: Option<f64>,
+    pub thinking_protocol: Option<astra_core::model_wire::thinking::ThinkingProtocol>,
     pub header_overrides: HashMap<String, String>,
     pub request_body_overrides: Option<Map<String, Value>>,
     pub completions_url_override: Option<String>,
@@ -919,6 +926,8 @@ impl OwnedLlmExecutionRoute {
     #[must_use]
     pub fn borrowed(&self) -> LlmExecutionRoute<'_> {
         LlmExecutionRoute {
+            fixed_temperature: self.fixed_temperature,
+            thinking_protocol: self.thinking_protocol,
             model_name: &self.model_name,
             wire_model_name: self.wire_model_name.as_deref(),
             api_key: &self.api_key,
@@ -3485,6 +3494,26 @@ fn apply_request_body_overrides(
     merge_json_object(body, overrides);
 }
 
+fn apply_admitted_openai_protocol(
+    body: &mut Value,
+    protocol: astra_core::model_wire::thinking::ThinkingProtocol,
+    thinking: &ThinkingConfig,
+    temperature: Option<f64>,
+    overrides: Option<&Map<String, Value>>,
+) {
+    // The legacy OpenAI effort serializer removes temperature for Adaptive.
+    // A binary toggle is not that contract: restore explicit sampling only,
+    // never manufacture a default or infer a mode-specific allowed value.
+    if protocol == astra_core::model_wire::thinking::ThinkingProtocol::Moonshot
+        && let Some(value) = temperature
+            .map(|value| json!(value))
+            .or_else(|| overrides.and_then(|o| o.get("temperature")).cloned())
+    {
+        body["temperature"] = value;
+    }
+    thinking.apply_openai_protocol(body, protocol);
+}
+
 fn validate_request_body_overrides(
     request_body_overrides: Option<&Map<String, Value>>,
 ) -> Result<(), astra_core::ClassifiedError> {
@@ -4589,12 +4618,20 @@ pub(crate) async fn call_llm_and_collect_with_stream_callback_and_no_tool_choice
     stream_callback: Option<&mut LlmStreamCallback<'_>>,
     attempt_observer: Option<&dyn ProviderAttemptObserver>,
 ) -> Result<LlmCallResult, astra_core::ClassifiedError> {
-    call_llm_and_collect_with_stream_callback_and_tool_choice(
+    // Reuse the provider-attempt deadline owner. Do not put a second timeout
+    // around the durable invocation, which would lose terminal settlement.
+    let total_budget = bounded_auxiliary_budget(
+        call.purpose,
+        llm_total_budget(),
+        std::time::Duration::from_secs(llm_secs_from_env("ASTRA_INTROSPECTION_TOTAL_BUDGET_S", 8)),
+    );
+    call_llm_and_collect_with_total_budget(
         call,
         cancel,
         stream_callback,
         attempt_observer,
         RuntimeToolChoice::None,
+        total_budget,
     )
     .await
 }
@@ -4604,6 +4641,18 @@ pub(crate) fn provider_supports_no_tool_choice(provider: &str) -> bool {
         llm_provider_protocol(provider),
         LlmProviderProtocol::OpenAiCompatible | LlmProviderProtocol::AnthropicMessages
     )
+}
+
+fn bounded_auxiliary_budget(
+    purpose: astra_turn_types::InferencePurpose,
+    global: std::time::Duration,
+    introspection: std::time::Duration,
+) -> std::time::Duration {
+    if purpose == astra_turn_types::InferencePurpose::Introspection {
+        global.min(introspection)
+    } else {
+        global
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -4652,7 +4701,20 @@ async fn call_llm_and_collect_with_total_budget(
         has_fallback,
         thinking,
     } = call;
+    let temperature = if route.fixed_temperature.is_some() {
+        astra_core::model_wire::thinking::configured_temperature(
+            route.request_body_overrides,
+            route.fixed_temperature,
+        )
+        .map_err(|message| {
+            astra_core::ClassifiedError::new(astra_core::ErrorKind::ContractViolation, message)
+        })?
+    } else {
+        temperature
+    };
     let LlmExecutionRoute {
+        fixed_temperature: _,
+        thinking_protocol,
         model_name,
         wire_model_name,
         api_key,
@@ -4710,7 +4772,22 @@ async fn call_llm_and_collect_with_total_budget(
     // endpoints still need their typed suppression field to honor it. Apply
     // this after user/catalog overrides so an admitted Off policy cannot be
     // accidentally re-enabled by stale model metadata.
-    thinking.apply_openai_suppression(&mut body, provider, base_url);
+    if !matches!(provider, "anthropic" | "bedrock") {
+        let protocol = thinking_protocol.unwrap_or_else(|| {
+            astra_core::model_wire::thinking::canonical_thinking_protocol(
+                provider,
+                base_url,
+                upstream_name,
+            )
+        });
+        apply_admitted_openai_protocol(
+            &mut body,
+            protocol,
+            thinking,
+            temperature,
+            request_body_overrides,
+        );
+    }
     let wire_output_limit = provider_request_output_limit(&body);
     match tool_choice {
         RuntimeToolChoice::Auto => {}
@@ -6933,7 +7010,20 @@ async fn call_llm_nonstream_with_attempt_observer_and_tool_choice(
         has_fallback: _,
         thinking,
     } = call;
+    let temperature = if route.fixed_temperature.is_some() {
+        astra_core::model_wire::thinking::configured_temperature(
+            route.request_body_overrides,
+            route.fixed_temperature,
+        )
+        .map_err(|message| {
+            astra_core::ClassifiedError::new(astra_core::ErrorKind::ContractViolation, message)
+        })?
+    } else {
+        temperature
+    };
     let LlmExecutionRoute {
+        fixed_temperature: _,
+        thinking_protocol,
         model_name,
         wire_model_name,
         api_key,
@@ -6975,7 +7065,22 @@ async fn call_llm_nonstream_with_attempt_observer_and_tool_choice(
         request_body_overrides,
         cache_capability,
     );
-    thinking.apply_openai_suppression(&mut body, provider, base_url);
+    if !matches!(provider, "anthropic" | "bedrock") {
+        let protocol = thinking_protocol.unwrap_or_else(|| {
+            astra_core::model_wire::thinking::canonical_thinking_protocol(
+                provider,
+                base_url,
+                upstream_name,
+            )
+        });
+        apply_admitted_openai_protocol(
+            &mut body,
+            protocol,
+            thinking,
+            temperature,
+            request_body_overrides,
+        );
+    }
     if matches!(tool_choice, RuntimeToolChoice::None) {
         apply_no_tool_choice(&mut body, provider, tools)?;
     }
@@ -7585,6 +7690,198 @@ pub(crate) fn parse_openai_sse_json_stream(
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn primary_streaming_and_nonstreaming_preserve_admitted_protocol_and_sampling() {
+        use astra_core::model_wire::thinking::ThinkingProtocol;
+        use axum::{Json, response::IntoResponse};
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<Value>::new()));
+        let capture = captured.clone();
+        let app = axum::Router::new().route("/v1/chat/completions", axum::routing::post(move |Json(body): Json<Value>| {
+            let capture = capture.clone();
+            async move {
+                capture.lock().unwrap().push(body.clone());
+                if body["stream"] == true {
+                    ([ ("content-type", "text/event-stream") ],
+                     "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n").into_response()
+                } else {
+                    Json(json!({"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]})).into_response()
+                }
+            }
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}/v1", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        for streaming in [false, true] {
+            for (protocol, thinking, fixed) in [
+                (ThinkingProtocol::Moonshot, ThinkingConfig::Off, Some(0.7)),
+                (
+                    ThinkingProtocol::Moonshot,
+                    ThinkingConfig::Adaptive {
+                        effort: astra_turn_core::thinking_config::ThinkingEffort::High,
+                    },
+                    Some(0.7),
+                ),
+                (
+                    ThinkingProtocol::Unknown,
+                    ThinkingConfig::Adaptive {
+                        effort: astra_turn_core::thinking_config::ThinkingEffort::High,
+                    },
+                    None,
+                ),
+                (ThinkingProtocol::Unknown, ThinkingConfig::Off, Some(0.7)),
+            ] {
+                let mut overrides = json!({"top_p":0.9,"presence_penalty":0.1});
+                if protocol == ThinkingProtocol::Unknown && thinking.is_enabled() {
+                    overrides["reasoning_effort"] = json!("medium");
+                }
+                let route = OwnedLlmExecutionRoute {
+                    model_name: "local-alias".into(),
+                    wire_model_name: Some("upstream-fixture".into()),
+                    api_key: "fixture".into(),
+                    base_url: base.clone(),
+                    provider: "openai".into(),
+                    thinking_capability: None,
+                    fixed_temperature: fixed,
+                    thinking_protocol: Some(protocol),
+                    header_overrides: HashMap::new(),
+                    request_body_overrides: overrides.as_object().cloned(),
+                    completions_url_override: None,
+                    request_timeout: None,
+                };
+                let call = LlmCall {
+                    purpose: astra_turn_types::InferencePurpose::PrimaryAgent,
+                    messages: &[json!({"role":"user","content":"hello"})],
+                    tools: &[],
+                    cache_capability: None,
+                    route: route.borrowed(),
+                    max_output_tokens: Some(128),
+                    temperature: None,
+                    has_fallback: false,
+                    thinking: &thinking,
+                };
+                if streaming {
+                    call_llm_and_collect_with_stream_callback_and_no_tool_choice(
+                        call,
+                        LlmCancel::None,
+                        None,
+                        None,
+                    )
+                    .await
+                    .unwrap();
+                } else {
+                    call_llm_nonstream(
+                        global_llm_client(),
+                        call,
+                        std::time::Duration::from_secs(10),
+                    )
+                    .await
+                    .unwrap();
+                }
+                let body = captured.lock().unwrap().last().unwrap().clone();
+                assert_eq!(body["model"], "upstream-fixture");
+                if protocol == ThinkingProtocol::Moonshot {
+                    assert_eq!(
+                        body["thinking"]["type"],
+                        if thinking.is_enabled() {
+                            "enabled"
+                        } else {
+                            "disabled"
+                        }
+                    );
+                    assert_eq!(body["top_p"], 0.9);
+                    assert_eq!(body["presence_penalty"], 0.1);
+                }
+                if thinking.is_enabled() && protocol == ThinkingProtocol::Unknown {
+                    assert_eq!(body["reasoning_effort"], "medium");
+                } else {
+                    assert_eq!(body["temperature"], 0.7);
+                }
+            }
+        }
+        assert_eq!(captured.lock().unwrap().len(), 8);
+        server.abort();
+    }
+
+    #[test]
+    fn introspection_budget_does_not_shorten_primary_or_extend_global_limit() {
+        use astra_turn_types::InferencePurpose;
+        let global = std::time::Duration::from_secs(60);
+        let cap = std::time::Duration::from_secs(8);
+        assert_eq!(
+            bounded_auxiliary_budget(InferencePurpose::Introspection, global, cap),
+            cap
+        );
+        assert_eq!(
+            bounded_auxiliary_budget(InferencePurpose::Introspection, cap, global),
+            cap
+        );
+        assert_eq!(
+            bounded_auxiliary_budget(InferencePurpose::PrimaryAgent, global, cap),
+            global
+        );
+        assert_eq!(
+            bounded_auxiliary_budget(InferencePurpose::RequiredCompaction, global, cap),
+            global
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_introspection_slow_provider_exits_without_protocol_retry() {
+        use axum::{Router, routing::post};
+        let requests = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let captured = requests.clone();
+        let app = Router::new().route(
+            "/chat/completions",
+            post(move || {
+                captured.fetch_add(1, Ordering::SeqCst);
+                async { std::future::pending::<axum::response::Response>().await }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let call = LlmCall {
+            purpose: astra_turn_types::InferencePurpose::Introspection,
+            messages: &[json!({"role":"user","content":"hello"})],
+            tools: &[],
+            cache_capability: None,
+            route: LlmExecutionRoute {
+                fixed_temperature: None,
+                thinking_protocol: Some(
+                    astra_core::model_wire::thinking::ThinkingProtocol::Moonshot,
+                ),
+                model_name: "slow-fixture",
+                wire_model_name: None,
+                api_key: "fixture",
+                base_url: &base,
+                provider: "openai",
+                header_overrides: None,
+                request_body_overrides: None,
+                completions_url_override: None,
+                request_timeout: None,
+            },
+            max_output_tokens: Some(1024),
+            temperature: None,
+            has_fallback: false,
+            thinking: &ThinkingConfig::Off,
+        };
+        let result = call_llm_and_collect_with_total_budget(
+            call,
+            LlmCancel::None,
+            None,
+            None,
+            RuntimeToolChoice::None,
+            std::time::Duration::from_millis(500),
+        )
+        .await;
+        assert!(matches!(
+            result.unwrap_err().kind,
+            astra_core::ErrorKind::BudgetExhausted | astra_core::ErrorKind::ProviderDeadline
+        ));
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
+        server.abort();
+    }
+
     #[test]
     fn cloud_byok_compatible_reuses_openai_message_and_tool_wire_format() {
         let messages = vec![json!({"role":"user","content":"Use the calculator"})];
@@ -7629,6 +7926,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "test-model",
                     wire_model_name: None,
                     api_key: "sk-private-secret",
@@ -7802,6 +8101,8 @@ mod tests {
         );
         headers.insert("x-workspace-id".to_string(), "workspace-secret".to_string());
         let route = LlmExecutionRoute {
+            fixed_temperature: None,
+            thinking_protocol: None,
             model_name: "model-a",
             wire_model_name: Some("wire-model-a"),
             api_key: "api-key-secret",
@@ -7878,6 +8179,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -7922,6 +8225,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -7987,6 +8292,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -8045,6 +8352,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -8102,6 +8411,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -8178,6 +8489,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -8245,6 +8558,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -8309,6 +8624,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -8380,6 +8697,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -8443,6 +8762,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -8485,6 +8806,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -8531,6 +8854,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -8596,6 +8921,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -8686,6 +9013,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "gpt-5-mini",
                     wire_model_name: None,
                     api_key: "",
@@ -8757,6 +9086,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "gpt-5-mini",
                     wire_model_name: None,
                     api_key: "k",
@@ -10701,6 +11032,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -10757,6 +11090,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -11352,6 +11687,8 @@ mod tests {
                     tools,
                     cache_capability: Some(cache_capability),
                     route: LlmExecutionRoute {
+                        fixed_temperature: None,
+                        thinking_protocol: None,
                         model_name: "m",
                         wire_model_name: None,
                         api_key: "k",
@@ -12982,6 +13319,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -13042,6 +13381,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -13088,6 +13429,8 @@ mod tests {
                     tools: &[],
                     cache_capability: None,
                     route: LlmExecutionRoute {
+                        fixed_temperature: None,
+                        thinking_protocol: None,
                         model_name: "m",
                         wire_model_name: None,
                         api_key: "k",
@@ -13131,6 +13474,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -13171,6 +13516,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -13214,6 +13561,8 @@ mod tests {
                     tools: &[],
                     cache_capability: None,
                     route: LlmExecutionRoute {
+                        fixed_temperature: None,
+                        thinking_protocol: None,
                         model_name: "m",
                         wire_model_name: None,
                         api_key: "k",
@@ -13287,6 +13636,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -13317,6 +13668,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -13368,6 +13721,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -13433,6 +13788,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -13480,6 +13837,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -13531,6 +13890,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -13576,6 +13937,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",
@@ -13620,6 +13983,8 @@ mod tests {
                 tools: &[],
                 cache_capability: None,
                 route: LlmExecutionRoute {
+                    fixed_temperature: None,
+                    thinking_protocol: None,
                     model_name: "m",
                     wire_model_name: None,
                     api_key: "k",

--- a/crates/runtime/src/turn/llm/durable.rs
+++ b/crates/runtime/src/turn/llm/durable.rs
@@ -4599,6 +4599,8 @@ mod tests {
             provider: "openai".to_string(),
             cache_capability: None,
             thinking_capability: None,
+            fixed_temperature: None,
+            thinking_protocol: None,
             request_body_overrides: None,
             context_window: Some(8_192),
             max_completion_tokens: Some(1_024),
@@ -4649,6 +4651,8 @@ mod tests {
             tools: &[],
             cache_capability: None,
             route: crate::turn::llm::client::LlmExecutionRoute {
+                fixed_temperature: None,
+                thinking_protocol: None,
                 model_name: "model-test",
                 wire_model_name: None,
                 api_key: "test-key",

--- a/crates/runtime/src/turn/llm/summary_client.rs
+++ b/crates/runtime/src/turn/llm/summary_client.rs
@@ -216,6 +216,16 @@ impl RuntimeSummaryClient {
     /// control. Use only admitted capability facts or Astra's maintained
     /// canonical-provider transition contract; never infer from a model name.
     fn thinking_for(purpose: InferencePurpose, route: &OwnedLlmExecutionRoute) -> ThinkingConfig {
+        let protocol = route.thinking_protocol.unwrap_or_else(|| {
+            astra_core::model_wire::thinking::canonical_thinking_protocol(
+                &route.provider,
+                &route.base_url,
+                route
+                    .wire_model_name
+                    .as_deref()
+                    .unwrap_or(&route.model_name),
+            )
+        });
         match (purpose, route.thinking_capability) {
             // A persisted EffortOnly value may predate the provider's typed
             // suppression capability. The admitted endpoint protocol is the
@@ -225,27 +235,12 @@ impl RuntimeSummaryClient {
             (
                 InferencePurpose::Introspection,
                 Some(astra_services::models::ThinkingCapability::EffortOnly),
-            ) if route
-                .thinking_protocol
-                .unwrap_or_else(|| {
-                    astra_core::model_wire::thinking::canonical_thinking_protocol(
-                        &route.provider,
-                        &route.base_url,
-                        route
-                            .wire_model_name
-                            .as_deref()
-                            .unwrap_or(&route.model_name),
-                    )
-                })
-                .can_disable() =>
-            {
-                ThinkingConfig::Off
-            }
+            ) if protocol.can_disable() => ThinkingConfig::Off,
             (
                 InferencePurpose::Introspection,
                 Some(astra_services::models::ThinkingCapability::EffortOnly),
-            ) if route.thinking_protocol
-                == Some(astra_core::model_wire::thinking::ThinkingProtocol::ReasoningEffort) =>
+            ) if protocol
+                == astra_core::model_wire::thinking::ThinkingProtocol::ReasoningEffort =>
             {
                 ThinkingConfig::Adaptive {
                     effort: ThinkingEffort::Low,
@@ -304,10 +299,12 @@ impl RuntimeSummaryClient {
                     SummaryTemperatureEmission::ProviderDefault,
                     SummaryGenerationPolicyProvenance::CanonicalProviderContract,
                 )
-            } else if matches!(
-                route.provider.as_str(),
-                "openai" | "anthropic" | "deepseek" | "bedrock"
-            ) {
+            } else if route.completions_url_override.is_none()
+                && astra_core::model_wire::thinking::canonical_zero_temperature(
+                    &route.provider,
+                    &route.base_url,
+                )
+            {
                 (
                     SummaryTemperatureEmission::Explicit(0.0),
                     SummaryGenerationPolicyProvenance::CanonicalProviderContract,
@@ -757,6 +754,15 @@ mod tests {
                 effort: ThinkingEffort::Low,
             }
         );
+        effort_only.thinking_protocol = None;
+        effort_only.base_url = "https://api.openai.com/v1".into();
+        assert_eq!(
+            RuntimeSummaryClient::thinking_for(InferencePurpose::Introspection, &effort_only),
+            ThinkingConfig::Adaptive {
+                effort: ThinkingEffort::Low
+            },
+            "canonical fallback must be shared by both EffortOnly branches"
+        );
 
         for capability in [
             None,
@@ -793,9 +799,14 @@ mod tests {
     #[test]
     fn bounded_introspection_resolves_temperature_from_admitted_capabilities() {
         let canonical = route_with_capability(None);
-        for provider in ["openai", "anthropic", "deepseek", "bedrock"] {
+        for (provider, base_url) in [
+            ("openai", "https://api.openai.com/v1"),
+            ("anthropic", "https://api.anthropic.com/v1"),
+            ("deepseek", "https://api.deepseek.com"),
+        ] {
             let mut route = canonical.clone();
             route.provider = provider.to_string();
+            route.base_url = base_url.into();
             let policy = RuntimeSummaryClient::resolve_generation_policy(
                 InferencePurpose::Introspection,
                 &route,
@@ -884,6 +895,51 @@ mod tests {
                 SummaryTemperatureEmission::InheritRouteDefault
             );
         }
+    }
+
+    #[test]
+    fn provider_labels_and_completion_overrides_do_not_prove_zero_temperature() {
+        for provider in [
+            "openai",
+            "anthropic",
+            "deepseek",
+            "bedrock",
+            "dashscope",
+            "moonshot",
+            "openrouter",
+        ] {
+            for url in [
+                "https://api.moonshot.cn/v1",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                "https://gateway.example/v1",
+            ] {
+                let mut route = route_with_capability(None);
+                route.provider = provider.into();
+                route.base_url = url.into();
+                assert_eq!(
+                    RuntimeSummaryClient::resolve_generation_policy(
+                        InferencePurpose::Introspection,
+                        &route
+                    )
+                    .unwrap()
+                    .temperature,
+                    SummaryTemperatureEmission::ProviderDefault,
+                    "{provider} {url}"
+                );
+            }
+        }
+        let mut route = route_with_capability(None);
+        route.base_url = "https://api.openai.com/v1".into();
+        route.completions_url_override = Some("https://gateway.example/chat/completions".into());
+        assert_eq!(
+            RuntimeSummaryClient::resolve_generation_policy(
+                InferencePurpose::Introspection,
+                &route
+            )
+            .unwrap()
+            .temperature,
+            SummaryTemperatureEmission::ProviderDefault
+        );
     }
 
     #[test]
@@ -1013,6 +1069,11 @@ mod tests {
                             .expect("strict provider rejection");
                     }
                     let decision = r#"{"work_lifecycle":"not_required","execution_topology":"primary","acceptance_unit_relationship":"single_outcome","acceptance_units":[{"objective":"Answer the question","expected_result":"One direct answer"}]}"#;
+                    if body["stream"] == true {
+                        let event = serde_json::json!({"choices":[{"index":0,"delta":{"content":decision},"finish_reason":null}]});
+                        return Response::builder().status(200).header("content-type", "text/event-stream")
+                            .body(Body::from(format!("data: {event}\n\ndata: {{\"choices\":[{{\"index\":0,\"delta\":{{}},\"finish_reason\":\"stop\"}}]}}\n\ndata: [DONE]\n\n"))).unwrap();
+                    }
                     let response = serde_json::json!({
                         "id": "kimi-like-summary",
                         "choices": [{
@@ -1038,33 +1099,59 @@ mod tests {
         // keeping the test server on loopback. The production
         // `openai-compatible` identifier intentionally activates public-HTTPS
         // SSRF enforcement and cannot target this local fixture.
-        execution.provider = "mock-openai-compatible".to_string();
-        let client = RuntimeSummaryClient::new_direct_for_test(summary_route(&execution), 1_024);
-        let messages = vec![serde_json::json!({
-            "role": "user",
-            "content": "Decide whether this turn needs durable Work"
-        })];
+        for provider in ["mock-openai-compatible", "openai"] {
+            execution.provider = provider.to_string();
+            for streaming in [false, true] {
+                let client = if streaming {
+                    let ledger = DurableInferenceLedger::required_with_persistence(
+                        None,
+                        Some(&execution),
+                        "summary-user",
+                        Some(Arc::new(RecoverFirstAdmissionPersistence::default())),
+                    )
+                    .unwrap()
+                    .with_run_authority(summary_authority());
+                    RuntimeSummaryClient::new_with_attempt_allocator(
+                        summary_route(&execution),
+                        1_024,
+                        ledger,
+                        summary_scope(),
+                        DurableSummaryAttemptAllocator::default(),
+                    )
+                } else {
+                    RuntimeSummaryClient::new_direct_for_test(summary_route(&execution), 1_024)
+                };
+                let messages = vec![serde_json::json!({
+                    "role": "user",
+                    "content": "Decide whether this turn needs durable Work"
+                })];
 
-        let summary = client
-            .summarize(InferencePurpose::Introspection, &messages)
-            .await
-            .expect("provider-default request must succeed");
-        astra_services::parse_work_admission_response(&summary.text)
-            .expect("the separate final content must remain a valid Work decision");
+                let summary = client
+                    .summarize(InferencePurpose::Introspection, &messages)
+                    .await
+                    .expect("provider-default request must succeed");
+                astra_services::parse_work_admission_response(&summary.text)
+                    .expect("the separate final content must remain a valid Work decision");
 
-        assert_eq!(provider_requests.load(Ordering::SeqCst), 1);
-        let body = captured_body
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone()
-            .expect("captured strict-provider request");
-        assert!(
-            body.get("temperature").is_none(),
-            "generic compatibility must not invent a sampling capability"
-        );
-        assert!(
-            body.get("thinking").is_none(),
-            "stage 1 leaves an unclassified endpoint's thinking mode at its provider default"
+                let body = captured_body
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .clone()
+                    .expect("captured strict-provider request");
+                assert!(
+                    body.get("temperature").is_none(),
+                    "generic compatibility must not invent a sampling capability"
+                );
+                assert!(
+                    body.get("thinking").is_none(),
+                    "stage 1 leaves an unclassified endpoint's thinking mode at its provider default"
+                );
+            }
+        }
+        assert_eq!(
+            provider_requests.load(Ordering::SeqCst),
+            4,
+            "one request per provider and transport, no retry/fallback"
         );
     }
 
@@ -1296,6 +1383,7 @@ mod tests {
     /// Explicit paid-provider check. The file contains URL, key and model as
     /// its last three nonempty lines; none of its contents are logged.
     #[tokio::test]
+    #[cfg(feature = "live-provider-tests")]
     #[ignore = "requires ASTRA_TEST_SUMMARY_CONFIG_FILE and a real provider credential"]
     async fn live_work_admission_provider_contract() {
         let path = std::env::var("ASTRA_TEST_SUMMARY_CONFIG_FILE")

--- a/crates/runtime/src/turn/llm/summary_client.rs
+++ b/crates/runtime/src/turn/llm/summary_client.rs
@@ -89,6 +89,65 @@ enum SummaryExecution {
     Direct,
 }
 
+/// Final temperature decision for one auxiliary inference call.
+///
+/// This is deliberately distinct from `Option<f64>`: both an inherited route
+/// default and an asserted provider default are represented by `None` at the
+/// lower-level client boundary, but only the former may contain a configured
+/// body override. Resolution below validates that distinction before provider
+/// I/O.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum SummaryTemperatureEmission {
+    InheritRouteDefault,
+    ProviderDefault,
+    Forbidden,
+    Explicit(f64),
+}
+
+impl SummaryTemperatureEmission {
+    fn call_temperature(self) -> Option<f64> {
+        match self {
+            Self::Explicit(value) => Some(value),
+            Self::InheritRouteDefault | Self::ProviderDefault | Self::Forbidden => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InheritRouteDefault => "inherit_route_default",
+            Self::ProviderDefault => "provider_default",
+            Self::Forbidden => "forbidden",
+            Self::Explicit(_) => "explicit",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SummaryGenerationPolicyProvenance {
+    ExistingPurposePolicy,
+    OfferingCapability,
+    CanonicalProviderContract,
+    ConservativeProtocolDefault,
+}
+
+impl SummaryGenerationPolicyProvenance {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ExistingPurposePolicy => "existing_purpose_policy",
+            Self::OfferingCapability => "offering_capability",
+            Self::CanonicalProviderContract => "canonical_provider_contract",
+            Self::ConservativeProtocolDefault => "conservative_protocol_default",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct ResolvedSummaryGenerationPolicy {
+    thinking: ThinkingConfig,
+    temperature: SummaryTemperatureEmission,
+    temperature_provenance: SummaryGenerationPolicyProvenance,
+}
+
 /// Runtime-owned adapter from the provider execution contract to summary work.
 /// Provider-specific request construction, authentication, timeouts, and
 /// response parsing remain centralized in the canonical LLM client.
@@ -154,8 +213,8 @@ impl RuntimeSummaryClient {
 
     /// Auxiliary semantic decisions need a short, predictable response. Some
     /// models cannot turn reasoning off but do offer an explicit low-effort
-    /// control. Use only the probe-derived capability contract; generic
-    /// OpenAI-compatible endpoints keep the established `Off` shape.
+    /// control. Use only admitted capability facts or Astra's maintained
+    /// canonical-provider transition contract; never infer from a model name.
     fn thinking_for(purpose: InferencePurpose, route: &OwnedLlmExecutionRoute) -> ThinkingConfig {
         match (purpose, route.thinking_capability) {
             // A persisted EffortOnly value may predate the provider's typed
@@ -166,29 +225,104 @@ impl RuntimeSummaryClient {
             (
                 InferencePurpose::Introspection,
                 Some(astra_services::models::ThinkingCapability::EffortOnly),
-            ) if astra_turn_core::thinking_config::openai_thinking_control(
-                &route.provider,
-                &route.base_url,
-            ) != astra_turn_core::thinking_config::OpenAiThinkingControl::None =>
+            ) if route
+                .thinking_protocol
+                .unwrap_or_else(|| {
+                    astra_core::model_wire::thinking::canonical_thinking_protocol(
+                        &route.provider,
+                        &route.base_url,
+                        route
+                            .wire_model_name
+                            .as_deref()
+                            .unwrap_or(&route.model_name),
+                    )
+                })
+                .can_disable() =>
             {
                 ThinkingConfig::Off
             }
             (
                 InferencePurpose::Introspection,
                 Some(astra_services::models::ThinkingCapability::EffortOnly),
-            ) => ThinkingConfig::Adaptive {
-                effort: ThinkingEffort::Low,
-            },
+            ) if route.thinking_protocol
+                == Some(astra_core::model_wire::thinking::ThinkingProtocol::ReasoningEffort) =>
+            {
+                ThinkingConfig::Adaptive {
+                    effort: ThinkingEffort::Low,
+                }
+            }
             _ => ThinkingConfig::Off,
         }
     }
 
-    /// Closed-schema runtime decisions must be reproducible for the same
-    /// admitted context. Main-agent generation and compaction keep their own
-    /// sampling policy; only the bounded introspection classifiers use zero
-    /// temperature.
-    fn temperature_for(purpose: InferencePurpose, thinking: &ThinkingConfig) -> Option<f64> {
-        (matches!(purpose, InferencePurpose::Introspection) && thinking.is_off()).then_some(0.0)
+    fn configured_temperature(route: &OwnedLlmExecutionRoute) -> Result<Option<f64>, String> {
+        astra_core::model_wire::thinking::configured_temperature(
+            route.request_body_overrides.as_ref(),
+            route.fixed_temperature,
+        )
+    }
+
+    /// Resolve the complete bounded-summary generation policy once from the
+    /// admitted route. Generic OpenAI-compatible transport is not proof that
+    /// zero temperature is supported, so an unclassified route uses the
+    /// endpoint default. Exact built-in providers retain their established
+    /// deterministic classifier behavior.
+    fn resolve_generation_policy(
+        purpose: InferencePurpose,
+        route: &OwnedLlmExecutionRoute,
+    ) -> Result<ResolvedSummaryGenerationPolicy, String> {
+        let thinking = Self::thinking_for(purpose, route);
+        let configured_temperature = Self::configured_temperature(route)?;
+        let protocol = route.thinking_protocol.unwrap_or_else(|| {
+            astra_core::model_wire::thinking::canonical_thinking_protocol(
+                &route.provider,
+                &route.base_url,
+                route
+                    .wire_model_name
+                    .as_deref()
+                    .unwrap_or(&route.model_name),
+            )
+        });
+        let (temperature, temperature_provenance) =
+            if !matches!(purpose, InferencePurpose::Introspection) {
+                (
+                    SummaryTemperatureEmission::InheritRouteDefault,
+                    SummaryGenerationPolicyProvenance::ExistingPurposePolicy,
+                )
+            } else if !thinking.is_off() {
+                (
+                    SummaryTemperatureEmission::Forbidden,
+                    SummaryGenerationPolicyProvenance::OfferingCapability,
+                )
+            } else if let Some(value) = configured_temperature {
+                (
+                    SummaryTemperatureEmission::Explicit(value),
+                    SummaryGenerationPolicyProvenance::OfferingCapability,
+                )
+            } else if protocol == astra_core::model_wire::thinking::ThinkingProtocol::Moonshot {
+                (
+                    SummaryTemperatureEmission::ProviderDefault,
+                    SummaryGenerationPolicyProvenance::CanonicalProviderContract,
+                )
+            } else if matches!(
+                route.provider.as_str(),
+                "openai" | "anthropic" | "deepseek" | "bedrock"
+            ) {
+                (
+                    SummaryTemperatureEmission::Explicit(0.0),
+                    SummaryGenerationPolicyProvenance::CanonicalProviderContract,
+                )
+            } else {
+                (
+                    SummaryTemperatureEmission::ProviderDefault,
+                    SummaryGenerationPolicyProvenance::ConservativeProtocolDefault,
+                )
+            };
+        Ok(ResolvedSummaryGenerationPolicy {
+            thinking,
+            temperature,
+            temperature_provenance,
+        })
     }
 
     /// Low-level provider-adapter constructor for unit tests. Production
@@ -214,7 +348,17 @@ impl SummaryLlmClient for RuntimeSummaryClient {
         purpose: InferencePurpose,
         messages: &[Value],
     ) -> Result<SummaryResponse, String> {
-        let thinking = Self::thinking_for(purpose, &self.route);
+        let policy = Self::resolve_generation_policy(purpose, &self.route)?;
+        let thinking = &policy.thinking;
+        let temperature = policy.temperature.call_temperature();
+        tracing::debug!(
+            target: "astra::inference_policy",
+            purpose = purpose.as_str(),
+            temperature_emission = policy.temperature.as_str(),
+            temperature_value = ?temperature,
+            temperature_provenance = policy.temperature_provenance.as_str(),
+            "resolved auxiliary generation policy"
+        );
         let result = match &self.execution {
             SummaryExecution::Durable(execution) => {
                 let DurableSummaryExecution {
@@ -253,9 +397,9 @@ impl SummaryLlmClient for RuntimeSummaryClient {
                                 cache_capability: self.cache_capability,
                                 route: self.route.borrowed(),
                                 max_output_tokens: Some(self.max_output_tokens),
-                                temperature: Self::temperature_for(purpose, &thinking),
+                                temperature,
                                 has_fallback: false,
-                                thinking: &thinking,
+                                thinking,
                             },
                         )
                         .await;
@@ -283,9 +427,9 @@ impl SummaryLlmClient for RuntimeSummaryClient {
                         cache_capability: self.cache_capability,
                         route: self.route.borrowed(),
                         max_output_tokens: Some(self.max_output_tokens),
-                        temperature: Self::temperature_for(purpose, &thinking),
+                        temperature,
                         has_fallback: false,
-                        thinking: &thinking,
+                        thinking,
                     },
                     llm_nonstream_timeout(),
                 )
@@ -520,6 +664,8 @@ mod tests {
             provider: "openai".to_string(),
             cache_capability: None,
             thinking_capability: None,
+            fixed_temperature: None,
+            thinking_protocol: None,
             request_body_overrides: None,
             context_window: Some(8_192),
             max_completion_tokens: Some(1_024),
@@ -537,6 +683,8 @@ mod tests {
             base_url: execution.base_url.clone(),
             provider: execution.provider.clone(),
             thinking_capability: None,
+            fixed_temperature: execution.fixed_temperature,
+            thinking_protocol: execution.thinking_protocol,
             header_overrides: HashMap::new(),
             request_body_overrides: None,
             completions_url_override: None,
@@ -576,6 +724,8 @@ mod tests {
             base_url: "https://example.invalid/v1".to_string(),
             provider: "openai".to_string(),
             thinking_capability,
+            fixed_temperature: None,
+            thinking_protocol: None,
             header_overrides: HashMap::new(),
             request_body_overrides: None,
             completions_url_override: None,
@@ -592,8 +742,15 @@ mod tests {
 
     #[test]
     fn bounded_introspection_uses_low_effort_only_when_model_admission_proves_support() {
-        let effort_only =
+        let mut effort_only =
             route_with_capability(Some(astra_services::models::ThinkingCapability::EffortOnly));
+        assert_eq!(
+            RuntimeSummaryClient::thinking_for(InferencePurpose::Introspection, &effort_only),
+            ThinkingConfig::Off,
+            "legacy capability alone cannot prove an effort wire protocol"
+        );
+        effort_only.thinking_protocol =
+            Some(astra_core::model_wire::thinking::ThinkingProtocol::ReasoningEffort);
         assert_eq!(
             RuntimeSummaryClient::thinking_for(InferencePurpose::Introspection, &effort_only),
             ThinkingConfig::Adaptive {
@@ -634,34 +791,132 @@ mod tests {
     }
 
     #[test]
-    fn closed_introspection_decisions_are_deterministic_without_changing_other_inference() {
-        assert_eq!(
-            RuntimeSummaryClient::temperature_for(
+    fn bounded_introspection_resolves_temperature_from_admitted_capabilities() {
+        let canonical = route_with_capability(None);
+        for provider in ["openai", "anthropic", "deepseek", "bedrock"] {
+            let mut route = canonical.clone();
+            route.provider = provider.to_string();
+            let policy = RuntimeSummaryClient::resolve_generation_policy(
                 InferencePurpose::Introspection,
-                &ThinkingConfig::Off,
-            ),
-            Some(0.0)
+                &route,
+            )
+            .expect("canonical policy");
+            assert_eq!(
+                policy.temperature,
+                SummaryTemperatureEmission::Explicit(0.0),
+                "provider={provider}"
+            );
+            assert_eq!(
+                policy.temperature_provenance,
+                SummaryGenerationPolicyProvenance::CanonicalProviderContract,
+                "provider={provider}"
+            );
+        }
+
+        let mut compatible = route_with_capability(None);
+        compatible.provider = astra_services::byok_endpoint::COMPATIBLE_PROVIDER.to_string();
+        let compatible_policy = RuntimeSummaryClient::resolve_generation_policy(
+            InferencePurpose::Introspection,
+            &compatible,
+        )
+        .expect("compatible policy");
+        assert_eq!(
+            compatible_policy.temperature,
+            SummaryTemperatureEmission::ProviderDefault,
+            "transport compatibility alone must not imply zero-temperature support"
         );
         assert_eq!(
-            RuntimeSummaryClient::temperature_for(
+            compatible_policy.temperature_provenance,
+            SummaryGenerationPolicyProvenance::ConservativeProtocolDefault
+        );
+
+        compatible.fixed_temperature = Some(0.6);
+        assert_eq!(
+            RuntimeSummaryClient::resolve_generation_policy(
                 InferencePurpose::Introspection,
-                &ThinkingConfig::Adaptive {
-                    effort: ThinkingEffort::Low,
-                },
-            ),
-            None,
+                &compatible,
+            )
+            .expect("fixed-temperature policy")
+            .temperature,
+            SummaryTemperatureEmission::Explicit(0.6)
+        );
+
+        compatible.fixed_temperature = None;
+        compatible.request_body_overrides = Some(serde_json::Map::from_iter([(
+            "temperature".to_string(),
+            serde_json::json!(0.7),
+        )]));
+        assert_eq!(
+            RuntimeSummaryClient::resolve_generation_policy(
+                InferencePurpose::Introspection,
+                &compatible,
+            )
+            .expect("configured-temperature policy")
+            .temperature,
+            SummaryTemperatureEmission::Explicit(0.7),
+            "the admitted override must not be silently replaced with zero"
+        );
+
+        let mut effort_only =
+            route_with_capability(Some(astra_services::models::ThinkingCapability::EffortOnly));
+        effort_only.thinking_protocol =
+            Some(astra_core::model_wire::thinking::ThinkingProtocol::ReasoningEffort);
+        assert_eq!(
+            RuntimeSummaryClient::resolve_generation_policy(
+                InferencePurpose::Introspection,
+                &effort_only,
+            )
+            .expect("effort-only policy")
+            .temperature,
+            SummaryTemperatureEmission::Forbidden,
             "thinking protocols own sampling and must not receive temperature"
         );
+
         for purpose in [
             InferencePurpose::PrimaryAgent,
             InferencePurpose::RequiredCompaction,
             InferencePurpose::MemoryExtraction,
         ] {
             assert_eq!(
-                RuntimeSummaryClient::temperature_for(purpose, &ThinkingConfig::Off),
-                None
+                RuntimeSummaryClient::resolve_generation_policy(purpose, &canonical)
+                    .expect("non-introspection policy")
+                    .temperature,
+                SummaryTemperatureEmission::InheritRouteDefault
             );
         }
+    }
+
+    #[test]
+    fn contradictory_or_invalid_temperature_capabilities_fail_before_provider_io() {
+        let mut route = route_with_capability(None);
+        route.provider = astra_services::byok_endpoint::COMPATIBLE_PROVIDER.to_string();
+        route.fixed_temperature = Some(0.6);
+        route.request_body_overrides = Some(serde_json::Map::from_iter([(
+            "temperature".to_string(),
+            serde_json::json!(1.0),
+        )]));
+        assert!(
+            RuntimeSummaryClient::resolve_generation_policy(
+                InferencePurpose::Introspection,
+                &route,
+            )
+            .expect_err("conflicting capabilities")
+            .contains("conflicts with fixed_temperature")
+        );
+
+        route.fixed_temperature = None;
+        route.request_body_overrides = Some(serde_json::Map::from_iter([(
+            "temperature".to_string(),
+            serde_json::json!("cold"),
+        )]));
+        assert!(
+            RuntimeSummaryClient::resolve_generation_policy(
+                InferencePurpose::Introspection,
+                &route,
+            )
+            .expect_err("invalid capability")
+            .contains("finite non-negative number")
+        );
     }
 
     #[tokio::test]
@@ -732,6 +987,168 @@ mod tests {
         assert_eq!(body.get("tool_choice"), Some(&Value::String("none".into())));
     }
 
+    #[tokio::test]
+    async fn generic_openai_compatible_work_admission_uses_provider_defaults_once() {
+        let provider_requests = Arc::new(AtomicU32::new(0));
+        let captured_body = Arc::new(std::sync::Mutex::new(None::<Value>));
+        let provider_requests_for_handler = provider_requests.clone();
+        let captured_body_for_handler = captured_body.clone();
+        let app = Router::new().route(
+            "/chat/completions",
+            post(move |axum::Json(body): axum::Json<Value>| {
+                let provider_requests = provider_requests_for_handler.clone();
+                let captured_body = captured_body_for_handler.clone();
+                async move {
+                    provider_requests.fetch_add(1, Ordering::SeqCst);
+                    *captured_body
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(body.clone());
+                    if body.get("temperature").is_some() {
+                        return Response::builder()
+                            .status(400)
+                            .header("content-type", "application/json")
+                            .body(Body::from(
+                                r#"{"error":{"message":"thinking mode fixes temperature"}}"#,
+                            ))
+                            .expect("strict provider rejection");
+                    }
+                    let decision = r#"{"work_lifecycle":"not_required","execution_topology":"primary","acceptance_unit_relationship":"single_outcome","acceptance_units":[{"objective":"Answer the question","expected_result":"One direct answer"}]}"#;
+                    let response = serde_json::json!({
+                        "id": "kimi-like-summary",
+                        "choices": [{
+                            "message": {
+                                "role": "assistant",
+                                "reasoning_content": "The prompt requests one direct answer.",
+                                "content": decision
+                            },
+                            "finish_reason": "stop"
+                        }],
+                        "usage": {"prompt_tokens": 10, "completion_tokens": 30}
+                    });
+                    Response::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(Body::from(response.to_string()))
+                        .expect("strict provider response")
+                }
+            }),
+        );
+        let mut execution = summary_execution(spawn_summary_test_server(app).await);
+        // Use an unclassified OpenAI-compatible protocol identifier while
+        // keeping the test server on loopback. The production
+        // `openai-compatible` identifier intentionally activates public-HTTPS
+        // SSRF enforcement and cannot target this local fixture.
+        execution.provider = "mock-openai-compatible".to_string();
+        let client = RuntimeSummaryClient::new_direct_for_test(summary_route(&execution), 1_024);
+        let messages = vec![serde_json::json!({
+            "role": "user",
+            "content": "Decide whether this turn needs durable Work"
+        })];
+
+        let summary = client
+            .summarize(InferencePurpose::Introspection, &messages)
+            .await
+            .expect("provider-default request must succeed");
+        astra_services::parse_work_admission_response(&summary.text)
+            .expect("the separate final content must remain a valid Work decision");
+
+        assert_eq!(provider_requests.load(Ordering::SeqCst), 1);
+        let body = captured_body
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+            .expect("captured strict-provider request");
+        assert!(
+            body.get("temperature").is_none(),
+            "generic compatibility must not invent a sampling capability"
+        );
+        assert!(
+            body.get("thinking").is_none(),
+            "stage 1 leaves an unclassified endpoint's thinking mode at its provider default"
+        );
+    }
+
+    #[tokio::test]
+    async fn admitted_moonshot_protocol_suppresses_reasoning_without_guessing_model_name() {
+        let app = Router::new().route("/chat/completions", post(|axum::Json(body): axum::Json<Value>| async move {
+            assert_eq!(body["thinking"], serde_json::json!({"type":"disabled"}));
+            assert!(body.get("enable_thinking").is_none());
+            assert!(body.get("reasoning_effort").is_none());
+            assert!(body.get("temperature").is_none());
+            assert_eq!(body["max_completion_tokens"], 1024);
+            axum::Json(serde_json::json!({"choices":[{"message":{"content":"decision"},"finish_reason":"stop"}]}))
+        }));
+        let execution = summary_execution(spawn_summary_test_server(app).await);
+        let mut route = summary_route(&execution);
+        route.model_name = "arbitrary-local-alias".into();
+        route.thinking_protocol =
+            Some(astra_core::model_wire::thinking::ThinkingProtocol::Moonshot);
+        let client = RuntimeSummaryClient::new_direct_for_test(route, 1024);
+        assert_eq!(
+            client
+                .summarize(
+                    InferencePurpose::Introspection,
+                    &[serde_json::json!({"role":"user","content":"hello"})]
+                )
+                .await
+                .unwrap()
+                .text,
+            "decision"
+        );
+    }
+
+    #[tokio::test]
+    async fn admitted_temperature_override_remains_authoritative_on_the_wire() {
+        let captured_body = Arc::new(std::sync::Mutex::new(None::<Value>));
+        let captured_body_for_handler = captured_body.clone();
+        let app = Router::new().route(
+            "/chat/completions",
+            post(move |axum::Json(body): axum::Json<Value>| {
+                let captured_body = captured_body_for_handler.clone();
+                async move {
+                    *captured_body
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(body);
+                    let response = serde_json::json!({
+                        "id": "configured-summary",
+                        "choices": [{
+                            "message": {"role": "assistant", "content": "configured"},
+                            "finish_reason": "stop"
+                        }]
+                    });
+                    Response::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(Body::from(response.to_string()))
+                        .expect("configured provider response")
+                }
+            }),
+        );
+        let execution = summary_execution(spawn_summary_test_server(app).await);
+        let mut route = summary_route(&execution);
+        route.provider = "mock-openai-compatible".to_string();
+        route.request_body_overrides = Some(serde_json::Map::from_iter([(
+            "temperature".to_string(),
+            serde_json::json!(0.7),
+        )]));
+        let client = RuntimeSummaryClient::new_direct_for_test(route, 128);
+
+        client
+            .summarize(
+                InferencePurpose::Introspection,
+                &[serde_json::json!({"role": "user", "content": "classify"})],
+            )
+            .await
+            .expect("configured request");
+
+        let body = captured_body
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+            .expect("captured configured request");
+        assert_eq!(body.get("temperature"), Some(&serde_json::json!(0.7)));
+    }
+
     #[test]
     fn summary_attempt_allocator_is_shared_only_within_the_exact_scope() {
         let allocator = DurableSummaryAttemptAllocator::default();
@@ -797,6 +1214,8 @@ mod tests {
             provider: "openai".to_string(),
             cache_capability: None,
             thinking_capability: None,
+            fixed_temperature: None,
+            thinking_protocol: None,
             request_body_overrides: None,
             context_window: Some(8_192),
             max_completion_tokens: Some(1_024),
@@ -831,6 +1250,8 @@ mod tests {
                 base_url,
                 provider: execution.provider.clone(),
                 thinking_capability: None,
+                fixed_temperature: None,
+                thinking_protocol: None,
                 header_overrides: HashMap::new(),
                 request_body_overrides: None,
                 completions_url_override: None,
@@ -870,6 +1291,107 @@ mod tests {
             vec![0, 1, 2],
             "repair must advance after the authoritative recovered N+1 identity"
         );
+    }
+
+    /// Explicit paid-provider check. The file contains URL, key and model as
+    /// its last three nonempty lines; none of its contents are logged.
+    #[tokio::test]
+    #[ignore = "requires ASTRA_TEST_SUMMARY_CONFIG_FILE and a real provider credential"]
+    async fn live_work_admission_provider_contract() {
+        let path = std::env::var("ASTRA_TEST_SUMMARY_CONFIG_FILE")
+            .expect("set ASTRA_TEST_SUMMARY_CONFIG_FILE");
+        let config = std::fs::read_to_string(path).expect("read provider configuration");
+        let lines: Vec<_> = config
+            .lines()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert!(lines.len() >= 3, "expected URL, key and model");
+        let fields = &lines[lines.len() - 3..];
+        let mut execution = summary_execution(fields[0].to_string());
+        execution.api_key = fields[1].to_string();
+        execution.model_name =
+            std::env::var("ASTRA_TEST_SUMMARY_MODEL").unwrap_or_else(|_| fields[2].to_string());
+        execution.provider = astra_services::byok_endpoint::COMPATIBLE_PROVIDER.to_string();
+        execution.access_kind = astra_services::ModelAccessKind::CloudByok;
+        execution.thinking_protocol = Some(match std::env::var("ASTRA_TEST_THINKING_PROTOCOL") {
+            Ok(value) => serde_json::from_value(serde_json::Value::String(value))
+                .expect("known thinking protocol"),
+            Err(_) => astra_core::model_wire::thinking::canonical_thinking_protocol(
+                &execution.provider,
+                &execution.base_url,
+                &execution.model_name,
+            ),
+        });
+        let persistence = Arc::new(RecoverFirstAdmissionPersistence::default());
+        let ledger = DurableInferenceLedger::required_with_persistence(
+            None,
+            Some(&execution),
+            "summary-user",
+            Some(persistence),
+        )
+        .expect("test ledger")
+        .with_run_authority(summary_authority());
+        let client = RuntimeSummaryClient::new_with_attempt_allocator(
+            summary_route(&execution),
+            1_024,
+            ledger,
+            summary_scope(),
+            DurableSummaryAttemptAllocator::default(),
+        );
+        let messages = astra_services::work_admission_judge_messages(
+            &astra_services::TurnIntentJudgeContext {
+                message: "今天星期几".to_string(),
+                turn_count: 1,
+                ..Default::default()
+            },
+        );
+        let started = std::time::Instant::now();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(60),
+            client.summarize(InferencePurpose::Introspection, &messages),
+        )
+        .await;
+        eprintln!(
+            "live_work_admission elapsed_ms={}",
+            started.elapsed().as_millis()
+        );
+        let response = result
+            .expect("provider deadline exceeded")
+            .unwrap_or_else(|error| {
+                for marker in [
+                    "DNS",
+                    "resolve",
+                    "non-public",
+                    "timeout",
+                    "budget",
+                    "deadline",
+                    "Budget",
+                    "Deadline",
+                    "exhausted",
+                    "400",
+                    "401",
+                    "403",
+                    "404",
+                    "429",
+                    "ledger",
+                    "admission",
+                    "empty text",
+                    "tool call",
+                ] {
+                    if error.contains(marker) {
+                        eprintln!("live_failure_marker={marker}");
+                    }
+                }
+                panic!("live summary request failed; credential and response suppressed")
+            });
+        let parsed = astra_services::parse_work_admission_response(&response.text);
+        eprintln!(
+            "live_work_admission structured_decision_valid={} response_bytes={}",
+            parsed.is_ok(),
+            response.text.len()
+        );
+        assert!(parsed.is_ok(), "provider returned no valid Work decision");
     }
 
     #[tokio::test]

--- a/crates/runtime/tests/test_support.rs
+++ b/crates/runtime/tests/test_support.rs
@@ -122,6 +122,8 @@ impl ModelService for StaticTestModelService {
                 fallback_chain: Vec::new(),
                 tags: Vec::new(),
                 request_body_overrides: None,
+                fixed_temperature: None,
+                thinking_protocol: None,
                 prompt_cache_capability: None,
                 thinking_capability: None,
                 context_window: Some(128_000),

--- a/crates/runtime/tests/user_models_http.rs
+++ b/crates/runtime/tests/user_models_http.rs
@@ -77,6 +77,7 @@ impl ModelService for TestModelService {
         }
         let model_id = format!("model-{}-{}", user_id, rows.len() + 1);
         let record = UserModelRecord {
+            thinking_probe: None,
             model_id: model_id.clone(),
             name: request.name,
             provider: request.provider,

--- a/crates/runtime/tests/web_agent_e2e.rs
+++ b/crates/runtime/tests/web_agent_e2e.rs
@@ -552,6 +552,8 @@ impl ModelService for TestModelService {
                 fallback_chain: Vec::new(),
                 tags: Vec::new(),
                 request_body_overrides: None,
+                fixed_temperature: None,
+                thinking_protocol: None,
                 prompt_cache_capability: None,
                 thinking_capability: None,
                 context_window: Some(128_000),

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -10,6 +10,8 @@ openssl-vendored = ["dep:openssl", "openssl/vendored"]
 e2e-hooks = []
 # External services are not provisioned by the ordinary MatrixOne CI lanes.
 external-contract-tests = []
+# Requires explicit feature + --ignored + private provider configuration.
+live-provider-tests = []
 
 [[test]]
 name = "memoria_live_contract_it"

--- a/crates/services/src/models.rs
+++ b/crates/services/src/models.rs
@@ -4192,6 +4192,30 @@ async fn probe_thinking_behavior_with_protocol(
     base_url: Option<&str>,
     protocol_override: Option<ThinkingProtocol>,
 ) -> ThinkingProbeResult {
+    tokio::time::timeout(
+        Duration::from_secs(30),
+        probe_thinking_behavior_with_protocol_inner(
+            provider,
+            model_name,
+            api_key,
+            base_url,
+            protocol_override,
+        ),
+    )
+    .await
+    .unwrap_or_else(|_| ThinkingProbeResult {
+        capability: ThinkingCapability::None,
+        error: Some("Thinking probe total budget exhausted".into()),
+    })
+}
+
+async fn probe_thinking_behavior_with_protocol_inner(
+    provider: &str,
+    model_name: &str,
+    api_key: &str,
+    base_url: Option<&str>,
+    protocol_override: Option<ThinkingProtocol>,
+) -> ThinkingProbeResult {
     if provider == "mock" {
         return ThinkingProbeResult {
             capability: ThinkingCapability::None,
@@ -4391,36 +4415,54 @@ async fn send_openai_probe(
     body: &serde_json::Value,
     observe_usage_reasoning: bool,
 ) -> Result<bool, String> {
-    let resp = client
+    send_openai_probe_with_timeout(
+        client,
+        url,
+        api_key,
+        body,
+        observe_usage_reasoning,
+        Duration::from_secs(15),
+    )
+    .await
+}
+
+async fn send_openai_probe_with_timeout(
+    client: &reqwest::Client,
+    url: &str,
+    api_key: &str,
+    body: &serde_json::Value,
+    observe_usage_reasoning: bool,
+    request_timeout: Duration,
+) -> Result<bool, String> {
+    let mut resp = client
         .post(url)
         .header("authorization", format!("Bearer {api_key}"))
         .header("content-type", "application/json")
-        .timeout(Duration::from_secs(30))
+        .timeout(request_timeout)
         .json(body)
         .send()
         .await
-        .map_err(|_| "Thinking probe transport failed".to_string())?;
+        .map_err(thinking_probe::transport_error)?;
 
     if resp.status().as_u16() >= 400 {
         let status = resp.status().as_u16();
         return Err(format!("Thinking probe HTTP {status}"));
     }
 
-    let text = resp.text().await.unwrap_or_default();
-    let json: serde_json::Value =
-        serde_json::from_str(&text).map_err(|e| format!("Probe parse error: {e}"))?;
-
-    if json
-        .pointer("/choices/0/finish_reason")
-        .and_then(Value::as_str)
-        != Some("stop")
-        || json
-            .pointer("/choices/0/message/content")
-            .and_then(Value::as_str)
-            .is_none_or(|s| s.trim().is_empty())
+    // Bound both buffered JSON and SSE responses, including malicious gateways.
+    let mut bytes = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(thinking_probe::transport_error)?
     {
-        return Err("Thinking probe returned incomplete or malformed output".into());
+        if bytes.len().saturating_add(chunk.len()) > 1024 * 1024 {
+            return Err("Thinking probe response exceeded size limit".into());
+        }
+        bytes.extend_from_slice(&chunk);
     }
+    let json = thinking_probe::parse_response(&bytes, body["stream"] == true)?;
+    thinking_probe::validate_output(&json)?;
 
     let content = json
         .get("choices")
@@ -4447,7 +4489,16 @@ async fn send_openai_probe(
             .pointer("/usage/completion_tokens_details/reasoning_tokens")
             .and_then(Value::as_u64)
             .is_some_and(|tokens| tokens > 0);
-    Ok(has_think_tags || has_reasoning_content || usage_reasoning)
+    let observed = has_think_tags || has_reasoning_content || usage_reasoning;
+    if !observed
+        && json
+            .pointer("/choices/0/finish_reason")
+            .and_then(Value::as_str)
+            == Some("length")
+    {
+        return Err("Truncated thinking probe cannot establish absence of reasoning".into());
+    }
+    Ok(observed)
 }
 
 // ── Noop implementation ──────────────────────────────────────────────────────
@@ -7643,6 +7694,10 @@ mod tests {
 
         let handler = move |axum::Json(body): axum::Json<serde_json::Value>| async move {
             let enable = body.get("enable_thinking").and_then(|v| v.as_bool());
+            assert_eq!(
+                body["stream"], true,
+                "DashScope thinking probes must support streaming-only deployments"
+            );
             let has_reasoning = match (supports_thinking, enable) {
                 (false, _) => false,
                 (true, Some(false)) => false,
@@ -7653,7 +7708,12 @@ mod tests {
             if has_reasoning {
                 msg["reasoning_content"] = serde_json::json!("thinking...");
             }
-            axum::Json(serde_json::json!({"choices": [{"message": msg, "finish_reason": "stop"}]}))
+            let event =
+                serde_json::json!({"choices": [{"index":0,"delta": msg, "finish_reason": "stop"}]});
+            (
+                [("content-type", "text/event-stream")],
+                format!("data: {event}\n\ndata: [DONE]\n\n"),
+            )
         };
         let app = Router::new().route("/chat/completions", post(handler));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -7673,6 +7733,7 @@ mod tests {
 
         let handler = |axum::Json(body): axum::Json<serde_json::Value>| async move {
             let enable = body.get("enable_thinking").and_then(|v| v.as_bool());
+            assert_eq!(body["stream"], true);
             let has_reasoning = match enable {
                 Some(false) => false, // Suppression works
                 _ => true,            // Default or explicit true → thinks
@@ -7681,7 +7742,12 @@ mod tests {
             if has_reasoning {
                 msg["reasoning_content"] = serde_json::json!("thinking...");
             }
-            axum::Json(serde_json::json!({"choices": [{"message": msg, "finish_reason": "stop"}]}))
+            let event =
+                serde_json::json!({"choices": [{"index":0,"delta": msg, "finish_reason": "stop"}]});
+            (
+                [("content-type", "text/event-stream")],
+                format!("data: {event}\n\ndata: [DONE]\n\n"),
+            )
         };
         let app = Router::new().route("/chat/completions", post(handler));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/crates/services/src/models.rs
+++ b/crates/services/src/models.rs
@@ -13,9 +13,14 @@ use std::{
 use uuid::Uuid;
 
 use crate::auth::FernetTokenEncryptor;
+use astra_core::model_wire::thinking::{ThinkingProtocol, canonical_thinking_protocol};
+mod thinking_probe;
 use astra_core::{
     ErrorKind, ErrorResponse, MatrixOneSettings, SharedPool,
     classify_model_resolution_error_message, error_response, error_response_coded, internal_error,
+};
+use thinking_probe::{
+    ThinkingProbeSnapshot, cached_capability, probe_chat_protocol, probe_identity,
 };
 
 // ── Data types ───────────────────────────────────────────────────────────────
@@ -96,6 +101,9 @@ fn validate_pricing_data(pricing: &PricingData) -> Result<(), String> {
 pub struct QuirksData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fixed_temperature: Option<f64>,
+    /// Explicit OpenAI-chat control protocol; None uses the maintained adapter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking_protocol: Option<astra_core::model_wire::thinking::ThinkingProtocol>,
     #[serde(default)]
     pub preserve_reasoning_content: bool,
     #[serde(default)]
@@ -488,7 +496,7 @@ impl ThinkingCapability {
 /// Result of the two-phase thinking behavior probe.
 ///
 /// Ephemeral — returned during `check_model`, but the capability is persisted to DB.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ThinkingProbeResult {
     pub capability: ThinkingCapability,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -599,6 +607,12 @@ pub struct ResolvedActiveLlmModel {
     pub fallback_chain: Vec<String>,
     pub tags: Vec<String>,
     pub request_body_overrides: Option<Map<String, Value>>,
+    /// Mode-independent fixed temperature declared by the admitted Offering.
+    ///
+    /// `None` means the endpoint owns its default. Models whose required
+    /// temperature varies with thinking mode cannot use this scalar contract.
+    pub fixed_temperature: Option<f64>,
+    pub thinking_protocol: Option<astra_core::model_wire::thinking::ThinkingProtocol>,
     pub prompt_cache_capability: Option<PromptCacheCapabilityData>,
     /// Probe-determined thinking capability. NULL if unprobed.
     pub thinking_capability: Option<ThinkingCapability>,
@@ -692,6 +706,9 @@ pub struct AdmittedModelExecution {
     /// capability fact rather than model-name heuristics when selecting a
     /// bounded auxiliary reasoning policy.
     pub thinking_capability: Option<ThinkingCapability>,
+    /// Mode-independent fixed temperature carried from Offering admission.
+    pub fixed_temperature: Option<f64>,
+    pub thinking_protocol: Option<astra_core::model_wire::thinking::ThinkingProtocol>,
     pub request_body_overrides: Option<Map<String, Value>>,
     pub context_window: Option<u32>,
     pub max_completion_tokens: Option<u32>,
@@ -714,6 +731,8 @@ impl AdmittedModelExecution {
             provider: offering.model.provider,
             cache_capability: offering.model.prompt_cache_capability,
             thinking_capability: offering.model.thinking_capability,
+            fixed_temperature: offering.model.fixed_temperature,
+            thinking_protocol: offering.model.thinking_protocol,
             request_body_overrides: offering.model.request_body_overrides,
             context_window: offering.model.context_window,
             max_completion_tokens: offering.model.max_completion_tokens,
@@ -743,6 +762,8 @@ impl AdmittedModelExecution {
             provider,
             cache_capability: None,
             thinking_capability: None,
+            fixed_temperature: None,
+            thinking_protocol: None,
             request_body_overrides: None,
             context_window: Some(context_window),
             max_completion_tokens: None,
@@ -764,6 +785,7 @@ impl std::fmt::Debug for AdmittedModelExecution {
             .field("model_name", &self.model_name)
             .field("wire_model_name", &self.wire_model_name)
             .field("provider", &self.provider)
+            .field("fixed_temperature", &self.fixed_temperature)
             .field("credential_present", &!self.api_key.is_empty())
             .field("header_names", &header_names)
             .field(
@@ -850,6 +872,7 @@ impl std::fmt::Debug for ResolvedActiveLlmModel {
             .field("fallback_chain", &self.fallback_chain)
             .field("tags", &self.tags)
             .field("request_body_overrides", &self.request_body_overrides)
+            .field("fixed_temperature", &self.fixed_temperature)
             .field("prompt_cache_capability", &self.prompt_cache_capability)
             .field("thinking_capability", &self.thinking_capability)
             .field("context_window", &self.context_window)
@@ -1122,10 +1145,33 @@ fn build_resolved_active_llm_from_row(
         .map_err(|e| format!("invalid infra_llm_models.thinking_capability: {e}"))?;
     let thinking_capability = ThinkingCapability::try_from_db_column(thinking_cap_str.as_deref())?;
 
+    let thinking_protocol = quirks.thinking_protocol.unwrap_or_else(|| {
+        canonical_thinking_protocol(
+            &provider,
+            &base_url,
+            quirks.wire_model_name.as_deref().unwrap_or(&model_name),
+        )
+    });
+    let snapshot: Option<String> = row
+        .try_get("thinking_probe_json")
+        .map_err(|e| e.to_string())?;
+    let identity = probe_identity(
+        &provider,
+        &base_url,
+        quirks.wire_model_name.as_deref().unwrap_or(&model_name),
+        &encrypted,
+        &quirks_json,
+    );
+    let thinking_capability = if snapshot.is_some() {
+        cached_capability(snapshot.as_deref(), &identity, thinking_protocol)
+    } else {
+        thinking_capability
+    };
     let fallback_chain = quirks.fallback_chain;
     let wire_model_name = quirks.wire_model_name;
     let prompt_cache_capability = quirks.prompt_cache_capability;
     let request_body_overrides = quirks.request_body_overrides;
+    let fixed_temperature = quirks.fixed_temperature;
     let request_headers = quirks.request_headers;
 
     let context_window: i32 = row
@@ -1165,6 +1211,8 @@ fn build_resolved_active_llm_from_row(
         fallback_chain,
         tags,
         request_body_overrides,
+        fixed_temperature,
+        thinking_protocol: Some(thinking_protocol),
         prompt_cache_capability,
         thinking_capability,
         context_window: Some(context_window),
@@ -1381,7 +1429,7 @@ const RESOLVE_COLS: &str = "\
     CAST(quirks AS CHAR) AS quirks_json, \
     CAST(pricing AS CHAR) AS pricing_json, \
     CAST(tags AS CHAR) AS tags_json, \
-    thinking_capability, context_window, max_completion_tokens";
+    thinking_capability, CAST(thinking_probe_json AS CHAR) AS thinking_probe_json, context_window, max_completion_tokens";
 const REQUIRED_MODEL_SELECTION_ERROR: &str =
     astra_core::model_override::MISSING_MODEL_SELECTION_MESSAGE;
 
@@ -1587,7 +1635,7 @@ pub async fn revalidate_admitted_model_execution(
         .map_err(ModelOfferingResolutionError::Backend)?;
     let row = query(
         "SELECT model_alias, model_name, provider, api_key_encrypted, base_url, \
-         context_window, is_active FROM user_llm_models \
+         context_window, is_active, CAST(thinking_probe_json AS CHAR) AS thinking_probe_json FROM user_llm_models \
          WHERE user_id = ? AND model_id = ? LIMIT 1",
     )
     .bind(user_id)
@@ -1642,6 +1690,15 @@ pub async fn revalidate_admitted_model_execution(
                 .await
                 .map_err(ModelOfferingResolutionError::Backend)?;
         }
+        let upstream: String = row
+            .try_get("model_name")
+            .map_err(|error| ModelOfferingResolutionError::Backend(error.to_string()))?;
+        let protocol = canonical_thinking_protocol(&provider, &base_url, &upstream);
+        let snapshot: Option<String> = row
+            .try_get("thinking_probe_json")
+            .map_err(|error| ModelOfferingResolutionError::Backend(error.to_string()))?;
+        let identity = probe_identity(&provider, &base_url, &upstream, &encrypted, "");
+        let thinking_capability = cached_capability(snapshot.as_deref(), &identity, protocol);
         return Ok(AdmittedModelExecution {
             offering_id: offering_id.to_string(),
             access_kind: ModelAccessKind::CloudByok,
@@ -1664,7 +1721,9 @@ pub async fn revalidate_admitted_model_execution(
                 ))
             })?,
             cache_capability: None,
-            thinking_capability: None,
+            thinking_capability,
+            fixed_temperature: None,
+            thinking_protocol: Some(protocol),
             request_body_overrides: None,
             context_window: Some(context_window),
             max_completion_tokens: None,
@@ -2218,6 +2277,8 @@ fn model_list_page_from_items(
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct UserModelRecord {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking_probe: Option<ThinkingProbeResult>,
     pub model_id: String,
     pub name: String,
     pub provider: String,
@@ -2612,7 +2673,19 @@ impl DatabaseModelService {
             .map_err(internal_error)?;
         let is_default: i16 = row.try_get("is_default").map_err(internal_error)?;
         let is_active: i16 = row.try_get("is_active").map_err(internal_error)?;
+        let provider: String = row.try_get("provider").map_err(internal_error)?;
+        let base: String = row.try_get("base_url").map_err(internal_error)?;
+        let model: String = row.try_get("model_name").map_err(internal_error)?;
+        let encrypted: String = row.try_get("api_key_encrypted").map_err(internal_error)?;
+        let raw: Option<String> = row.try_get("thinking_probe_json").map_err(internal_error)?;
+        let identity = probe_identity(&provider, &base, &model, &encrypted, "");
+        let protocol = canonical_thinking_protocol(&provider, &base, &model);
+        let thinking_probe = raw
+            .as_deref()
+            .and_then(|s| serde_json::from_str::<ThinkingProbeSnapshot>(s).ok())
+            .and_then(|s| s.result(&identity, protocol));
         Ok(UserModelRecord {
+            thinking_probe,
             model_id: row.try_get("model_id").map_err(internal_error)?,
             name: row.try_get("model_alias").map_err(internal_error)?,
             provider: row.try_get("provider").map_err(internal_error)?,
@@ -2663,6 +2736,7 @@ const MODEL_LIST_CURSOR_SQL: &str = " AND (provider > ? \
      OR (provider = ? AND model_name = ? AND model_id > ?))";
 const MODEL_LIST_ORDER_SQL: &str = " ORDER BY provider ASC, model_name ASC, model_id ASC LIMIT ?";
 const USER_MODEL_SELECT_COLS: &str = "model_id, model_alias, model_name, provider, base_url, \
+    api_key_encrypted, CAST(thinking_probe_json AS CHAR) AS thinking_probe_json, \
     context_window, is_default, is_active, \
     CAST(created_at AS CHAR) AS created_at_text, CAST(updated_at AS CHAR) AS updated_at_text";
 
@@ -2885,7 +2959,7 @@ impl ModelService for DatabaseModelService {
             .map_err(internal_error)?;
         }
         if let Some(encrypted_key) = encrypted_key {
-            query("UPDATE user_llm_models SET api_key_encrypted = ?, updated_at = NOW(6) WHERE user_id = ? AND model_id = ?")
+            query("UPDATE user_llm_models SET api_key_encrypted = ?, thinking_probe_json = NULL, updated_at = NOW(6) WHERE user_id = ? AND model_id = ?")
                 .bind(encrypted_key)
                 .bind(&user_id)
                 .bind(&model_id)
@@ -2951,7 +3025,7 @@ impl ModelService for DatabaseModelService {
     ) -> Result<UserModelRecord, (StatusCode, Json<ErrorResponse>)> {
         let pool = self.get_pool().await.map_err(internal_error)?;
         let row = query(
-            "SELECT model_name, provider, api_key_encrypted, base_url \
+            "SELECT model_name, provider, api_key_encrypted, base_url, CAST(thinking_probe_json AS CHAR) AS thinking_probe_json \
              FROM user_llm_models WHERE user_id = ? AND model_id = ?",
         )
         .bind(&user_id)
@@ -2976,6 +3050,39 @@ impl ModelService for DatabaseModelService {
             return Err(error_response(
                 StatusCode::BAD_GATEWAY,
                 format!("Model credential or endpoint check failed: {reason}"),
+            ));
+        }
+        let protocol = canonical_thinking_protocol(&provider, &base_url, &model);
+        let result = probe_thinking_behavior_with_protocol(
+            &provider,
+            &model,
+            &api_key,
+            Some(&base_url),
+            Some(protocol),
+        )
+        .await;
+        let snapshot = ThinkingProbeSnapshot::new(
+            probe_identity(&provider, &base_url, &model, &encrypted, ""),
+            protocol,
+            &result,
+        )
+        .with_previous(
+            row.try_get::<Option<String>, _>("thinking_probe_json")
+                .map_err(internal_error)?
+                .as_deref(),
+            None,
+        );
+        let json = serde_json::to_string(&snapshot).map_err(internal_error)?;
+        // A check must never publish an observation for a concurrently rotated
+        // credential or changed endpoint. No network I/O is held in a DB txn.
+        let updated = query("UPDATE user_llm_models SET thinking_probe_json = ?, updated_at = NOW(6) WHERE user_id = ? AND model_id = ? AND provider = ? AND base_url = ? AND model_name = ? AND api_key_encrypted = ? AND CAST(thinking_probe_json AS CHAR) <=> ?")
+            .bind(json).bind(&user_id).bind(&model_id).bind(&provider).bind(&base_url).bind(&model).bind(&encrypted)
+            .bind(row.try_get::<Option<String>, _>("thinking_probe_json").map_err(internal_error)?)
+            .execute(&pool).await.map_err(internal_error)?;
+        if updated.rows_affected() == 0 {
+            return Err(error_response(
+                StatusCode::CONFLICT,
+                "Model changed during probe; check again",
             ));
         }
         self.get_user_model(user_id, model_id).await
@@ -3194,17 +3301,23 @@ impl ModelService for DatabaseModelService {
             });
         }
         if !is_admin && !user_id.is_empty() {
-            let user_rows = query(
-                "SELECT model_id, model_alias, provider, context_window, is_active \
+            let user_rows = query(&format!(
+                "SELECT {USER_MODEL_SELECT_COLS} \
                  FROM user_llm_models WHERE user_id = ? AND is_active = 1 \
                  ORDER BY provider, model_alias, model_id",
-            )
+            ))
             .bind(&user_id)
             .fetch_all(&pool)
             .await
             .map_err(internal_error)?;
             for row in user_rows {
                 let is_active: i16 = row.try_get("is_active").map_err(internal_error)?;
+                let thinking_capability = Self::user_model_record_from_row(&row)?
+                    .thinking_probe
+                    .filter(|result| {
+                        result.error.is_none() || result.capability != ThinkingCapability::None
+                    })
+                    .map(|result| result.capability);
                 models.push(ModelListItem {
                     offering_id: row.try_get("model_id").map_err(internal_error)?,
                     access_id: "cloud-byok".to_string(),
@@ -3218,7 +3331,7 @@ impl ModelService for DatabaseModelService {
                     context_window: row.try_get("context_window").map_err(internal_error)?,
                     max_completion_tokens: None,
                     architecture: None,
-                    thinking_capability: None,
+                    thinking_capability,
                 });
             }
         }
@@ -3523,6 +3636,15 @@ impl ModelService for DatabaseModelService {
         update_field!(tags, "tags", json);
         update_field!(quirks, "quirks", json);
 
+        if request.api_key.is_some()
+            || request.base_url.is_some()
+            || request.provider.is_some()
+            || request.quirks.is_some()
+        {
+            query("UPDATE infra_llm_models SET thinking_capability = NULL, thinking_probe_error = NULL, thinking_probe_json = NULL WHERE model_name = ?")
+                .bind(&model_name).execute(&pool).await.map_err(internal_error)?;
+        }
+
         if let Some(active) = request.is_active {
             let val: i16 = if active { 1 } else { 0 };
             query("UPDATE infra_llm_models SET is_active = ?, updated_at = NOW(6) WHERE model_name = ?")
@@ -3585,7 +3707,7 @@ impl ModelService for DatabaseModelService {
         invalidate_active_llm_model_resolution_cache();
         let row = query(
             "SELECT api_key_encrypted, provider, base_url, \
-                    CAST(quirks AS CHAR) AS quirks_json \
+                    CAST(quirks AS CHAR) AS quirks_json, thinking_capability, CAST(thinking_probe_json AS CHAR) AS thinking_probe_json \
              FROM infra_llm_models WHERE model_name = ?",
         )
         .bind(&model_name)
@@ -3640,36 +3762,78 @@ impl ModelService for DatabaseModelService {
 
         // Phase 2: two-phase thinking behavior probe (only when connected)
         let thinking_probe = if check.is_none() {
-            let result =
-                probe_thinking_behavior(&provider, &probe_name, &api_key, base_url.as_deref())
-                    .await;
+            let protocol = quirks.thinking_protocol.unwrap_or_else(|| {
+                canonical_thinking_protocol(
+                    &provider,
+                    base_url.as_deref().unwrap_or("https://api.openai.com/v1"),
+                    &probe_name,
+                )
+            });
+            let result = probe_thinking_behavior_with_protocol(
+                &provider,
+                &probe_name,
+                &api_key,
+                base_url.as_deref(),
+                Some(protocol),
+            )
+            .await;
+            let snapshot = ThinkingProbeSnapshot::new(
+                probe_identity(
+                    &provider,
+                    base_url.as_deref().unwrap_or("https://api.openai.com/v1"),
+                    &probe_name,
+                    &encrypted,
+                    &quirks_json,
+                ),
+                protocol,
+                &result,
+            )
+            .with_previous(
+                row.try_get::<Option<String>, _>("thinking_probe_json")
+                    .map_err(internal_error)?
+                    .as_deref(),
+                ThinkingCapability::try_from_db_column(
+                    row.try_get::<Option<String>, _>("thinking_capability")
+                        .map_err(internal_error)?
+                        .as_deref(),
+                )
+                .map_err(internal_error)?,
+            );
+            let snapshot_json = serde_json::to_string(&snapshot).map_err(internal_error)?;
             // Persist probe result to DB.
-            // Only write capability when the probe succeeded (no error).
-            // A failed probe should leave capability=NULL (re-probable)
-            // rather than permanently marking the model as non-thinking.
-            let cap_str: Option<&str> = if result.error.is_none() {
-                Some(result.capability.as_db_str())
-            } else {
-                None
-            };
+            // Latest error is independent of still-valid prior capability.
+            let cap_str = snapshot.persisted_capability().map(|cap| cap.as_db_str());
             let err_str = result.error.as_deref();
-            if let Err(e) = query(
+            let updated = query(
                 "UPDATE infra_llm_models SET thinking_capability = ?, \
-                 thinking_probe_error = ?, updated_at = NOW(6) WHERE model_name = ?",
+                 thinking_probe_error = ?, thinking_probe_json = ?, updated_at = NOW(6) WHERE model_name = ? \
+                 AND provider = ? AND COALESCE(base_url, '') = ? AND api_key_encrypted = ? AND CAST(quirks AS CHAR) = ? AND CAST(thinking_probe_json AS CHAR) <=> ?",
             )
             .bind(cap_str)
             .bind(err_str)
+            .bind(snapshot_json)
             .bind(&model_name)
+            .bind(&provider)
+            .bind(base_url.as_deref().unwrap_or(""))
+            .bind(&encrypted)
+            .bind(&quirks_json)
+            .bind(row.try_get::<Option<String>, _>("thinking_probe_json").map_err(internal_error)?)
             .execute(&pool)
-            .await
-            {
-                tracing::warn!(
-                    model = %model_name,
-                    err = %e,
-                    "failed to persist thinking_capability to DB"
-                );
+            .await.map_err(internal_error)?;
+            if updated.rows_affected() == 0 {
+                return Err(error_response(
+                    StatusCode::CONFLICT,
+                    "Model changed during probe; check again",
+                ));
             }
-            Some(result)
+            invalidate_active_llm_model_resolution_cache();
+            self.invalidate_catalog_revision_cache();
+            Some(ThinkingProbeResult {
+                capability: snapshot
+                    .persisted_capability()
+                    .unwrap_or(ThinkingCapability::None),
+                error: result.error,
+            })
         } else {
             None
         };
@@ -4005,52 +4169,28 @@ pub async fn validate_connectivity(
     }
 }
 
-/// Select the DeepSeek probe only from the admitted provider identity or the
-/// endpoint authority. Model names and arbitrary hostname substrings are not
-/// protocol evidence; a gateway such as `deepseek-proxy.example.com` must not
-/// receive a DeepSeek-only extension field by accident.
+#[cfg(test)]
 fn is_deepseek_probe_route(provider: &str, base_url: &str) -> bool {
-    let provider = provider.trim().to_ascii_lowercase();
-    if provider == "deepseek" || provider.starts_with("deepseek-") {
-        return true;
-    }
-    let authority = base_url
-        .trim()
-        .strip_prefix("https://")
-        .or_else(|| base_url.trim().strip_prefix("http://"))
-        .and_then(|rest| rest.split('/').next())
-        .unwrap_or_default()
-        .split('@')
-        .next_back()
-        .unwrap_or_default()
-        .split(':')
-        .next()
-        .unwrap_or_default()
-        .trim_end_matches('.')
-        .to_ascii_lowercase();
-    authority == "api.deepseek.com" || authority.ends_with(".deepseek.com")
+    canonical_thinking_protocol(provider, base_url, "") == ThinkingProtocol::ThinkingObject
 }
 
-/// Provider-aware two-phase probe of a model's thinking behavior.
-///
-/// **Bedrock/Anthropic** (default = no thinking):
-///   Phase 1: Send WITH thinking enabled → can model think at all?
-///   If yes → Both (user can toggle). If error/no → None.
-///
-/// **DashScope/native thinkers** (default = thinking):
-///   Phase 1: Send default request → confirms it thinks.
-///   Phase 2: Send with `enable_thinking: false` → can it stop?
-///   Both phases think → NativeOnly. Phase 2 stops → Both.
-///
-/// **Generic OpenAI-compatible**:
-///   Phase 1: Send default request → does it think by default?
-///   If no → try with `reasoning_effort: "low"` → if it returns thinking → Both.
-///   If still no → None.
+/// Explicit protocol-aware check; unknown OpenAI-compatible routes are never
+/// probed with guessed extension fields. Probe failure leaves capability unknown.
 pub async fn probe_thinking_behavior(
     provider: &str,
     model_name: &str,
     api_key: &str,
     base_url: Option<&str>,
+) -> ThinkingProbeResult {
+    probe_thinking_behavior_with_protocol(provider, model_name, api_key, base_url, None).await
+}
+
+async fn probe_thinking_behavior_with_protocol(
+    provider: &str,
+    model_name: &str,
+    api_key: &str,
+    base_url: Option<&str>,
+    protocol_override: Option<ThinkingProtocol>,
 ) -> ThinkingProbeResult {
     if provider == "mock" {
         return ThinkingProbeResult {
@@ -4062,7 +4202,15 @@ pub async fn probe_thinking_behavior(
     let probe_builder = astra_core::net::apply_env_proxy(
         reqwest::Client::builder().timeout(std::time::Duration::from_secs(15)),
     );
-    let client = match probe_builder.build() {
+    let client_result = if provider == crate::byok_endpoint::COMPATIBLE_PROVIDER {
+        crate::byok_endpoint::endpoint_client(base_url.unwrap_or_default()).await
+    } else {
+        probe_builder
+            .build()
+            .map(crate::byok_endpoint::EndpointClient::from)
+            .map_err(|e| e.to_string())
+    };
+    let client = match client_result {
         Ok(c) => c,
         Err(e) => {
             return ThinkingProbeResult {
@@ -4079,179 +4227,30 @@ pub async fn probe_thinking_behavior(
         return probe_anthropic(&client, model_name, api_key, base_url).await;
     }
 
-    // OpenAI-compatible — provider-aware probe based on base_url.
-    let base_trim = base_url.map(str::trim).filter(|s| !s.is_empty());
-    let url = match base_trim {
-        Some(b) => b.trim_end_matches('/').to_string(),
-        None if provider == "openai" => "https://api.openai.com/v1".to_string(),
-        None => {
-            return ThinkingProbeResult {
-                capability: ThinkingCapability::None,
-                error: Some(format!("No base_url for provider '{provider}'")),
-            };
-        }
-    };
-    let probe_url = format!("{url}/chat/completions");
-    let url_lower = url.to_ascii_lowercase();
-    let base_body = serde_json::json!({
-        "model": model_name,
-        "max_tokens": 50,
-        "temperature": 0,
-        "messages": [{"role": "user", "content": "Say hello"}]
-    });
-
-    // ── DeepSeek: V4 exposes a typed thinking toggle on the OpenAI endpoint ──
-    if is_deepseek_probe_route(provider, &url) {
-        let default_thinks = match send_openai_probe(&client, &probe_url, api_key, &base_body).await
-        {
-            Ok(v) => v,
-            Err(e) => {
-                return ThinkingProbeResult {
-                    capability: ThinkingCapability::None,
-                    error: Some(e),
-                };
-            }
-        };
-        if !default_thinks {
-            return ThinkingProbeResult {
-                capability: ThinkingCapability::None,
-                error: None,
-            };
-        }
-
-        // DeepSeek V4 uses `thinking: {type: "disabled"}`. A rejection of
-        // this extension means the endpoint is an older/native-only route;
-        // keep the conservative effort-only contract rather than guessing
-        // that suppression succeeded.
-        let mut body_disable = base_body;
-        body_disable["thinking"] = serde_json::json!({"type": "disabled"});
-        return match send_openai_probe(&client, &probe_url, api_key, &body_disable).await {
-            Ok(false) => ThinkingProbeResult {
-                capability: ThinkingCapability::Both,
-                error: None,
-            },
-            Ok(true) => ThinkingProbeResult {
-                capability: ThinkingCapability::NativeOnly,
-                error: None,
-            },
-            Err(_) => ThinkingProbeResult {
-                capability: ThinkingCapability::EffortOnly,
-                error: None,
-            },
-        };
-    }
-
-    // ── MiniMax: always thinks via <think> tags, can't disable ──
-    if url_lower.contains("minimax") {
-        return match send_openai_probe(&client, &probe_url, api_key, &base_body).await {
-            Ok(true) => ThinkingProbeResult {
-                capability: ThinkingCapability::NativeOnly,
-                error: None,
-            },
-            Ok(false) => ThinkingProbeResult {
-                capability: ThinkingCapability::None,
-                error: None,
-            },
-            Err(e) => ThinkingProbeResult {
-                capability: ThinkingCapability::None,
-                error: Some(e),
-            },
-        };
-    }
-
-    // ── DashScope (Qwen, GLM-5.1): default=no thinking, enable_thinking toggles ──
-    if url_lower.contains("dashscope") || url_lower.contains("aliyun") {
-        // First check if it thinks by default (GLM-5.1 does)
-        let default_thinks = match send_openai_probe(&client, &probe_url, api_key, &base_body).await
-        {
-            Ok(v) => v,
-            Err(e) => {
-                return ThinkingProbeResult {
-                    capability: ThinkingCapability::None,
-                    error: Some(e),
-                };
-            }
-        };
-        if default_thinks {
-            // Thinks by default — test suppression
-            let mut body_disable = base_body;
-            body_disable["enable_thinking"] = serde_json::json!(false);
-            let (still_thinks, suppress_err) =
-                match send_openai_probe(&client, &probe_url, api_key, &body_disable).await {
-                    Ok(v) => (v, None),
-                    Err(e) => (true, Some(e)), // conservative: assume can't suppress on error
-                };
-            return ThinkingProbeResult {
-                capability: if still_thinks {
-                    ThinkingCapability::NativeOnly
-                } else {
-                    ThinkingCapability::Both
-                },
-                error: suppress_err,
-            };
-        }
-        // Doesn't think by default — try enabling
-        let mut body_enable = base_body;
-        body_enable["enable_thinking"] = serde_json::json!(true);
-        return match send_openai_probe(&client, &probe_url, api_key, &body_enable).await {
-            Ok(true) => ThinkingProbeResult {
-                capability: ThinkingCapability::Both,
-                error: None,
-            },
-            Ok(false) => ThinkingProbeResult {
-                capability: ThinkingCapability::None,
-                error: None,
-            },
-            Err(e) => ThinkingProbeResult {
-                capability: ThinkingCapability::None,
-                error: Some(e),
-            },
-        };
-    }
-
-    // ── Generic OpenAI-compatible: probe default, then try enable_thinking ──
-    let default_thinks = match send_openai_probe(&client, &probe_url, api_key, &base_body).await {
-        Ok(v) => v,
-        Err(e) => {
-            return ThinkingProbeResult {
-                capability: ThinkingCapability::None,
-                error: Some(e),
-            };
-        }
-    };
-    if default_thinks {
-        let mut body_suppress = base_body;
-        body_suppress["enable_thinking"] = serde_json::json!(false);
-        let (still_thinks, suppress_err) =
-            match send_openai_probe(&client, &probe_url, api_key, &body_suppress).await {
-                Ok(v) => (v, None),
-                Err(e) => (true, Some(e)), // conservative: assume can't suppress on error
-            };
+    let url = base_url
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or(if provider == "openai" {
+            "https://api.openai.com/v1"
+        } else {
+            ""
+        });
+    if url.is_empty() {
         return ThinkingProbeResult {
-            capability: if still_thinks {
-                ThinkingCapability::NativeOnly
-            } else {
-                ThinkingCapability::Both
-            },
-            error: suppress_err,
+            capability: ThinkingCapability::None,
+            error: Some("No base_url configured".into()),
         };
     }
-    let mut body_enable = base_body;
-    body_enable["enable_thinking"] = serde_json::json!(true);
-    match send_openai_probe(&client, &probe_url, api_key, &body_enable).await {
-        Ok(true) => ThinkingProbeResult {
-            capability: ThinkingCapability::Both,
-            error: None,
-        },
-        Ok(false) => ThinkingProbeResult {
-            capability: ThinkingCapability::None,
-            error: None,
-        },
-        Err(e) => ThinkingProbeResult {
-            capability: ThinkingCapability::None,
-            error: Some(e),
-        },
-    }
+    let protocol =
+        protocol_override.unwrap_or_else(|| canonical_thinking_protocol(provider, url, model_name));
+    probe_chat_protocol(
+        &client,
+        provider,
+        model_name,
+        &format!("{}/chat/completions", url.trim_end_matches('/')),
+        api_key,
+        protocol,
+    )
+    .await
 }
 
 async fn probe_bedrock(
@@ -4390,28 +4389,38 @@ async fn send_openai_probe(
     url: &str,
     api_key: &str,
     body: &serde_json::Value,
+    observe_usage_reasoning: bool,
 ) -> Result<bool, String> {
     let resp = client
         .post(url)
         .header("authorization", format!("Bearer {api_key}"))
         .header("content-type", "application/json")
+        .timeout(Duration::from_secs(30))
         .json(body)
         .send()
         .await
-        .map_err(|e| format!("Probe request failed: {e}"))?;
+        .map_err(|_| "Thinking probe transport failed".to_string())?;
 
     if resp.status().as_u16() >= 400 {
         let status = resp.status().as_u16();
-        let text = resp.text().await.unwrap_or_default();
-        return Err(format!(
-            "Probe HTTP {status}: {}",
-            &text[..text.len().min(200)]
-        ));
+        return Err(format!("Thinking probe HTTP {status}"));
     }
 
     let text = resp.text().await.unwrap_or_default();
     let json: serde_json::Value =
         serde_json::from_str(&text).map_err(|e| format!("Probe parse error: {e}"))?;
+
+    if json
+        .pointer("/choices/0/finish_reason")
+        .and_then(Value::as_str)
+        != Some("stop")
+        || json
+            .pointer("/choices/0/message/content")
+            .and_then(Value::as_str)
+            .is_none_or(|s| s.trim().is_empty())
+    {
+        return Err("Thinking probe returned incomplete or malformed output".into());
+    }
 
     let content = json
         .get("choices")
@@ -4421,7 +4430,10 @@ async fn send_openai_probe(
         .and_then(serde_json::Value::as_str)
         .unwrap_or("");
 
-    let has_think_tags = content.contains("<think>");
+    let has_think_tags = content
+        .split_once("<think>")
+        .and_then(|(_, rest)| rest.split_once("</think>"))
+        .is_some_and(|(reasoning, _)| !reasoning.trim().is_empty());
     let has_reasoning_content = json
         .get("choices")
         .and_then(|c| c.get(0))
@@ -4430,7 +4442,12 @@ async fn send_openai_probe(
         .and_then(serde_json::Value::as_str)
         .is_some_and(|s| !s.is_empty());
 
-    Ok(has_think_tags || has_reasoning_content)
+    let usage_reasoning = observe_usage_reasoning
+        && json
+            .pointer("/usage/completion_tokens_details/reasoning_tokens")
+            .and_then(Value::as_u64)
+            .is_some_and(|tokens| tokens > 0);
+    Ok(has_think_tags || has_reasoning_content || usage_reasoning)
 }
 
 // ── Noop implementation ──────────────────────────────────────────────────────
@@ -5641,12 +5658,27 @@ mod tests {
             fallback_chain: Vec::new(),
             tags: Vec::new(),
             request_body_overrides: None,
+            fixed_temperature: None,
+            thinking_protocol: None,
             prompt_cache_capability: None,
             thinking_capability: None,
             context_window: Some(200_000),
             max_completion_tokens: Some(16_384),
             request_headers: None,
         }
+    }
+
+    #[test]
+    fn admitted_execution_carries_mode_independent_fixed_temperature() {
+        let mut model = sample_resolved_active_model("fixed-temperature-model");
+        model.fixed_temperature = Some(0.6);
+        let execution = AdmittedModelExecution::from_offering(ResolvedModelOffering {
+            offering_id: "fixed-temperature-offering".to_string(),
+            model,
+        })
+        .expect("admitted execution");
+
+        assert_eq!(execution.fixed_temperature, Some(0.6));
     }
 
     #[test]
@@ -6095,6 +6127,8 @@ mod tests {
             fallback_chain: vec![],
             tags: vec![],
             request_body_overrides: None,
+            fixed_temperature: None,
+            thinking_protocol: None,
             prompt_cache_capability: None,
             thinking_capability: None,
             context_window: None,
@@ -6117,6 +6151,8 @@ mod tests {
             fallback_chain: vec![],
             tags: vec![],
             request_body_overrides: None,
+            fixed_temperature: None,
+            thinking_protocol: None,
             prompt_cache_capability: None,
             thinking_capability: None,
             context_window: None,
@@ -6258,6 +6294,7 @@ mod tests {
     fn quirks_data_serialization_roundtrip() {
         let q = QuirksData {
             fixed_temperature: Some(0.7),
+            thinking_protocol: None,
             preserve_reasoning_content: true,
             no_parallel_tool_calls: true,
             tool_choice_required: false,
@@ -7616,7 +7653,7 @@ mod tests {
             if has_reasoning {
                 msg["reasoning_content"] = serde_json::json!("thinking...");
             }
-            axum::Json(serde_json::json!({"choices": [{"message": msg}]}))
+            axum::Json(serde_json::json!({"choices": [{"message": msg, "finish_reason": "stop"}]}))
         };
         let app = Router::new().route("/chat/completions", post(handler));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -7644,7 +7681,7 @@ mod tests {
             if has_reasoning {
                 msg["reasoning_content"] = serde_json::json!("thinking...");
             }
-            axum::Json(serde_json::json!({"choices": [{"message": msg}]}))
+            axum::Json(serde_json::json!({"choices": [{"message": msg, "finish_reason": "stop"}]}))
         };
         let app = Router::new().route("/chat/completions", post(handler));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -7673,7 +7710,7 @@ mod tests {
             if !disabled {
                 msg["reasoning_content"] = serde_json::json!("thinking...");
             }
-            axum::Json(serde_json::json!({"choices": [{"message": msg}]}))
+            axum::Json(serde_json::json!({"choices": [{"message": msg, "finish_reason": "stop"}]}))
         };
         let app = Router::new().route("/chat/completions", post(handler));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -7691,7 +7728,7 @@ mod tests {
     #[tokio::test]
     async fn probe_dashscope_qwen_plus_both() {
         let base = spawn_dashscope_mock(true).await;
-        let result = probe_thinking_behavior("openai", "qwen-plus", "k", Some(&base)).await;
+        let result = probe_thinking_behavior("dashscope", "qwen-plus", "k", Some(&base)).await;
         assert_eq!(result.capability, ThinkingCapability::Both, "{:?}", result);
     }
 
@@ -7699,15 +7736,19 @@ mod tests {
     #[tokio::test]
     async fn probe_dashscope_qwen25_3b_none() {
         let base = spawn_dashscope_mock(false).await;
-        let result = probe_thinking_behavior("openai", "qwen2.5-3b", "k", Some(&base)).await;
+        let result = probe_thinking_behavior("dashscope", "qwen2.5-3b", "k", Some(&base)).await;
         assert_eq!(result.capability, ThinkingCapability::None, "{:?}", result);
+        assert!(
+            result.error.is_some(),
+            "No visible reasoning is inconclusive, not proof of no capability"
+        );
     }
 
     // ── DashScope glm-5.1: thinks by default, enable_thinking:false suppresses → Both ──
     #[tokio::test]
     async fn probe_dashscope_glm51_native_both() {
         let base = spawn_dashscope_native_thinker_mock().await;
-        let result = probe_thinking_behavior("openai", "glm-5.1", "k", Some(&base)).await;
+        let result = probe_thinking_behavior("dashscope", "glm-5.1", "k", Some(&base)).await;
         assert_eq!(result.capability, ThinkingCapability::Both, "{:?}", result);
     }
 
@@ -7729,18 +7770,21 @@ mod tests {
             serde_json::json!({
                 "choices": [{"message": {
                     "content": "<think>reasoning</think>\n\nHello!"
-                }}]
+                }, "finish_reason":"stop"}]
             }),
         )
         .await;
         let result = probe_thinking_behavior("openai", "MiniMax-M2.5", "k", Some(&base)).await;
-        // Generic path: detects <think> → tries suppression with same mock → still thinks → NativeOnly
-        assert!(
-            result.capability == ThinkingCapability::NativeOnly
-                || result.capability == ThinkingCapability::Both,
-            "MiniMax with <think> tags: {:?}",
-            result
-        );
+        assert!(result.error.is_none());
+        assert_eq!(result.capability, ThinkingCapability::NativeOnly);
+        let captured = captured.lock().unwrap();
+        let body = captured.as_ref().unwrap();
+        for field in ["thinking", "enable_thinking", "reasoning_effort"] {
+            assert!(
+                body.get(field).is_none(),
+                "Unknown protocol must not guess a control"
+            );
+        }
     }
 
     // ── Error paths ──

--- a/crates/services/src/models/thinking_probe.rs
+++ b/crates/services/src/models/thinking_probe.rs
@@ -136,6 +136,11 @@ pub(super) async fn probe_chat_protocol(
         true,
         (protocol == ThinkingProtocol::ReasoningEffort).then_some("low"),
     );
+    if protocol == ThinkingProtocol::EnableThinking {
+        // Some DashScope deployments require streaming when thinking is on.
+        // Use it for both legs so the observation protocol is identical.
+        enabled["stream"] = serde_json::json!(true);
+    }
     match send_openai_probe(
         client,
         url,
@@ -176,9 +181,266 @@ pub(super) async fn probe_chat_protocol(
     }
 }
 
+pub(super) fn transport_error(error: reqwest::Error) -> String {
+    // Never format the original error: it may contain a private URL or key.
+    let category = if error.is_timeout() {
+        "timeout"
+    } else if error.is_connect() {
+        "connection/DNS/TLS"
+    } else if error.is_body() || error.is_decode() {
+        "response body"
+    } else {
+        "request transport"
+    };
+    format!("Thinking probe {category} failure")
+}
+
+pub(super) fn validate_output(json: &Value) -> Result<(), String> {
+    let content = json
+        .pointer("/choices/0/message/content")
+        .and_then(Value::as_str);
+    let finish = json.pointer("/choices/0/finish_reason");
+    let acceptable_finish = match finish {
+        None | Some(Value::Null) => true,
+        Some(Value::String(reason)) => matches!(reason.as_str(), "stop" | "length"),
+        _ => false,
+    };
+    // Missing finish metadata is common on compatible gateways. Truncated but
+    // nonempty output can show reasoning; empty/refused/error output cannot
+    // establish either positive capability or successful suppression.
+    if json.get("error").is_some()
+        || json
+            .pointer("/choices/0/message/refusal")
+            .is_some_and(|v| !v.is_null())
+        || !acceptable_finish
+        || content.is_none_or(|s| s.trim().is_empty())
+    {
+        return Err("Thinking probe returned incomplete or malformed output".into());
+    }
+    Ok(())
+}
+
+/// Bounded probe-only SSE normalization, not a runtime inference parser.
+/// Operates after capped response collection, so network chunk/UTF-8 boundaries
+/// cannot split a JSON event. Reject malformed frames rather than infer absence.
+pub(super) fn parse_response(bytes: &[u8], streaming: bool) -> Result<Value, String> {
+    let invalid = || "Thinking probe returned malformed response".to_string();
+    if !streaming {
+        return serde_json::from_slice(bytes).map_err(|_| invalid());
+    }
+    let text = std::str::from_utf8(bytes).map_err(|_| invalid())?;
+    let mut data = Vec::new();
+    let mut events = Vec::new();
+    let mut done = false;
+    for line in text.lines().chain(std::iter::once("")) {
+        if line.is_empty() {
+            if data.is_empty() {
+                continue;
+            }
+            let payload = data.join("\n");
+            data.clear();
+            if done {
+                return Err(invalid());
+            }
+            if payload.trim() == "[DONE]" {
+                done = true;
+                continue;
+            }
+            events.push(serde_json::from_str::<Value>(&payload).map_err(|_| invalid())?);
+        } else if let Some(value) = line.strip_prefix("data:") {
+            data.push(value.strip_prefix(' ').unwrap_or(value));
+        }
+    }
+    let mut content = String::new();
+    let mut reasoning = String::new();
+    let mut finish = Value::Null;
+    let mut usage = Value::Null;
+    for event in events {
+        if event.get("error").is_some() {
+            return Err(invalid());
+        }
+        if let Some(value) = event.get("usage") {
+            usage = value.clone();
+        }
+        let choices = event
+            .get("choices")
+            .and_then(Value::as_array)
+            .ok_or_else(invalid)?;
+        for choice in choices {
+            if choice
+                .get("index")
+                .and_then(Value::as_u64)
+                .is_some_and(|i| i != 0)
+            {
+                continue;
+            }
+            let delta = choice
+                .get("delta")
+                .and_then(Value::as_object)
+                .ok_or_else(invalid)?;
+            if delta.get("refusal").is_some_and(|v| !v.is_null()) {
+                return Err(invalid());
+            }
+            for (key, target) in [
+                ("content", &mut content),
+                ("reasoning_content", &mut reasoning),
+            ] {
+                match delta.get(key) {
+                    Some(Value::String(value)) => target.push_str(value),
+                    None | Some(Value::Null) => {}
+                    _ => return Err(invalid()),
+                }
+            }
+            if let Some(value) = choice.get("finish_reason").filter(|v| !v.is_null()) {
+                finish = value.clone();
+            }
+        }
+    }
+    if !done && finish.is_null() {
+        return Err(invalid());
+    }
+    Ok(
+        serde_json::json!({"choices":[{"finish_reason":finish,"message":{"content":content,"reasoning_content":reasoning}}],"usage":usage}),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn optional_finish_metadata_does_not_reject_valid_gateway_output() {
+        for finish in [
+            Value::Null,
+            serde_json::json!("stop"),
+            serde_json::json!("length"),
+        ] {
+            let response = serde_json::json!({"choices":[{"finish_reason":finish,"message":{"content":"391"}}]});
+            assert!(validate_output(&response).is_ok());
+        }
+        assert!(
+            validate_output(&serde_json::json!({"choices":[{"message":{"content":"391"}}]}))
+                .is_ok()
+        );
+        for response in [
+            serde_json::json!({"choices":[{"message":{"content":""}}]}),
+            serde_json::json!({"choices":[{"finish_reason":"content_filter","message":{"content":"blocked"}}]}),
+            serde_json::json!({"choices":[{"message":{"content":"391","refusal":"no"}}]}),
+            serde_json::json!({"error":"private upstream text"}),
+        ] {
+            assert!(validate_output(&response).is_err());
+        }
+    }
+
+    #[test]
+    fn streaming_probe_handles_multiline_utf8_usage_and_rejects_incomplete_frames() {
+        let wire = concat!(
+            ": keepalive\r\n\r\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"计算\"},\"finish_reason\":null}]}\r\n\r\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"391\"},\n",
+            "data: \"finish_reason\":\"stop\"}]}\n\n",
+            "data: {\"choices\":[],\"usage\":{\"completion_tokens_details\":{\"reasoning_tokens\":3}}}\n\n",
+            "data: [DONE]\n\n"
+        );
+        let json = parse_response(wire.as_bytes(), true).unwrap();
+        validate_output(&json).unwrap();
+        assert_eq!(json["choices"][0]["message"]["reasoning_content"], "计算");
+        assert_eq!(json["choices"][0]["message"]["content"], "391");
+        for wire in [
+            "data: {broken}\n\n",
+            "data: {\"error\":\"secret\"}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"391\"}}]}\n\n",
+        ] {
+            assert!(parse_response(wire.as_bytes(), true).is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn probe_classifies_connect_failure_without_disclosing_url() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let error = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap()
+            .get(format!("http://{addr}/private-key"))
+            .send()
+            .await
+            .unwrap_err();
+        let safe = transport_error(error);
+        assert!(safe.contains("connection/DNS/TLS"));
+        assert!(!safe.contains("private-key"));
+        assert!(!safe.contains(&addr.to_string()));
+    }
+
+    #[tokio::test]
+    async fn probe_bounds_body_and_distinguishes_positive_from_negative_truncation() {
+        use axum::{Json, Router, routing::post};
+        let app = Router::new().route("/chat/completions", post(|Json(body): Json<Value>| async move {
+            let model = body["model"].as_str().unwrap();
+            if model == "oversized" { return "x".repeat(1024 * 1024 + 1); }
+            let mut message = serde_json::json!({"content":"391"});
+            if model == "reasoning-length" { message["reasoning_content"] = serde_json::json!("multiply"); }
+            serde_json::json!({"choices":[{"message":message,"finish_reason":if model == "missing-finish" {Value::Null} else {serde_json::json!("length")}}]}).to_string()
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/chat/completions", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        for (model, expected) in [
+            ("oversized", None),
+            ("negative-length", None),
+            ("reasoning-length", Some(true)),
+            ("missing-finish", Some(false)),
+        ] {
+            let result = send_openai_probe(
+                &client,
+                &url,
+                "fixture-secret",
+                &serde_json::json!({"model":model}),
+                false,
+            )
+            .await;
+            match expected {
+                Some(value) => assert_eq!(result.unwrap(), value),
+                None => assert!(result.is_err()),
+            }
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn stalled_probe_body_honors_request_deadline() {
+        use axum::{Router, body::Body, routing::post};
+        let app = Router::new().route(
+            "/chat/completions",
+            post(|| async {
+                Body::from_stream(futures_util::stream::pending::<
+                    Result<String, std::io::Error>,
+                >())
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/chat/completions", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            send_openai_probe_with_timeout(
+                &client,
+                &url,
+                "fixture-secret",
+                &serde_json::json!({}),
+                false,
+                Duration::from_millis(50),
+            ),
+        )
+        .await
+        .expect("request body must honor its configured deadline");
+        assert!(result.unwrap_err().contains("timeout"));
+        server.abort();
+    }
 
     #[tokio::test]
     async fn strict_toggle_probe_uses_shared_protocol_and_rejects_ignored_controls() {
@@ -356,6 +618,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "live-provider-tests")]
     #[ignore = "requires a real paid provider credential in ASTRA_TEST_SUMMARY_CONFIG_FILE"]
     async fn live_thinking_protocol_probe() {
         let path = std::env::var("ASTRA_TEST_SUMMARY_CONFIG_FILE").expect("provider config path");

--- a/crates/services/src/models/thinking_probe.rs
+++ b/crates/services/src/models/thinking_probe.rs
@@ -1,0 +1,488 @@
+//! Persistable, configuration-bound thinking observations. Never probe during
+//! model resolution or inference; only explicit model checks perform I/O.
+use super::*;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct ThinkingProbeSnapshot {
+    revision: u32,
+    identity: String,
+    protocol: ThinkingProtocol,
+    capability: Option<ThinkingCapability>,
+    error: Option<String>,
+    observed_at: String,
+    #[serde(default)]
+    legacy_hint: bool,
+}
+
+impl ThinkingProbeSnapshot {
+    pub(super) fn result(
+        &self,
+        identity: &str,
+        protocol: ThinkingProtocol,
+    ) -> Option<ThinkingProbeResult> {
+        (self.revision == ThinkingProtocol::REVISION
+            && self.identity == identity
+            && self.protocol == protocol)
+            .then(|| ThinkingProbeResult {
+                capability: self.capability.unwrap_or(ThinkingCapability::None),
+                error: self.error.clone(),
+            })
+    }
+    pub(super) fn new(
+        identity: String,
+        protocol: ThinkingProtocol,
+        result: &ThinkingProbeResult,
+    ) -> Self {
+        Self {
+            revision: ThinkingProtocol::REVISION,
+            identity,
+            protocol,
+            capability: result.error.is_none().then_some(result.capability),
+            error: result.error.clone(),
+            observed_at: chrono::Utc::now().to_rfc3339(),
+            legacy_hint: false,
+        }
+    }
+
+    /// An inconclusive check is not a negative capability observation. Keep
+    /// prior knowledge only for exactly the same configuration and protocol.
+    pub(super) fn with_previous(
+        mut self,
+        raw: Option<&str>,
+        legacy: Option<ThinkingCapability>,
+    ) -> Self {
+        // A baseline observation cannot disprove previously known controls.
+        if self.error.is_some()
+            || (self.protocol == ThinkingProtocol::Unknown
+                && self.capability == Some(ThinkingCapability::NativeOnly))
+        {
+            if let Some(raw) = raw {
+                if let Ok(previous) = serde_json::from_str::<Self>(raw)
+                    && let Some(capability) = previous.capability(&self.identity, self.protocol)
+                {
+                    self.capability = Some(capability);
+                    self.legacy_hint = previous.legacy_hint;
+                }
+            } else if let Some(legacy) = legacy {
+                self.capability = Some(legacy);
+                self.legacy_hint = true;
+            }
+        }
+        self
+    }
+
+    pub(super) fn persisted_capability(&self) -> Option<ThinkingCapability> {
+        self.capability
+    }
+
+    pub(super) fn capability(
+        &self,
+        identity: &str,
+        protocol: ThinkingProtocol,
+    ) -> Option<ThinkingCapability> {
+        (self.revision == ThinkingProtocol::REVISION
+            && self.identity == identity
+            && self.protocol == protocol)
+            .then_some(self.capability)
+            .flatten()
+    }
+}
+
+/// Hash configuration, not plaintext credentials. Ciphertext generation binds
+/// the observation to credential rotation without persisting a key-derived hash.
+pub(super) fn probe_identity(
+    provider: &str,
+    endpoint: &str,
+    model: &str,
+    encrypted: &str,
+    config: &str,
+) -> String {
+    let serialized = serde_json::to_vec(&(provider, endpoint, model, encrypted, config))
+        .expect("string tuple serializes");
+    format!("{:x}", Sha256::digest(serialized))
+}
+
+pub(super) fn cached_capability(
+    raw: Option<&str>,
+    identity: &str,
+    protocol: ThinkingProtocol,
+) -> Option<ThinkingCapability> {
+    raw.and_then(|raw| serde_json::from_str::<ThinkingProbeSnapshot>(raw).ok())
+        .and_then(|snapshot| snapshot.capability(identity, protocol))
+}
+
+/// Binary controls require two-sided observation. Native/effort protocols
+/// establish reasoning only, never suppression. An accepted but ignored toggle
+/// is not `Both`; absent observable reasoning remains inconclusive.
+pub(super) async fn probe_chat_protocol(
+    client: &reqwest::Client,
+    provider: &str,
+    model: &str,
+    url: &str,
+    key: &str,
+    protocol: ThinkingProtocol,
+) -> ThinkingProbeResult {
+    let unknown = |message: &str| ThinkingProbeResult {
+        capability: ThinkingCapability::None,
+        error: Some(message.to_string()),
+    };
+    let mut enabled = serde_json::json!({
+        "model": model,
+        "messages": [{"role": "user", "content": "Calculate 17 * 23. Reply with the result."}]
+    });
+    astra_core::model_wire::apply_chat_output_token_limit(&mut enabled, provider, 1024);
+    protocol.apply(
+        &mut enabled,
+        true,
+        (protocol == ThinkingProtocol::ReasoningEffort).then_some("low"),
+    );
+    match send_openai_probe(
+        client,
+        url,
+        key,
+        &enabled,
+        protocol == ThinkingProtocol::ReasoningEffort,
+    )
+    .await
+    {
+        Ok(true) => {}
+        Ok(false) => {
+            return unknown("No observable reasoning in enabled mode; capability remains unknown");
+        }
+        Err(error) => return unknown(&error),
+    }
+    if !protocol.can_disable() {
+        return ThinkingProbeResult {
+            capability: if protocol == ThinkingProtocol::ReasoningEffort {
+                ThinkingCapability::EffortOnly
+            } else {
+                // Observed native reasoning, but no evidence of a toggle.
+                ThinkingCapability::NativeOnly
+            },
+            error: None,
+        };
+    }
+    let mut disabled = enabled;
+    protocol.apply(&mut disabled, false, None);
+    match send_openai_probe(client, url, key, &disabled, false).await {
+        Ok(false) => ThinkingProbeResult {
+            capability: ThinkingCapability::Both,
+            error: None,
+        },
+        Ok(true) => unknown(
+            "Reasoning remained visible with suppression requested; capability remains unknown",
+        ),
+        Err(error) => unknown(&error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn strict_toggle_probe_uses_shared_protocol_and_rejects_ignored_controls() {
+        use axum::{Json, Router, routing::post};
+        use serde_json::json;
+        let app = Router::new().route(
+            "/chat/completions",
+            post(|Json(body): Json<Value>| async move {
+                assert!(body.get("temperature").is_none());
+                assert!(body.get("enable_thinking").is_none());
+                assert_eq!(body["max_completion_tokens"], 1024);
+                let mut message = json!({"content":"391"});
+                if body["thinking"]["type"] == "enabled" || body["model"] == "ignores-control" {
+                    message["reasoning_content"] = json!("multiplication");
+                }
+                Json(json!({"choices":[{"message":message,"finish_reason":"stop"}]}))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/chat/completions", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let result = probe_chat_protocol(
+            &client,
+            "openai-compatible",
+            "m",
+            &url,
+            "fixture",
+            ThinkingProtocol::Moonshot,
+        )
+        .await;
+        assert_eq!(result.capability, ThinkingCapability::Both);
+        assert!(result.error.is_none());
+        let result = probe_chat_protocol(
+            &client,
+            "openai-compatible",
+            "ignores-control",
+            &url,
+            "fixture",
+            ThinkingProtocol::Moonshot,
+        )
+        .await;
+        assert!(result.error.is_some());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn native_and_effort_probes_do_not_guess_binary_controls() {
+        use axum::{Json, Router, routing::post};
+        let app = Router::new().route("/chat/completions", post(|Json(body): Json<Value>| async move {
+            assert!(body.get("thinking").is_none());
+            assert!(body.get("enable_thinking").is_none());
+            let mut response = serde_json::json!({"choices":[{"finish_reason":"stop","message":{"content":"391"}}]});
+            if body["model"] == "native" {
+                assert!(body.get("reasoning_effort").is_none());
+                response["choices"][0]["message"]["reasoning_content"] = serde_json::json!("multiply");
+            } else if body["model"] == "effort" {
+                assert_eq!(body["reasoning_effort"], "low");
+                response["usage"] = serde_json::json!({"completion_tokens_details":{"reasoning_tokens":12}});
+            }
+            Json(response)
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/chat/completions", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        for (model, protocol, expected) in [
+            (
+                "native",
+                ThinkingProtocol::Unknown,
+                Some(ThinkingCapability::NativeOnly),
+            ),
+            (
+                "effort",
+                ThinkingProtocol::ReasoningEffort,
+                Some(ThinkingCapability::EffortOnly),
+            ),
+            ("inconclusive", ThinkingProtocol::Unknown, None),
+        ] {
+            let result =
+                probe_chat_protocol(&client, "openai", model, &url, "fixture", protocol).await;
+            assert_eq!(
+                result.error.is_none().then_some(result.capability),
+                expected
+            );
+        }
+        server.abort();
+    }
+
+    #[test]
+    fn inconclusive_probe_preserves_only_matching_knowledge() {
+        let protocol = ThinkingProtocol::ThinkingObject;
+        let success = ThinkingProbeResult {
+            capability: ThinkingCapability::Both,
+            error: None,
+        };
+        let failure = ThinkingProbeResult {
+            capability: ThinkingCapability::None,
+            error: Some("inconclusive".into()),
+        };
+        let old = ThinkingProbeSnapshot::new("identity".into(), protocol, &success);
+        let raw = serde_json::to_string(&old).unwrap();
+        let retained = ThinkingProbeSnapshot::new("identity".into(), protocol, &failure)
+            .with_previous(Some(&raw), None);
+        assert_eq!(
+            retained.capability("identity", protocol),
+            Some(ThinkingCapability::Both)
+        );
+        assert!(
+            retained
+                .result("identity", protocol)
+                .unwrap()
+                .error
+                .is_some()
+        );
+        for changed in ["rotated-key", "changed-model"] {
+            let invalid = ThinkingProbeSnapshot::new(changed.into(), protocol, &failure)
+                .with_previous(Some(&raw), Some(ThinkingCapability::Both));
+            assert_eq!(invalid.capability(changed, protocol), None);
+        }
+        let legacy = ThinkingProbeSnapshot::new("identity".into(), protocol, &failure)
+            .with_previous(None, Some(ThinkingCapability::NativeOnly));
+        assert!(legacy.legacy_hint);
+        assert_eq!(
+            legacy.persisted_capability(),
+            Some(ThinkingCapability::NativeOnly)
+        );
+        let malformed = ThinkingProbeSnapshot::new("identity".into(), protocol, &failure)
+            .with_previous(Some("invalid"), Some(ThinkingCapability::Both));
+        assert_eq!(malformed.persisted_capability(), None);
+        let native = ThinkingProbeResult {
+            capability: ThinkingCapability::NativeOnly,
+            error: None,
+        };
+        let baseline =
+            ThinkingProbeSnapshot::new("identity".into(), ThinkingProtocol::Unknown, &native)
+                .with_previous(None, Some(ThinkingCapability::Both));
+        assert_eq!(
+            baseline.persisted_capability(),
+            Some(ThinkingCapability::Both)
+        );
+        assert!(
+            baseline.legacy_hint,
+            "baseline must not claim it verified a toggle"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_output_and_error_bodies_cannot_become_capabilities_or_leak_secrets() {
+        use axum::{Json, Router, routing::post};
+        let app = Router::new().route("/chat/completions", post(|Json(body): Json<Value>| async move {
+            if body["model"] == "error" {
+                return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error":"fixture-secret"})));
+            }
+            (StatusCode::OK, Json(serde_json::json!({"choices":[{"finish_reason":"length", "message":{"content":"", "reasoning_content":"thinking"}}]})))
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/chat/completions", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        for model in ["error", "truncated"] {
+            let result = probe_chat_protocol(
+                &client,
+                "openai-compatible",
+                model,
+                &url,
+                "fixture-secret",
+                ThinkingProtocol::Moonshot,
+            )
+            .await;
+            assert!(result.error.is_some());
+            assert!(!format!("{result:?}").contains("fixture-secret"));
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a real paid provider credential in ASTRA_TEST_SUMMARY_CONFIG_FILE"]
+    async fn live_thinking_protocol_probe() {
+        let path = std::env::var("ASTRA_TEST_SUMMARY_CONFIG_FILE").expect("provider config path");
+        let config = std::fs::read_to_string(path).expect("read config");
+        let lines: Vec<_> = config
+            .lines()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert!(lines.len() >= 3);
+        let fields = &lines[lines.len() - 3..];
+        let model =
+            std::env::var("ASTRA_TEST_SUMMARY_MODEL").unwrap_or_else(|_| fields[2].to_string());
+        let protocol = match std::env::var("ASTRA_TEST_THINKING_PROTOCOL") {
+            Ok(s) => serde_json::from_value(Value::String(s)).expect("protocol"),
+            Err(_) => canonical_thinking_protocol(
+                crate::byok_endpoint::COMPATIBLE_PROVIDER,
+                fields[0],
+                &model,
+            ),
+        };
+        let result = probe_thinking_behavior_with_protocol(
+            crate::byok_endpoint::COMPATIBLE_PROVIDER,
+            &model,
+            fields[1],
+            Some(fields[0]),
+            Some(protocol),
+        )
+        .await;
+        eprintln!(
+            "thinking_probe verified_toggle={}",
+            result.error.is_none() && result.capability == ThinkingCapability::Both
+        );
+        assert!(
+            result.error.is_none(),
+            "probe failed (upstream details suppressed)"
+        );
+        assert_eq!(result.capability, ThinkingCapability::Both);
+    }
+
+    #[test]
+    fn snapshot_reuse_is_bound_to_exact_configuration_and_revision() {
+        let identity = probe_identity(
+            "openai-compatible",
+            "https://provider.test/v1",
+            "m",
+            "ciphertext-v1",
+            "{}",
+        );
+        let result = ThinkingProbeResult {
+            capability: ThinkingCapability::Both,
+            error: None,
+        };
+        let snapshot =
+            ThinkingProbeSnapshot::new(identity.clone(), ThinkingProtocol::ThinkingObject, &result);
+        let raw = serde_json::to_string(&snapshot).unwrap();
+        assert_eq!(
+            cached_capability(Some(&raw), &identity, ThinkingProtocol::ThinkingObject),
+            Some(ThinkingCapability::Both)
+        );
+        for changed in [
+            probe_identity(
+                "openai",
+                "https://provider.test/v1",
+                "m",
+                "ciphertext-v1",
+                "{}",
+            ),
+            probe_identity(
+                "openai-compatible",
+                "https://other.test/v1",
+                "m",
+                "ciphertext-v1",
+                "{}",
+            ),
+            probe_identity(
+                "openai-compatible",
+                "https://provider.test/v1",
+                "n",
+                "ciphertext-v1",
+                "{}",
+            ),
+            probe_identity(
+                "openai-compatible",
+                "https://provider.test/v1",
+                "m",
+                "ciphertext-v2",
+                "{}",
+            ),
+            probe_identity(
+                "openai-compatible",
+                "https://provider.test/v1",
+                "m",
+                "ciphertext-v1",
+                "{\"changed\":true}",
+            ),
+        ] {
+            assert_eq!(
+                cached_capability(Some(&raw), &changed, ThinkingProtocol::ThinkingObject),
+                None
+            );
+        }
+        assert_eq!(
+            cached_capability(Some(&raw), &identity, ThinkingProtocol::Moonshot),
+            None
+        );
+        assert_eq!(
+            cached_capability(None, &identity, ThinkingProtocol::ThinkingObject),
+            None
+        );
+        let mut stale = snapshot.clone();
+        stale.revision += 1;
+        assert_eq!(
+            stale.capability(&identity, ThinkingProtocol::ThinkingObject),
+            None
+        );
+        let failed = ThinkingProbeSnapshot::new(
+            identity.clone(),
+            ThinkingProtocol::ThinkingObject,
+            &ThinkingProbeResult {
+                capability: ThinkingCapability::Both,
+                error: Some("failed".into()),
+            },
+        );
+        assert_eq!(
+            failed.capability(&identity, ThinkingProtocol::ThinkingObject),
+            None
+        );
+    }
+}

--- a/crates/services/src/runs.rs
+++ b/crates/services/src/runs.rs
@@ -31315,6 +31315,8 @@ mod tests {
                 provider: "openai".to_string(),
                 cache_capability: None,
                 thinking_capability: None,
+                fixed_temperature: None,
+                thinking_protocol: None,
                 request_body_overrides: None,
                 context_window: Some(128_000),
                 max_completion_tokens: Some(16_384),

--- a/crates/services/src/storage.rs
+++ b/crates/services/src/storage.rs
@@ -121,7 +121,7 @@ pub const AGENT_ID_LEN: usize = 255;
 pub const AGENT_EVENT_ID_LEN: usize = 128;
 static CORE_SCHEMA_INIT_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 const CORE_SCHEMA_CONTRACT_COMPONENT: &str = "astra-core";
-pub const CORE_SCHEMA_CONTRACT_VERSION: &str = "2026-09-04-v70";
+pub const CORE_SCHEMA_CONTRACT_VERSION: &str = "2026-09-09-v71";
 const CORE_SCHEMA_CONTRACT_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS astra_schema_contracts (
     component VARCHAR(64) NOT NULL PRIMARY KEY,
     contract_version VARCHAR(64) NOT NULL,
@@ -6776,6 +6776,7 @@ async fn ensure_core_schema_while_leased(
             quirks JSON NOT NULL,
             thinking_capability VARCHAR(20) NULL,
             thinking_probe_error TEXT NULL,
+            thinking_probe_json JSON NULL,
             created_by VARCHAR(128) NULL,
             created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
             updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
@@ -6811,6 +6812,18 @@ async fn ensure_core_schema_while_leased(
     )
     .execute(&pool)
     .await?;
+
+    // Additive observations; old models stay usable. Never probe in migrations.
+    for table in ["infra_llm_models", "user_llm_models"] {
+        add_column_if_missing(
+            &pool,
+            &settings.database,
+            table,
+            "thinking_probe_json",
+            &format!("ALTER TABLE {table} ADD COLUMN thinking_probe_json JSON NULL"),
+        )
+        .await?;
+    }
 
     // Canonical inference execution ledger. Admission writes the immutable route
     // and logical invocation together; each physical attempt is then committed

--- a/crates/services/src/storage.rs
+++ b/crates/services/src/storage.rs
@@ -6799,6 +6799,7 @@ async fn ensure_core_schema_while_leased(
             api_key_encrypted TEXT NOT NULL,
             base_url VARCHAR(500) NOT NULL,
             context_window INT NOT NULL,
+            thinking_probe_json JSON NULL,
             is_default SMALLINT NOT NULL DEFAULT 0,
             is_active SMALLINT NOT NULL DEFAULT 1,
             created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),

--- a/crates/services/tests/common/isolated_database.rs
+++ b/crates/services/tests/common/isolated_database.rs
@@ -24,6 +24,31 @@ fn is_designated_database(database: &str, designated: &str) -> bool {
         )
 }
 
+/// Extra guard for destructive schema rehearsals, not ordinary row fixtures.
+pub fn is_schema_rehearsal_database(database: &str) -> bool {
+    database
+        .strip_prefix("astra_test_probe_")
+        .is_some_and(|suffix| !suffix.is_empty())
+        && is_designated_database(database, database)
+}
+
+// This shared module is also included by the default memoria_auth_db_it target:
+// the guard test runs without external-contract-tests or a database connection.
+#[test]
+fn schema_rehearsal_rejects_broad_or_non_test_targets() {
+    assert!(is_schema_rehearsal_database("astra_test_probe_20260910"));
+    for name in [
+        "production",
+        "review_local",
+        "astra_runtime",
+        "astra_test_probe_",
+        "astra_test_probe_x;DROP",
+        "mysql",
+    ] {
+        assert!(!is_schema_rehearsal_database(name));
+    }
+}
+
 #[test]
 fn isolated_database_contract_accepts_runner_names_and_rejects_implicit_targets() {
     for name in [

--- a/crates/services/tests/user_model_probe_db_it.rs
+++ b/crates/services/tests/user_model_probe_db_it.rs
@@ -19,8 +19,12 @@ use std::sync::Arc;
 #[tokio::test]
 #[ignore = "requires isolated MatrixOne DB and loopback DeepSeek fixture override"]
 async fn user_model_create_rotate_and_probe_enforce_provider_wire_contract() {
-    let settings = astra_core::MatrixOneSettings::from_env();
+    let settings = common::require_db_it_env();
     isolated_database::require_isolated_database(&settings.database);
+    assert!(
+        isolated_database::is_schema_rehearsal_database(&settings.database),
+        "schema rehearsal requires an astra_test_probe_* disposable database"
+    );
     assert_eq!(
         std::env::var("ASTRA_ALLOW_INSECURE_DEFAULTS").as_deref(),
         Ok("1")

--- a/crates/services/tests/user_model_probe_db_it.rs
+++ b/crates/services/tests/user_model_probe_db_it.rs
@@ -29,11 +29,16 @@ async fn user_model_create_rotate_and_probe_enforce_provider_wire_contract() {
     let url = reqwest::Url::parse(&base).unwrap();
     assert_eq!(url.scheme(), "http");
     assert_eq!(url.host_str(), Some("127.0.0.1"));
+    let fail_probe = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let app = Router::new()
         .route(
             "/chat/completions",
             post(
-                |headers: axum::http::HeaderMap, Json(body): Json<Value>| async move {
+                |axum::extract::State(fail): axum::extract::State<
+                    Arc<std::sync::atomic::AtomicBool>,
+                >,
+                 headers: axum::http::HeaderMap,
+                 Json(body): Json<Value>| async move {
                     // Each simulated upstream enforces its own documented
                     // field; do not reuse the serializer under test here.
                     let (limit, forbidden) = match body["model"].as_str() {
@@ -47,11 +52,32 @@ async fn user_model_create_rotate_and_probe_enforce_provider_wire_contract() {
                         StatusCode::UNAUTHORIZED
                     } else if body["model"] != "deepseek-chat" && body["model"] != "o3" {
                         StatusCode::NOT_FOUND
-                    } else if body[limit] != 32 || body.get(forbidden).is_some() {
+                    } else if (body[limit] != 32 && body[limit] != 1024)
+                        || body.get(forbidden).is_some()
+                    {
                         StatusCode::BAD_REQUEST
                     } else {
                         StatusCode::OK
                     };
+                    if status == StatusCode::OK && body[limit] == 1024 {
+                        if fail.load(std::sync::atomic::Ordering::SeqCst) {
+                            return (
+                                StatusCode::SERVICE_UNAVAILABLE,
+                                Json(json!({"error":"fixture failure"})),
+                            );
+                        }
+                        assert!(body.get("temperature").is_none());
+                        assert!(body.get("enable_thinking").is_none());
+                        assert!(body.get("reasoning_effort").is_none());
+                        let mut message = json!({"content":"391"});
+                        if body["thinking"]["type"] == "enabled" {
+                            message["reasoning_content"] = json!("multiplication");
+                        }
+                        return (
+                            status,
+                            Json(json!({"choices":[{"message":message,"finish_reason":"stop"}]})),
+                        );
+                    }
                     (
                         status,
                         Json(json!({"error":{"message":"strict fixture rejection"}})),
@@ -86,15 +112,16 @@ async fn user_model_create_rotate_and_probe_enforce_provider_wire_contract() {
                     )
                 },
             ),
-        );
+        )
+        .with_state(fail_probe.clone());
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", url.port().unwrap()))
         .await
         .unwrap();
     let fixture = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
     let (pool, settings) = common::setup_pool_and_settings().await;
     let encryptor = FernetTokenEncryptor::new("provider-wire-test-only-key").unwrap();
-    let service =
-        DatabaseModelService::new(settings, Arc::new(encryptor.clone())).with_pool(pool.clone());
+    let service = DatabaseModelService::new(settings.clone(), Arc::new(encryptor.clone()))
+        .with_pool(pool.clone());
     let owner = uuid::Uuid::new_v4().to_string();
     let make_request = |name: &str, model: &str, key: &str| UserModelCreateRequestData {
         name: name.into(),
@@ -130,6 +157,45 @@ async fn user_model_create_rotate_and_probe_enforce_provider_wire_contract() {
         )
         .await
         .unwrap();
+    // Simulate the pre-upgrade schema in this explicitly designated disposable
+    // database. Preserve a real old model row across two idempotent bootstraps.
+    let personal_rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM user_llm_models")
+        .fetch_one(pool.get())
+        .await
+        .unwrap();
+    let administrator_rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM infra_llm_models")
+        .fetch_one(pool.get())
+        .await
+        .unwrap();
+    assert_eq!(
+        personal_rows, 1,
+        "schema rehearsal requires only this test's model row"
+    );
+    assert_eq!(
+        administrator_rows, 0,
+        "schema rehearsal refuses existing administrator models"
+    );
+    for table in ["infra_llm_models", "user_llm_models"] {
+        sqlx::query(&format!(
+            "ALTER TABLE {table} DROP COLUMN thinking_probe_json"
+        ))
+        .execute(pool.get())
+        .await
+        .unwrap();
+    }
+    sqlx::query("UPDATE astra_schema_contracts SET contract_version = '2026-09-04-v70' WHERE component = 'astra-core'")
+        .execute(pool.get()).await.unwrap();
+    for _ in 0..2 {
+        astra_services::storage::ensure_core_schema(&settings, "mysql")
+            .await
+            .unwrap();
+    }
+    let migrated = service
+        .get_user_model(owner.clone(), created.model_id.clone())
+        .await
+        .unwrap();
+    assert_eq!(migrated.name, created.name);
+    assert!(migrated.thinking_probe.is_none());
     // Fixed official endpoints are not user-overridable. Seed their *test row*
     // with this loopback fixture to exercise the real rotate/probe service paths
     // without adding a production transport bypass or spending a live API key.
@@ -140,10 +206,55 @@ async fn user_model_create_rotate_and_probe_enforce_provider_wire_contract() {
     ] {
         sqlx::query("UPDATE user_llm_models SET provider = ?, model_name = ?, api_key_encrypted = ? WHERE user_id = ? AND model_id = ?")
             .bind(provider).bind(model).bind(encryptor.encrypt("valid-key").unwrap()).bind(&owner).bind(&created.model_id).execute(pool.get()).await.unwrap();
-        service
+        let checked = service
             .check_user_model(owner.clone(), created.model_id.clone())
             .await
             .unwrap();
+        if provider == "deepseek" {
+            assert_eq!(
+                checked.thinking_probe.as_ref().unwrap().capability,
+                astra_services::models::ThinkingCapability::Both
+            );
+            assert!(checked.thinking_probe.as_ref().unwrap().error.is_none());
+            let execution = astra_services::models::revalidate_admitted_model_execution(
+                &settings,
+                &encryptor,
+                &owner,
+                &created.model_id,
+                Some(pool.get()),
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                execution.thinking_capability,
+                Some(astra_services::models::ThinkingCapability::Both)
+            );
+            fail_probe.store(true, std::sync::atomic::Ordering::SeqCst);
+            let failed_check = service
+                .check_user_model(owner.clone(), created.model_id.clone())
+                .await
+                .unwrap();
+            let observation = failed_check.thinking_probe.unwrap();
+            assert_eq!(
+                observation.capability,
+                astra_services::models::ThinkingCapability::Both
+            );
+            assert!(observation.error.is_some());
+            let retained = astra_services::models::revalidate_admitted_model_execution(
+                &settings,
+                &encryptor,
+                &owner,
+                &created.model_id,
+                Some(pool.get()),
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                retained.thinking_capability,
+                Some(astra_services::models::ThinkingCapability::Both)
+            );
+            fail_probe.store(false, std::sync::atomic::Ordering::SeqCst);
+        }
         let before: String = sqlx::query_scalar(
             "SELECT api_key_encrypted FROM user_llm_models WHERE user_id = ? AND model_id = ?",
         )
@@ -193,11 +304,69 @@ async fn user_model_create_rotate_and_probe_enforce_provider_wire_contract() {
         .await
         .unwrap();
         assert_eq!(encryptor.decrypt(&after).unwrap(), "rotated-key");
+        assert!(
+            service
+                .get_user_model(owner.clone(), created.model_id.clone())
+                .await
+                .unwrap()
+                .thinking_probe
+                .is_none(),
+            "rotation must invalidate the previous observation"
+        );
         service
             .check_user_model(owner.clone(), created.model_id.clone())
             .await
             .unwrap();
     }
+    // Administrator legacy hints survive an inconclusive first check, and
+    // fresh successful observations survive a later transient probe failure.
+    use astra_services::models::{
+        ModelCreateRequestData, PricingData, QuirksData, ThinkingCapability,
+    };
+    service
+        .create_model(
+            owner.clone(),
+            ModelCreateRequestData {
+                name: "admin-fixture".into(),
+                provider: "deepseek".into(),
+                api_key: "valid-key".into(),
+                base_url: Some(base),
+                description: None,
+                context_window: Some(128000),
+                max_completion_tokens: None,
+                input_modalities: vec!["text".into()],
+                output_modalities: vec!["text".into()],
+                supported_parameters: vec![],
+                pricing: PricingData {
+                    prompt: 0.0,
+                    completion: 0.0,
+                    cache_read: None,
+                    cache_write: None,
+                },
+                architecture: None,
+                tags: vec![],
+                quirks: Some(QuirksData {
+                    wire_model_name: Some("deepseek-chat".into()),
+                    ..Default::default()
+                }),
+            },
+        )
+        .await
+        .unwrap();
+    sqlx::query("UPDATE infra_llm_models SET thinking_capability = 'native_only' WHERE model_name = 'admin-fixture'")
+        .execute(pool.get()).await.unwrap();
+    for (fail, expected) in [
+        (true, ThinkingCapability::NativeOnly),
+        (false, ThinkingCapability::Both),
+        (true, ThinkingCapability::Both),
+    ] {
+        fail_probe.store(fail, std::sync::atomic::Ordering::SeqCst);
+        let checked = service.check_model("admin-fixture".into()).await.unwrap();
+        let result = checked.thinking_probe.unwrap();
+        assert_eq!(result.capability, expected);
+        assert_eq!(result.error.is_some(), fail);
+    }
+    service.delete_model("admin-fixture".into()).await.unwrap();
     service
         .delete_user_model(owner, created.model_id)
         .await

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -33,7 +33,7 @@ These documents describe target contracts. They should not be read as proof that
 | Runtime tool boundary | [edge-runtime-tool-boundary.md](edge-runtime-tool-boundary.md) | Runtime authority domains, workspace isolation, side effects, and result containment. |
 | Cloud-edge sync | [../architecture/edge-cloud-sync-architecture.md](../architecture/edge-cloud-sync-architecture.md) | Durable outbox, sync facts, repair, retention. |
 | Orchestration | [orchestration.md](orchestration.md) | Multi-agent delegation, model selection per agent, coordination. |
-| Model access and inference | [model-access-and-inference.md](model-access-and-inference.md) | Cloud/Workspace/Device model access, TaaS bindings, Offerings, connections, inference placement, invocation, usage, and billing boundaries. |
+| Model access and inference | [model-access-and-inference.md](model-access-and-inference.md) | Cloud/Workspace/Device model access, TaaS bindings, Offerings, connections, provider request capabilities, parameter emission, inference placement, invocation, usage, and billing boundaries. |
 | Model routing | [model-routing.md](model-routing.md) | Model/provider selection, escalation, fallback chains, and traceability. |
 | Multi-agent runtime | [multi-agent-runtime.md](multi-agent-runtime.md) | Durable child runs, fanout/fanin, delegation lineage, and bounded parallelism. |
 | Memory | [memory.md](memory.md) | Cross-session and in-session memory semantics. |

--- a/docs/design/model-access-and-inference.md
+++ b/docs/design/model-access-and-inference.md
@@ -1,7 +1,7 @@
 # Model access and inference
 
 > Status: target design contract.
-> Last updated: 2026-09-06.
+> Last updated: 2026-09-09.
 
 Model access and inference defines how Astra presents model capability as a product, binds cloud accounts, resolves an eligible model to a trusted execution path, and records inference usage consistently across Web, CLI, Server, and Edge.
 
@@ -34,6 +34,9 @@ It does not own:
 - Web, CLI, Server Only, and Edge + Server expose the same model and run semantics.
 - Every inference has an immutable execution placement, credential owner, billing owner, policy decision, and durable identity.
 - Account, entitlement, credential, endpoint, and billing failures are visible and recoverable without corrupting run state.
+- Protocol compatibility and optional generation-parameter capability remain
+  separate facts; an OpenAI-compatible route is never assumed to accept every
+  OpenAI request field.
 - The design supports multi-tenant SaaS operation, hundreds of concurrent clients, and horizontal Server scaling.
 
 ## Non-goals
@@ -45,6 +48,7 @@ It does not own:
 - Silent fallback across billing or data boundaries.
 - Treating cached balance, health, or entitlement data as authoritative without freshness.
 - Preserving obsolete request shapes such as client-selected gateways or request-scoped inference URLs.
+- Hostname- or model-name-specific request shaping in runtime hot paths.
 
 ## Product contract
 
@@ -585,6 +589,7 @@ struct ResolvedInferenceRoute {
     billing_owner: BillingOwner,
     data_boundary: DataBoundary,
     purpose: InferencePurpose,
+    generation_policy: ResolvedGenerationPolicy,
     policy_version: PolicyVersion,
     fallback_policy: ResolvedFallbackPolicy,
 }
@@ -695,7 +700,6 @@ struct InferenceRequest {
     messages: Vec<CanonicalMessage>,
     tools: Vec<CanonicalToolSchema>,
     response_contract: ResponseContract,
-    thinking: ThinkingConfig,
     output_limit: u32,
     cache: CacheIntent,
     deadline: Timestamp,
@@ -713,6 +717,401 @@ enum InferenceStreamEvent {
 ```
 
 Provider adapters translate the canonical contract to OpenAI, Anthropic, Bedrock, local, or other supported protocols. Adapter differences do not leak into agent state-machine behavior.
+
+## Provider request capability contract
+
+### Problem and invariant
+
+An inference protocol describes the transport envelope. It does not prove that
+every optional field, value, or interaction accepted by one provider is
+accepted by another provider implementing the same envelope. In particular,
+`openai-compatible` does not by itself prove support for:
+
+- an explicit `temperature`, including `0.0`;
+- one provider's thinking-control field;
+- `stream_options` or usage-in-stream behavior;
+- a particular tool-choice representation;
+- one completion-token-limit field;
+- structured-output or system-role extensions.
+
+The invariant is:
+
+> Astra emits an optional provider field only when the resolved route proves
+> that the field/value is supported, or when the user or administrator has
+> supplied an explicit typed Offering capability. Unknown capability means
+> omission, not OpenAI-default behavior.
+
+This rule applies to primary, delegated, compaction, memory, reflection,
+verification, and introspection calls. Auxiliary paths must not create their
+own provider heuristics.
+
+### Resolved generation policy
+
+Model admission resolves the call-level generation behavior before provider
+payload construction:
+
+```rust
+struct ResolvedGenerationPolicy {
+    thinking: ResolvedThinkingPolicy,
+    temperature: TemperatureEmission,
+    provenance: GenerationPolicyProvenance,
+}
+
+enum ThinkingConfig {
+    Off,
+    Enabled { budget_tokens: u32 },
+    Adaptive { effort: ThinkingEffort },
+}
+
+struct ResolvedThinkingPolicy {
+    requested: ThinkingConfig,
+    emission: ThinkingEmission,
+    provenance: GenerationPolicyProvenance,
+}
+
+enum ThinkingEmission {
+    // Emit no control field and allow the endpoint to select its default.
+    ProviderDefault,
+    // Emit the adapter's typed disable control.
+    Disabled,
+    // Emit the adapter's typed enable/effort/budget control.
+    Enabled {
+        effort: Option<ThinkingEffort>,
+        budget_tokens: Option<u32>,
+    },
+}
+
+enum TemperatureEmission {
+    // The final payload must not contain temperature; use endpoint default.
+    ProviderDefault,
+    // The final payload must not contain temperature because the selected
+    // thinking/provider protocol rejects it.
+    Forbidden,
+    Explicit(f64),
+}
+
+enum GenerationPolicyProvenance {
+    OfferingCapability,
+    CanonicalProviderContract,
+    ConservativeProtocolDefault,
+}
+```
+
+`ThinkingConfig` is the requested product behavior. `ResolvedThinkingPolicy`
+is the admitted wire behavior. `ProviderDefault` is not equivalent to
+`ThinkingConfig::Off`: it makes no claim that provider-side reasoning is
+disabled. `Disabled` is legal only when a typed adapter capability can encode
+the disable control; otherwise the resolver must choose `ProviderDefault` or
+reject a request that strictly requires disabled reasoning.
+
+`TemperatureEmission` is deliberately a final wire decision, not a guessed
+model attribute. Both `ProviderDefault` and `Forbidden` assert that the field
+is absent after all overrides; they differ so trace and replay can distinguish
+endpoint-default behavior from a protocol prohibition. Its non-secret value
+and provenance are persisted with the resolved route and provider attempt.
+
+`ResolvedInferenceRoute.generation_policy` is the single owner. An
+`InferenceRequest` carries the route and does not duplicate the policy.
+Provider payload builders read only `request.route.generation_policy`.
+
+Resolution uses the following precedence:
+
+1. Resolve requested `ThinkingConfig` against the admitted thinking
+   capability. An unclassified OpenAI-compatible route uses
+   `ThinkingEmission::ProviderDefault`; it must not pretend that thinking is
+   disabled.
+2. A selected thinking protocol that forbids temperature resolves to
+   `TemperatureEmission::Forbidden`.
+3. A validated per-Offering temperature capability for the selected thinking
+   mode resolves to `Explicit(value)`, `ProviderDefault`, or `Forbidden`.
+4. A canonical provider/model contract may resolve bounded low-variance
+   introspection to `Explicit(0.0)` only when that exact contract is maintained
+   and tested by Astra.
+5. An unclassified OpenAI-compatible route resolves to `ProviderDefault`.
+6. All non-introspection purposes retain their existing product policy; they
+   do not inherit the auxiliary classifier's low-variance preference.
+
+Contradictory capabilities fail model admission before provider I/O. Provider
+payload assembly consumes this resolved value after applying provider-specific
+thinking rules.
+
+Before resolution, a numeric legacy `request_body_overrides.temperature` is
+validated, normalized into an Offering-scoped `Explicit(value)` capability,
+and removed from the generic override map. An invalid value fails admission.
+After that extraction, `temperature` is runtime-owned: generic overrides cannot
+reintroduce it, and the final payload must exactly match
+`TemperatureEmission`. This preserves the administrator's existing explicit
+temperature control while removing the current behavior where an
+introspection-level `0.0` silently overwrites it.
+
+Mode-dependent models require a mode-dependent capability shape:
+
+```rust
+struct TemperatureCapabilities {
+    provider_default: TemperatureConstraint,
+    thinking_disabled: Option<TemperatureConstraint>,
+    thinking_enabled: Option<TemperatureConstraint>,
+}
+
+enum TemperatureConstraint {
+    ProviderDefault,
+    Forbidden,
+    Fixed(f64),
+    ExplicitZeroSupported,
+}
+```
+
+The existing scalar `QuirksData.fixed_temperature` is a backward-compatible
+declaration for a temperature that is fixed across every admitted mode of that
+Offering. It cannot describe a model whose fixed value changes with thinking
+mode. Such a model uses `ProviderDefault` in the first implementation stage;
+a later typed `TemperatureCapabilities` declaration may select the exact value
+per mode without a new runtime heuristic.
+
+### Persisted thinking protocol (stage 2)
+
+OpenAI-chat probes and Server inference share `astra_core::model_wire::thinking`.
+`QuirksData.thinking_protocol` is an optional administrator declaration with
+`unknown`, `enable_thinking`, `thinking_object`, `reasoning_effort`, or
+`moonshot` values. Absence selects the maintained canonical adapter; explicit
+`unknown` opts out of the new adapter, retaining established request assembly
+and explicit overrides. Endpoint authority and upstream model, not a local alias or
+an arbitrary URL substring, select the Moonshot adapter. It covers the official
+`/v1` endpoints and the maintained `kimi-k2.5`, `kimi-k2.6`, and
+`kimi-k3` IDs. K2.5/K2.6 follow the
+[official toggle documentation](https://platform.kimi.com/docs/guide/kimi-k2-6-quickstart);
+K3 is covered by the optional real-provider toggle contract. Other model IDs or
+gateways remain unknown unless explicitly configured. This is a maintained
+adapter registry, not a Work-admission-specific model matcher.
+
+The protocol reaches admitted execution, normal streaming/nonstreaming calls,
+memory inference, and bounded summaries. Final OpenAI-chat emission removes
+controls belonging to other protocols after generic body overrides when a
+protocol is known. Unknown adds and removes nothing: existing thinking-off
+sanitization and provider behavior remain authoritative. Anthropic Messages and Bedrock retain
+their existing native envelope adapters; this stage does not redefine those
+providers' probing semantics or authorize Runner introspection.
+
+Moonshot introspection defaults sampling to the provider rather than injecting
+the classifier's zero temperature. The toggle adapter does not impose sampling
+limits or remove explicit temperature, top_p or penalty settings. A verified
+toggle is not evidence of a fixed-temperature contract for every model version.
+The mode-independent Offering `fixed_temperature` uses the same configuration
+resolver in main and auxiliary requests; conflicting explicit overrides are
+reported. Existing native adapter restrictions remain authoritative. Generic
+OpenAI-compatible routes retain their pre-existing effort and override behavior;
+Cloud BYOK does not require a protocol configuration UI to keep working.
+
+Explicit model checks perform the probe; model creation and normal inference do
+not. A supported binary protocol is tested in both enabled and disabled modes
+with a bounded 1024-token request. Both responses must have completed visible
+content; the enabled response must expose reasoning and the disabled response
+must not. This establishes observed toggle behavior, not proof of zero internal
+reasoning tokens. Truncated/malformed output, ignored controls, transport errors,
+or unknown protocols cannot become a successful `both` observation. Unknown
+protocols use a baseline request without guessed controls and can establish only
+observed native reasoning (`native_only`), not suppression support. Declared
+effort protocols send low effort and require observable reasoning (including
+reported reasoning token usage) before reporting `effort_only`. This confirms
+reasoning under the declared protocol, not a measurement of effort effectiveness.
+BYOK probing retains the
+same pinned public-endpoint transport and owner authorization as inference.
+
+Both `infra_llm_models` and `user_llm_models` have nullable
+`thinking_probe_json` observations containing adapter revision, configuration
+fingerprint, protocol, capability/error, and observation time. The fingerprint
+binds provider, endpoint, upstream model, encrypted credential generation and
+administrator configuration. It contains no plaintext credential. Results are
+published using configuration- and previous-observation-matching conditional updates, so a concurrent
+rotation cannot publish a result for the replacement configuration. Resolution
+reuses only matching observations, without network probing; explicit checks
+refresh them. Credential/configuration changes invalidate observations. Old
+rows remain usable, and schema migration never makes provider requests. Legacy
+administrator capability values are imported as explicitly marked legacy hints
+when the first new check is inconclusive, not evidence of a verified wire protocol.
+A failed/inconclusive check retains a prior capability only for the same bound
+configuration and protocol while recording the latest error separately. Stale
+or malformed snapshots never fall back to an unbound legacy capability column.
+
+User model responses optionally include `thinking_probe`; a missing or stale
+observation is absent, while an inconclusive check has an error. A thinking
+probe failure does not disable a model whose connectivity check succeeded.
+
+`ASTRA_INTROSPECTION_TOTAL_BUDGET_S` defaults to 8 seconds, capped by the global
+LLM budget, for no-tool introspection provider execution. It uses the existing
+provider-attempt deadline/settlement owner, not an outer cancelling timeout.
+Primary and other purposes retain their budgets. This is **not** an eight-second
+end-to-end TTFT guarantee: pre-provider durable admission and post-provider
+logical settlement have their own lifecycle costs. Existing auxiliary failure
+handling remains responsible for degraded Work admission.
+The default is a latency policy, not a provider-success guarantee: K3 samples
+have exceeded the approximately 7.2-second provider work allowance. Rollout must
+measure Work-admission success/degradation rate and end-to-end TTFT together;
+compatibility tests with a larger budget do not establish the default-budget SLO.
+
+### Immediate compatibility decision
+
+The first implementation stage applies to Server-executed Cloud BYOK and
+changes only bounded introspection request construction:
+
+| Route | Introspection temperature behavior |
+| --- | --- |
+| Exact canonical provider/model Offering with a tested zero-temperature contract | Send `0.0` only when the resolved thinking policy permits it. |
+| Offering with a validated mode-independent `fixed_temperature` | Send the configured value. |
+| Offering with an explicit numeric legacy `request_body_overrides.temperature` | Normalize it to `Explicit(value)` and preserve that value unless thinking forbids temperature. |
+| Generic `openai-compatible` route without an explicit capability | Use provider default: remove `temperature` from the final payload. |
+| Route whose enabled thinking protocol forbids temperature | Use `Forbidden`: remove `temperature` from the final payload. |
+| Primary agent and other inference purposes | Preserve their existing policy. |
+
+The immediate Cloud BYOK fix requires no new user setting, public API field, or
+database migration. Existing `openai-compatible` rows acquire the conservative
+behavior on Server upgrade. The CLI continues to ask only for provider, base
+URL, upstream model ID, alias, context window, default selection, and key.
+
+For an unclassified OpenAI-compatible route, stage 1 also resolves thinking to
+`ThinkingEmission::ProviderDefault`. It guarantees that Astra does not send the
+known-invalid zero-temperature combination; it does **not** guarantee that
+provider-side thinking is disabled or that latency decreases. A provider may
+still return malformed or empty classifier output, which remains a separate
+semantic failure class. The originating issue is complete only after a strict
+Kimi-like contract test and a hosted Kimi end-to-end check both produce a
+parsed Work-admission decision, or after Astra rejects that auxiliary purpose
+before provider I/O with an explicit typed policy.
+
+The target implementation uses one shared resolver for every execution
+placement that authorizes the purpose. It must not introduce a matcher for
+`api.moonshot.cn`, `kimi-*`, or any other new hostname/model string. Existing
+Offering metadata such as `fixed_temperature` may feed the typed resolver, but
+it must be carried through the canonical admitted route rather than read
+directly inside a provider adapter.
+
+The initial implementation follows the existing execution-material path:
+
+```text
+Offering/provider capability
+  -> ResolvedActiveLlmModel
+  -> AdmittedModelExecution
+  -> ResolvedTurnLlmConfig
+  -> OwnedLlmExecutionRoute
+  -> RuntimeSummaryClient
+  -> provider payload reconciliation
+```
+
+The stage-1 policy resolver is a pure function at the Server summary-call
+boundary. `RuntimeSummaryClient` supplies the inference purpose and desired
+thinking mode; the route supplies admitted capabilities. Its result shape is
+kept independent of Server state so it can move to the shared model-call
+boundary before another execution placement authorizes `Introspection`. The
+provider payload builder remains the final enforcement point and removes
+temperature whenever the resolved thinking protocol forbids it.
+
+The current `openai_thinking_control(provider, base_url)` helper is a
+grandfathered transition mechanism, not a second product-policy owner. During
+stage 1 the Server summary resolver may consult it to select the bounded
+thinking policy, while final payload assembly invokes the same helper only to
+serialize an admitted `Off` policy into the maintained DeepSeek or DashScope
+wire control. Contract tests must keep those two uses consistent. No Kimi,
+Moonshot, new hostname, or model-name branch is added. In the target state,
+the helper's facts belong to the admitted Offering/connection and payload
+assembly consumes the resolved typed control without inspecting endpoint text.
+The non-goal on hostname/model matching applies to this target state and
+prohibits adding new runtime matchers during the transition.
+
+User Runner authorization is a separate gate. PR #712 currently allows only
+`PrimaryAgent`, `SubAgent`, and `RequiredCompaction`; it rejects
+`Introspection` before provider I/O even though its proposed summary client
+uses no temperature. Stage 1 therefore fixes Server Cloud BYOK only. It must
+not add a vacuous Server/Runner parity test. If Runner later authorizes
+`Introspection`, that authorization change requires its own design and tests
+and must consume this same resolver before Work admission is enabled.
+
+### Rejected alternatives
+
+- **Match Kimi, Moonshot, or a hostname.** The same model may be exposed by a
+  gateway or proxy, and another model can have the same constraint.
+- **Treat every OpenAI-compatible endpoint as OpenAI.** This is the faulty
+  assumption the contract removes.
+- **Ask every Cloud BYOK user for temperature/thinking internals.** Safe default
+  behavior must not require provider expertise; advanced capability declaration
+  can remain an administrator or future probe concern.
+- **Retry a 400 after deleting optional fields.** A generic 400 does not identify
+  the incompatible field, and retry can add latency and bill twice.
+- **Omit temperature for all providers and purposes.** That is safe at the wire
+  level but unnecessarily changes maintained canonical-provider behavior and
+  established low-variance classifier behavior where an exact contract is
+  known.
+- **Implement a separate Work-admission HTTP client.** It would duplicate route,
+  credential, usage, error, and policy semantics instead of fixing the shared
+  inference boundary.
+
+### Auxiliary inference and latency
+
+Work admission is a bounded introspection call. It starts concurrently with the
+primary model request and settles before a plain-text completion or provider
+tool batch crosses its execution boundary. Therefore its latency is not added
+unconditionally to primary latency; the pre-output critical path is:
+
+```text
+request preparation
+  + max(primary provider path, Work-admission provider path)
+  + required reconciliation and client delivery
+```
+
+If Work admission finishes first, the primary path determines the remaining
+time. If the primary response finishes first, the remaining Work-admission
+deadline can delay the first executable completion boundary. Provider cache
+hits, endpoint load, network variance, and scheduler delay can change the
+winner between otherwise identical turns.
+
+The compatibility fix must not add a second provider attempt after a generic
+HTTP 400. Retrying after stripping fields would increase latency and may double
+billing without proving which field was rejected. Astra instead sends the
+conservative payload on the first attempt. An unavailable optional judge keeps
+the existing typed Primary degradation; a required primary inference does not
+silently switch Offering, credential owner, billing owner, or data boundary.
+
+Latency optimization after correctness requires phase telemetry, not inference
+from end-to-end TTFT. Every primary and auxiliary attempt records:
+
+- queue/admission, provider-request-start, provider-first-byte, and completion
+  timestamps;
+- resolved temperature emission and provenance, without request-body or secret
+  values;
+- cache read/write token facts when the provider reports them;
+- Work-admission reconciliation wait after the primary result;
+- first durable output and first client-delivery timestamps;
+- typed failure class and whether semantic Primary degradation occurred.
+
+### Compatibility and rollout
+
+- Existing Cloud BYOK rows remain readable and require no backfill.
+- Existing canonical provider behavior remains unchanged unless its adapter no
+  longer has a tested zero-temperature contract.
+- Unknown and custom OpenAI-compatible endpoints become less prescriptive;
+  omission lets the endpoint apply its own valid default.
+- A numeric `request_body_overrides.temperature` is an intentional typed
+  declaration after admission. Today bounded introspection silently replaces
+  that value with `0.0`; after this change the declared value remains
+  authoritative unless the selected thinking protocol forbids temperature.
+  This is a deliberate user-visible correction, not a no-op refactor.
+- The scalar `fixed_temperature` field keeps its persisted shape and requires
+  no backfill, but stage 1 treats it as mode-independent. A model whose fixed
+  temperature varies with thinking mode stays on `ProviderDefault` until a
+  richer typed capability is admitted.
+- No provider response body is exposed merely to diagnose compatibility; raw
+  non-authentication 4xx bodies remain protected by the existing secret
+  reflection boundary.
+- The change is rolled back by restoring the previous Server binary; no stored
+  state must be reverted.
+- A later richer capability probe or user-visible advanced setting is a
+  separate contract change. It must not be required to make default Cloud BYOK
+  safe.
+
+Rollout observes per-purpose provider 400 rates, Work-admission availability,
+TTFT, provider-first-byte latency, and reconciliation wait. A rise in malformed
+judge responses is evaluated separately from transport compatibility: omitting
+temperature may change sampling, but it must not be treated as a transport
+failure.
 
 ## Client and SDK contract
 
@@ -906,6 +1305,8 @@ not satisfy these gates.
 | Entitlement revoked | Reject new inference and return eligible alternatives. |
 | Credential receives 401 | Refresh or request reauthorization for that binding; do not disable the global model identity. |
 | Provider returns 429/overload | Use bounded exponential backoff with jitter within deadline and budget. |
+| Optional field capability is unknown | Resolve it to the typed provider-default policy and enforce absence from the final payload; do not infer support from protocol compatibility. |
+| Auxiliary provider request is rejected as incompatible | Record typed degradation and preserve the Primary path; do not retry by stripping guessed fields. |
 | Provider delivery is uncertain | Enter `DeliveryUnknown`; reconcile when possible; do not blind retry. |
 | Edge offline before start | Mark Offering offline and offer wait, choose model, or cancel. |
 | Edge disconnects during stream | Preserve durable partial state and query by invocation ID after reconnect. |
@@ -966,6 +1367,8 @@ Inference spans and durable facts include non-secret identifiers for:
 - execution placement and billing owner;
 - policy and relevant revisions;
 - admitted, queued, first-token, and complete latency;
+- resolved generation-parameter emission/provenance and post-primary
+  reconciliation wait;
 - token usage, cache status, retry count, and typed outcome.
 
 Metrics include resolution latency/errors, active/queued inference, provider 401/429/5xx, TaaS link/billing/credential health, Edge disconnect/recovery, per-purpose usage, fallback, and optional-inference degradation.
@@ -1011,6 +1414,30 @@ Tests validate behavior, persisted facts, wire payloads, streams, and product pr
 ### Provider and Edge end-to-end
 
 - Canonical message/tool/thinking payload and stream translation.
+- Generic OpenAI-compatible introspection omits unproven optional sampling
+  fields on its first and only attempt.
+- Strict mock endpoints that reject `temperature: 0.0` accept the conservative
+  Work-admission payload and return a parsed structured decision.
+- A Kimi-like default-thinking mock rejects `temperature: 0.0`, accepts the
+  provider-default request, returns separate reasoning plus structured final
+  content within the classifier token cap, and produces a parsed Work decision.
+- A numeric legacy `request_body_overrides.temperature` is normalized to a
+  typed `Explicit(value)` capability and is not silently replaced with `0.0`;
+  invalid values fail admission, while `ProviderDefault` and `Forbidden`
+  remove the field from the final payload.
+- Canonical OpenAI, Anthropic, and DeepSeek adapter fixtures preserve their
+  tested request behavior; primary, compaction, memory, and reflection calls do
+  not inherit the introspection-only temperature rule.
+- Server Cloud BYOK resolves generation policy from the admitted route without
+  adding a Kimi, Moonshot, hostname, or model-name matcher.
+- Until User Runner authorizes `Introspection`, it returns a typed error before
+  provider I/O. If that purpose is authorized later, its contract test must
+  prove that it consumes the shared resolver rather than a Runner-local policy.
+- An opt-in hosted Kimi check, kept outside required CI because it needs a real
+  credential, produces a parsed Work-admission decision. Failure keeps the
+  originating compatibility issue open even if the strict mock passes.
+- Incompatible auxiliary inference records typed Primary degradation without
+  leaking provider response bodies or creating a second billed attempt.
 - Cancellation, deadline, context overflow, and typed provider error.
 - Edge secret never reaches Server storage or logs.
 - Offline-before-start, mid-stream disconnect, completion-ack loss, and reconnect.
@@ -1045,6 +1472,8 @@ Cover Web, CLI + Server, Server Only, and Edge + Server:
   device; Cloud BYOK credentials are explicitly uploaded and encrypted on
   Astra Server.
 - All inference purposes use one resolver and invocation contract.
+- OpenAI-compatible protocol selection alone never authorizes an optional
+  provider request field or value.
 - Every upstream request is attributable to a durable provider attempt.
 - No client can select an endpoint, credential, or placement directly.
 - Refresh, reconnect, process crash, credential rotation, and Server failover preserve truthful run state.

--- a/docs/design/model-access-and-inference.md
+++ b/docs/design/model-access-and-inference.md
@@ -1,7 +1,40 @@
 # Model access and inference
 
 > Status: target design contract.
-> Last updated: 2026-09-09.
+> Last updated: 2026-09-10.
+
+## Implemented scope: generation-policy stages 1 and 2
+
+The full route/admission design below is a target, not a claim that every type
+and invariant is implemented by these stages.
+
+- Implemented: conservative Server summary temperature resolution, endpoint-bound
+  canonical defaults, propagation of fixed temperature and thinking protocol to
+  main/auxiliary execution, configuration-bound persisted thinking observations,
+  and a bounded introspection budget. Unknown/custom endpoints (regardless of
+  their provider label), custom completion URLs and Bedrock gateways use the
+  provider default unless an explicit temperature is configured.
+- Implemented: numeric override validation at summary resolution and the main
+  streaming/nonstreaming entrypoints. The main call's explicit temperature still
+  takes precedence over a route override unless fixed_temperature is declared.
+- Not implemented: removing temperature from the generic override map at model
+  admission, making it runtime-owned in all routes, or replacing all request
+  types with the target ResolvedGenerationPolicy below. Overrides are still
+  merged and reconciled by the existing payload builder. Admission-time rejection
+  and one universal generation-policy owner remain target work.
+- Stage 2 adds typed maintained endpoint/model thinking contracts and administrator
+  declarations. Stage-1-only statements about adding no new provider matchers do
+  not describe the complete stage-2 adapter set. User Runner purpose authorization
+  is unchanged; these changes do not enable Runner Work admission.
+
+Thinking checks use a 30-second total budget, including client setup and both
+legs, with at most 15 seconds per HTTP request and a 1 MiB response limit.
+The separate connectivity check can add its own time; 30 seconds is not an
+end-to-end model-check API deadline. EnableThinking probes use streamed SSE in
+both legs to cover streaming-only deployments. Missing finish metadata is
+accepted with valid output; truncation cannot prove absence of reasoning.
+Connection/DNS/TLS, timeout, body and HTTP failures remain distinguishable
+without exposing upstream response bodies or credentials.
 
 Model access and inference defines how Astra presents model capability as a product, binds cloud accounts, resolves an eligible model to a trusted execution path, and records inference usage consistently across Web, CLI, Server, and Edge.
 
@@ -1084,10 +1117,28 @@ from end-to-end TTFT. Every primary and auxiliary attempt records:
 
 ### Compatibility and rollout
 
+- Historical administrator `quirks.fixed_temperature` values were previously
+  persisted without affecting inference. They now become active for primary and
+  auxiliary requests, take precedence over a call-level temperature, and reject
+  conflicting route overrides. This can change sampling or cause a local
+  configuration error after upgrade; it is not a behavior-neutral migration.
+  Before rollout, audit configured values without printing credentials:
+
+  ```sql
+  SELECT model_id, model_name, JSON_EXTRACT(quirks, '$.fixed_temperature') AS fixed_temperature
+  FROM infra_llm_models
+  WHERE JSON_EXTRACT(quirks, '$.fixed_temperature') IS NOT NULL;
+  ```
+
+  Review non-null values and their compatibility with every enabled thinking
+  mode. Change unintended values through the existing administrator model API;
+  schema migration must not silently delete or rewrite them.
 - Existing Cloud BYOK rows remain readable and require no backfill.
 - Existing canonical provider behavior remains unchanged unless its adapter no
   longer has a tested zero-temperature contract.
-- Unknown and custom OpenAI-compatible endpoints become less prescriptive;
+- All routes without a maintained endpoint-bound zero-temperature contract or
+  explicit temperature become less prescriptive, not just routes literally
+  labelled `openai-compatible` (e.g. DashScope, OpenRouter and custom gateways);
   omission lets the endpoint apply its own valid default.
 - A numeric `request_body_overrides.temperature` is an intentional typed
   declaration after admission. Today bounded introspection silently replaces

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -85,6 +85,10 @@ CARGO_INCREMENTAL=0 cargo test --locked -p astra-services \
 This covers create, credential rotation, explicit probe and failed-write
 preservation. Official OpenAI/Anthropic probe and rotation tests seed only their
 fixture rows with loopback endpoints; production official endpoints remain fixed.
+The same fixture also removes the new thinking observation columns in its
+designated disposable database, reruns schema bootstrap twice, and verifies
+that the old model row survives and credential rotation invalidates observations.
+Never designate a database containing non-test data for this fixture.
 `memoria_reauthentication_http` separately covers same-key reconnect, pending
 proof invalidation and an in-flight verification crossing disconnect/reconnect.
 
@@ -108,6 +112,40 @@ Optionally set **`ASTRA_AUTO_CREATE_DATABASE=1`** so the first
 EXISTS` for that effective name (bootstrap catalog defaults to `mysql`).
 
 ## Recommended Workflow
+
+### Optional thinking-protocol compatibility checks
+
+Offline checks require no credentials:
+
+```bash
+CARGO_INCREMENTAL=0 cargo test -p astra-core --lib model_wire::
+CARGO_INCREMENTAL=0 cargo test -p astra-services --lib models::
+CARGO_INCREMENTAL=0 cargo test -p astra-runtime --lib turn::llm::
+```
+
+Explicit real-provider checks accept a private configuration file whose last
+three nonempty lines are endpoint URL, API key, and upstream model ID. Do not
+commit that file or print its contents. Each check makes paid provider calls:
+
+```bash
+ASTRA_TEST_SUMMARY_CONFIG_FILE=/absolute/path/to/private-config \
+ASTRA_TEST_SUMMARY_MODEL=kimi-k2.6 \
+CARGO_INCREMENTAL=0 cargo test -p astra-services --lib \
+  live_thinking_protocol_probe -- --ignored --nocapture
+
+ASTRA_TEST_SUMMARY_CONFIG_FILE=/absolute/path/to/private-config \
+ASTRA_TEST_SUMMARY_MODEL=kimi-k2.6 \
+CARGO_INCREMENTAL=0 cargo test -p astra-runtime --lib \
+  live_work_admission_provider_contract -- --ignored --nocapture
+```
+
+Repeat for `kimi-k3`. The first check verifies observable enabled/disabled
+behavior; the second uses the actual streaming summary transport and Work
+decision parser with a test persistence implementation, without starting an
+Astra Server. Its elapsed time is invocation duration, not user-visible TTFT.
+Neither replaces the MatrixOne-backed persistence fixture above. Configure
+`ASTRA_BYOK_DNS_SERVERS` only when required by the local network; do not disable
+the BYOK public-endpoint policy to run these checks.
 
 ```bash
 # 1. Smallest relevant target while iterating

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -75,7 +75,7 @@ port for the fixture:
 
 ```bash
 ASTRA_TEST_DB_IT=1 ASTRA_DATABASE_PREFIX= \
-ASTRA_DATABASE=astra_probe_test ASTRA_TEST_DATABASE=astra_probe_test \
+ASTRA_DATABASE=astra_test_probe_local ASTRA_TEST_DATABASE=astra_test_probe_local \
 ASTRA_ALLOW_INSECURE_DEFAULTS=1 \
 ASTRA_BYOK_DEEPSEEK_BASE_URL=http://127.0.0.1:18994 \
 CARGO_INCREMENTAL=0 cargo test --locked -p astra-services \
@@ -89,6 +89,9 @@ The same fixture also removes the new thinking observation columns in its
 designated disposable database, reruns schema bootstrap twice, and verifies
 that the old model row survives and credential rotation invalidates observations.
 Never designate a database containing non-test data for this fixture.
+Destructive schema rehearsals require an effective database name beginning with
+`astra_test_probe_` and a nonempty suffix, checked before bootstrap or writes.
+This prefix is a guardrail, not permission to reuse a database containing data.
 `memoria_reauthentication_http` separately covers same-key reconnect, pending
 proof invalidation and an in-flight verification crossing disconnect/reconnect.
 
@@ -130,14 +133,18 @@ commit that file or print its contents. Each check makes paid provider calls:
 ```bash
 ASTRA_TEST_SUMMARY_CONFIG_FILE=/absolute/path/to/private-config \
 ASTRA_TEST_SUMMARY_MODEL=kimi-k2.6 \
-CARGO_INCREMENTAL=0 cargo test -p astra-services --lib \
+CARGO_INCREMENTAL=0 cargo test -p astra-services --features live-provider-tests --lib \
   live_thinking_protocol_probe -- --ignored --nocapture
 
 ASTRA_TEST_SUMMARY_CONFIG_FILE=/absolute/path/to/private-config \
 ASTRA_TEST_SUMMARY_MODEL=kimi-k2.6 \
-CARGO_INCREMENTAL=0 cargo test -p astra-runtime --lib \
+CARGO_INCREMENTAL=0 cargo test -p astra-runtime --features live-provider-tests --lib \
   live_work_admission_provider_contract -- --ignored --nocapture
 ```
+
+Both paid checks require `live-provider-tests` and `--ignored`; default
+MatrixOne CI can run ignored tests without a paid key. Do not enable this
+feature in the generic online lane.
 
 Repeat for `kimi-k3`. The first check verifies observable enabled/disabled
 behavior; the second uses the actual streaming summary transport and Work

--- a/scripts/dev/test_edge_process_contract.sh
+++ b/scripts/dev/test_edge_process_contract.sh
@@ -19,7 +19,16 @@ trap cleanup EXIT
 trap 'exit 1' HUP INT TERM
 
 mkdir -p "${fixture_root}/target/debug"
+mkdir -p "${fixture_root}/scripts/dev"
+# Exercise the real scripts in an isolated checkout, without sourcing the
+# developer's .env or allowing its PID/lock settings to affect the test.
+cp "${script_dir}/edge-process.sh" "${script_dir}/stop-edge.sh" "${fixture_root}/scripts/dev/"
 cp /bin/sleep "${fixture_root}/target/debug/astra-edge"
+# macOS may reject a relocated platform binary with SIGKILL. Ad-hoc sign
+# only the disposable fixture; do not change /bin/sleep or host security policy.
+if [ "$(uname -s)" = "Darwin" ]; then
+    codesign --force --sign - "${fixture_root}/target/debug/astra-edge"
+fi
 "${fixture_root}/target/debug/astra-edge" 30 &
 owned_pid=$!
 /bin/sleep 30 &
@@ -38,7 +47,7 @@ fi
 printf '%s\n' "$unrelated_pid" > "${fixture_root}/unrelated.pid"
 ASTRA_EDGE_PID_FILE="${fixture_root}/unrelated.pid" \
 ASTRA_EDGE_LOCK_DIR="${fixture_root}/edge.lock" \
-    "${script_dir}/stop-edge.sh" >/dev/null
+    "${fixture_root}/scripts/dev/stop-edge.sh" >/dev/null
 if ! kill -0 "$unrelated_pid" 2>/dev/null; then
     echo "stop-edge terminated a process not owned by this checkout" >&2
     exit 1

--- a/scripts/dev/test_edge_process_contract.sh
+++ b/scripts/dev/test_edge_process_contract.sh
@@ -27,6 +27,10 @@ cp /bin/sleep "${fixture_root}/target/debug/astra-edge"
 # macOS may reject a relocated platform binary with SIGKILL. Ad-hoc sign
 # only the disposable fixture; do not change /bin/sleep or host security policy.
 if [ "$(uname -s)" = "Darwin" ]; then
+    if ! command -v codesign >/dev/null 2>&1; then
+        echo "macOS edge-process fixture requires codesign (Command Line Tools)" >&2
+        exit 1
+    fi
     codesign --force --sign - "${fixture_root}/target/debug/astra-edge"
 fi
 "${fixture_root}/target/debug/astra-edge" 30 &


### PR DESCRIPTION
## Summary

- Stop forcing zero temperature on unclassified OpenAI-compatible Work-admission requests; carry explicit fixed-temperature and thinking protocol declarations through admitted main, auxiliary, memory, streaming and nonstreaming execution.
- Share typed thinking wire controls and persist configuration-bound capability observations. Preserve legacy/custom controls for unknown protocols and retain matching previous knowledge when probes are inconclusive.
- Bound introspection latency and preserve typed Primary fallback without claiming a fixed end-to-end TTFT.
- Document the policy, rollout, migration and optional real-provider checks. Repair the macOS edge-process test fixture's signing and isolation from developer .env configuration.

## Related issue

Closes #741

## Change type

- [x] Bug fix
- [x] Documentation
- [x] Refactor or performance improvement
- [x] Test
- [x] Build, CI, or maintenance
- [ ] Feature

## User and compatibility impact

- Generic compatible endpoints no longer receive an assumed temperature of zero for introspection. Explicit route overrides remain usable unless they conflict with a known authoritative constraint.
- Protocol declarations reach primary inference as well as auxiliary calls. Moonshot controls thinking without silently deleting sampling overrides or enforcing hard-coded model-specific temperature values.
- Native-only, effort-only and binary thinking capability checks remain distinct. Persisted observations are tied to configuration/credential identity and probe revision; stale observations are not reused.
- Add nullable thinking_probe_json columns to infra_llm_models and user_llm_models through the existing schema bootstrap (contract v71). Existing rows remain usable; migrations do not invoke providers.
- The default 8-second introspection budget is a latency cap, not a guarantee of admission success or total chat latency. Slow/incompatible providers may still use the existing Primary fallback.
- This does not expand User Runner's authorized inference purposes.

## Architecture and complexity delta

- Canonical owner changed or extended: shared core model-wire thinking protocol, services model resolution/probe persistence, admitted execution routes, and RuntimeSummaryClient.
- Existing implementations and callers searched: thinking_config provider adapters, request override reconciliation, admin and BYOK resolution, main server loop, summaries, memory inference and Runner routes.
- Superseded code, states, tables, shims, or self-only tests removed: unconditional generic introspection zero-temperature assumption; duplicate/manual main-route construction that dropped declarations.
- If parallel implementations remain, their boundary and retirement condition: canonical provider adapters remain supported compatibility contracts; shared typed controls consume declarations without creating a second lifecycle or execution authority. Unknown protocols preserve established request controls.

## Verification

- Commands and results (after syncing official main at bb01c8180):
  - cargo check --workspace --all-targets: passed.
  - cargo fmt --all -- --check and git diff --check: passed.
  - cargo clippy -p astra-core -p astra-services -p astra-turn-core -p astra-tools -p astra-runtime --lib --tests -- -D warnings: passed.
  - Targeted tests used the same package selection for each filter:
    CARGO_INCREMENTAL=0 cargo test -p astra-runtime -p astra-services -p astra-core -p astra-turn-core -p astra-tools --lib <filter> --no-fail-fast
    - turn::llm::: 401 passed, 1 ignored.
    - models::: 127 passed, 1 ignored (122 services + 5 runtime).
    - thinking_config::: 56 passed.
    - model_wire::: 6 passed.
    - workspace_observation::: 59 passed (with -- --test-threads=1).
    - Total: 649 passed, 2 optional live-provider tests ignored.
  - python3 scripts/ci/validate_repository.py: passed.
  - python3 -m unittest discover -s scripts/ci -p test_release_build_shells.py: 17 passed.
  - bash scripts/dev/test_edge_process_contract.sh: passed.
- Public entrypoint exercised: production request-building and streaming summary/Work-decision parsing paths under deterministic provider fixtures, plus model create/rotation/probe service operations. A hosted CLI login/chat end-to-end run was not repeated after synchronization.
- Unhappy paths exercised: unsupported/unknown controls, explicit sampling conflicts, ignored thinking controls, invalid/error probe output, configuration/key changes, stale observations, failed probe retention, and bounded auxiliary fallback.
- Database verification: the opt-in user_model_create_rotate_and_probe_enforce_provider_wire_contract integration fixture passed against local MatrixOne 4.2.1 before this final upstream sync. It covered additive migration with old rows, repeated bootstrap, create/rotation/probe persistence and capability retention. The three synchronized upstream commits did not change database/model paths, so that database run was not repeated.
- Scope limits: targeted regression suites, not the full offline/online suite. No fresh paid Kimi calls or end-to-end latency claim in the final verification pass. Required CI and reviewer approval remain outstanding.

## Final checklist

- [x] I added or updated tests at the layer that owns the behavior, or explained why no test is needed.
- [x] I updated public or design documentation for contract changes, or the change needs no documentation update.
- [x] I checked the diff for credentials, private URLs, customer data, generated files, and other sensitive information.
- [x] The PR title follows the repository's Conventional Commit format.
