### PR TITLE
docs(readme): do not promise the Web dashboard and SDK to hosted users

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ Explain Analyze DAG — turn-1
 
 <sub>Abbreviated output of a real one-shot turn against a hosted Astra Server with `deepseek-v4-flash`. Every line answers a question a database engineer already knows how to ask: what was the budget, what did each source cost, what was dropped, and did the cache hit.</sub>
 
-Astra ships as one binary (CLI, TUI, and Server), plus a Web dashboard and a
-TypeScript SDK sharing one agent backbone. Bring any model endpoint.
+Astra ships as one binary: the CLI, the TUI, and the Server. Bring any model
+endpoint. Self-hosted deployments add a Web dashboard and a TypeScript SDK on
+the same backbone.
 
 <div align="center">
   <img alt="Recorded terminal session: astra chat --explain verbose answers a question, then prints the Explain Analyze DAG for the turn — token counts, context assembly budget, prompt breakdown by source, tool surface, memory retrieval, and per-round timing." src="docs/assets/astra-cli-demo.gif" width="900">


### PR DESCRIPTION
## Summary

Follow-up to #748. The opening said Astra ships "plus a Web dashboard and a TypeScript SDK". For a reader on the hosted path that is not true today: the hosted Server exposes only the API (`/login` is 404) and `@astra/sdk` is not published to npm. The sentence now says one binary (CLI, TUI, Server) and mentions the Web dashboard and SDK as self-hosted additions.

## Related issue

Follow-up to #748.

## Change type

- [x] Documentation

## User and compatibility impact

None. README only.

## Architecture and complexity delta

N/A

## Verification

- Commands and results: `curl -I https://astra.thememoria.ai/login` → 404; `curl https://registry.npmjs.org/@astra%2Fsdk` → `{"error":"Not found"}`; `web/` and `packages/sdk` exist in the repository and remain documented in the self-host and Embed sections.
- Public entrypoint exercised: N/A (docs).
- Unhappy paths exercised: N/A.
- Database verification: N/A.

## Final checklist

- [x] No test needed (docs).
- [x] No design documentation change needed.
- [x] Diff checked for credentials, private URLs, customer data, generated files, and other sensitive information.
- [x] PR title follows Conventional Commit format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
