### PR TITLE
docs(readme): open with EXPLAIN ANALYZE for context and a recorded DAG demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Astra
 
-### The self-hosted runtime for agents that must act inside private systems
+### See what your agent saw. Fix it where the work lives.
 
-**Durable work on fewer tokens. Agent changes you can trace and roll back. Work that moves with you.**
+**Inspectable context. Evidence you can roll back. Execution in your environment.**
 
 [![Test Suite](https://github.com/matrixorigin/Astra/actions/workflows/test.yml/badge.svg)](https://github.com/matrixorigin/Astra/actions/workflows/test.yml)
 [![Static Checks](https://github.com/matrixorigin/Astra/actions/workflows/static-checks.yml/badge.svg)](https://github.com/matrixorigin/Astra/actions/workflows/static-checks.yml)
@@ -21,30 +21,46 @@
 
 ---
 
-Astra is not another coding agent or a library for wrapping one model call. It
-is the open-source, self-hosted runtime behind CLI, Web, and application agents
-that must keep long-running Work alive without replaying an ever-growing
-context, make captured changes inspectable and reversible, and reconnect Work
-to authorized execution wherever the relevant tools and private systems live.
+Astra is a self-hosted runtime for long-running agent Work. Every model
+request is assembled by a budgeted pipeline you can EXPLAIN, every attempt
+leaves evidence you can inspect, diff, and roll back, and execution runs
+through a Runner inside your own environment.
 
-| Durable work on fewer tokens | Agent changes you can trace and roll back | Work that moves with you |
+| What did the model receive? | What changed, and what next? | Where does it run? |
 | --- | --- | --- |
-| ContextPipe budgets and compresses context while checkpoints keep long-running Work resumable. | Trace links captured file, session, and database changes to evidence and scoped rollback. | The Server keeps the Work; a user-bound Runner reconnects it to private repositories, tools, credentials, and networks. |
+| `EXPLAIN ANALYZE` shows every context source, its budget, its actual cost, and what was dropped and why. `Self` exposes goals, budgets, and tool health. ContextPipe cut tokens 31% against append-only context. | Every attempt, config change, and checkpoint is versioned. Rewind a session, diff two runs, replay against the record, and continue durable Work with a new constraint. | A User Runner executes admitted tool calls in your repositories and networks. The Server coordinates; it never gets ambient access to your machine. |
+| **Understand what happened.** | **Know what changed and what still needs verification.** | **Keep code and credentials where they are.** |
 
-Astra includes the Server, CLI/TUI, Web dashboard, APIs, and TypeScript SDK. You
-bring the LLM and embedding endpoints, then connect tools and data through a
-Runner or MCP.
+```bash
+astra chat --explain verbose -m "Run the shell command: ls *.sh | wc -l and answer with just the number."
+```
 
-**Codex starts with the agent experience. DeepSeek Harness starts with the
-plugin graph. Astra starts with durable enterprise Work: context is budgeted,
-captured changes carry rollback evidence, and execution reconnects to the
-identity and environment allowed to perform it.**
+```text
+Explain Analyze DAG — turn-1
+  tokens fresh_in=928 cache_read=82688 cache_write=0 out=44
+├─ context_assembly ms=187ms budget=41783/102400 (40.8%)
+│  ├─ prompt system=6294 history=0 memory=0 tool_schemas=11269 user=18
+│  ├─ tool_surface selected=28/28 [agent, agent_fanout, bash, git, glob, grep, +22]
+│  └─ memory query="Run the shell command: ls *.sh | wc -l …" considered=0 selected=0 tokens=0 ms=0ms
+├─ preflight semantic admission outcome=unavailable ms=2ms
+├─ round[1] request preparation outcome=succeeded ms=564ms
+├─ round[1] model inference outcome=succeeded ms=1.2s
+├─ round[1] tool execution outcome=succeeded ms=1.4s
+├─ preflight semantic admission outcome=decided ms=1.8s
+├─ round[2] request preparation outcome=succeeded ms=478ms
+├─ round[2] model inference outcome=succeeded ms=1.7s
+└─ assistant out_tokens=44 chars=1
+   └─ preview 2
+```
+
+<sub>Abbreviated output of a real one-shot turn against a hosted Astra Server with `deepseek-v4-flash`. Every line answers a question a database engineer already knows how to ask: what was the budget, what did each source cost, what was dropped, and did the cache hit.</sub>
+
+Astra ships as one binary (CLI, TUI, and Server), plus a Web dashboard and a
+TypeScript SDK sharing one agent backbone. Bring any model endpoint.
 
 <div align="center">
   <img alt="Illustrative 20-second Astra flow: ContextPipe keeps durable Work within a smaller token budget, a user-bound Runner makes a captured change inside a private environment, and Astra traces and rolls the change back before the Work continues." src="docs/assets/astra-cli-demo.gif" width="900">
 </div>
-
-<p align="center"><sub>Less context to carry. Changes you can recover from. The same Work wherever you continue.</sub></p>
 
 ### Pick the layer you need
 


### PR DESCRIPTION
## Summary

Rewrites the README opening so the first screen answers the three questions a developer asks before adopting a runtime: **what did the model receive, what changed, and where does it run**. The abstract intro, the Codex/DeepSeek Harness paragraph, and the closing caption are replaced by a one-line command and an abbreviated `Explain Analyze DAG` captured from a real one-shot turn. The demo GIF is replaced by a recording of `astra chat --explain verbose` printing the DAG (same path, `docs/assets/astra-cli-demo.gif`, 1.3 MB vs 2.4 MB). Badges, nav, and everything from "Pick the layer you need" onward are unchanged.

Who benefits: first-time readers on GitHub. The positioning ("EXPLAIN ANALYZE for agent context") is already the name of the renderer in `crates/astra-cli/src/explain_dag.rs`; this makes the README say it too.

The DAG is real output, lightly abbreviated. Two lines were dropped on purpose: in one-shot `chat` mode the header currently renders `tool_calls=0 tools=0ms` and `llm ms=?` even though a bash call ran (visible in the phase list). Once that rendering path is fixed the full header can go back in.

## Related issue

None. Related discussion: #467 (competitive landscape), #674 (capability maturity matrix).

## Change type

- [ ] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Refactor or performance improvement
- [ ] Test
- [ ] Build, CI, or maintenance

## User and compatibility impact

None. README and one replaced asset. Note: `scripts/render_readme_demo.py` previously generated the GIF; the new recording was made outside that script.

## Architecture and complexity delta

N/A

## Verification

- Commands and results: captured with `astra 0.2.3` (darwin-arm64 release) against a hosted Server, `deepseek-v4-flash` via personal Cloud BYOK:
  `astra chat --no-resume -y --explain verbose -m "Run the shell command: ls *.sh | wc -l and answer with just the number."` → answer `2`, DAG as shown (abbreviated).
- Public entrypoint exercised: `astra chat --explain verbose`.
- Unhappy paths exercised: N/A (docs).
- Database verification: N/A.

## Final checklist

- [x] I added or updated tests at the layer that owns the behavior, or
      explained why no test is needed.
- [x] I updated public or design documentation for contract changes, or the
      change needs no documentation update.
- [x] I checked the diff for credentials, private URLs, customer data,
      generated files, and other sensitive information.
- [x] The PR title follows the repository's Conventional Commit format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
