### PR TITLE
chore(release): prepare Astra 0.2.4

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -3,7 +3,7 @@
 
 # ── Published images / ingress ─────────────────────────────────────────────
 # Pin an immutable release tag or digest. Do not deploy `latest` in production.
-ASTRA_IMAGE=matrixorigin/astra:0.2.3
+ASTRA_IMAGE=matrixorigin/astra:0.2.4
 NGINX_IMAGE=nginx:1.30.4-alpine
 ASTRA_PUBLIC_BIND_ADDRESS=0.0.0.0
 ASTRA_PUBLIC_HTTP_PORT=80

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use Astra, please cite the ContextPipe paper and this software."
 title: Astra
 type: software
-version: 0.2.3
+version: 0.2.4
 authors:
   - name: MatrixOrigin
 repository-code: "https://github.com/matrixorigin/Astra"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "astra-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-config",
  "astra-core",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "astra-config"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "astra-turn-types",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "astra-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "astra-credentials"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "dirs",
  "fs2",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "astra-edge"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "astra-credentials",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "astra-harness"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-turn-core",
  "serde",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "astra-logging"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "astra-mcp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-turn-types",
  "chrono",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "astra-memoria"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-turn-types",
  "async-trait",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "astra-messaging"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-text-utils",
  "astra-turn-types",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "astra-pipeline"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "astra-services",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "astra-plan"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "astra-services",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "astra-prompts"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "chrono",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "astra-runtime"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-config",
  "astra-core",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "astra-runtime-env"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "async-trait",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "astra-sandbox"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "astra-skills",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "astra-server-types"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "astra-services",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "astra-services"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-config",
  "astra-core",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "astra-skills"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "astra-pipeline",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "astra-sync-protocol"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "hmac",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "astra-test-harness"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "astra-credentials",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "astra-text-utils"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "dirs",
  "serde",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "astra-thin-client"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "astra-runtime-env",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "astra-tools"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "astra-memoria",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "astra-turn-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-core",
  "astra-messaging",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "astra-turn-types"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "astra-prompts",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = ["vendor/crossterm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/deployment/all-in-one/.env.example
+++ b/deployment/all-in-one/.env.example
@@ -15,7 +15,7 @@
 # These three images are one tested compatibility set. Release PRs update the
 # Astra version and deliberately advance dependency digests only after the
 # all-in-one candidate smoke passes on AMD64 and ARM64.
-ASTRA_IMAGE=matrixorigin/astra:0.2.3
+ASTRA_IMAGE=matrixorigin/astra:0.2.4
 MEMORIA_IMAGE=matrixorigin/memoria@sha256:9075cb57c0304197d906d1fdb6c71cbeb1e000153ab5fe3b766ddcd0134e8478
 MATRIXONE_IMAGE=matrixorigin/matrixone@sha256:c95d1b468e3fc5f4f2b377da14f4601e7efefa6eb143758636d60114a5bbb436
 

--- a/deployment/kubernetes/chart/Chart.yaml
+++ b/deployment/kubernetes/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: astra-engine
 description: Enterprise agent runtime with auditable context and execution
 type: application
-version: 0.2.3
-appVersion: "0.2.3"
+version: 0.2.4
+appVersion: "0.2.4"

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astra/sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@astra/sdk",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astra/sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "Apache-2.0",
   "description": "TypeScript SDK for Astra — streaming chat, tool execution, and WebSocket support",
   "homepage": "https://github.com/matrixorigin/Astra#readme",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astra-web",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astra-web",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@astra/sdk": "file:../packages/sdk",
         "@floating-ui/core": "1.8.0",
@@ -55,7 +55,7 @@
     },
     "../packages/sdk": {
       "name": "@astra/sdk",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astra-web",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "scripts": {
     "dev": "../scripts/dev/run-web-dev.sh",


### PR DESCRIPTION
## Summary

- Prepare the Rust workspace, TypeScript SDK, Web application, Helm chart, citation metadata, lockfiles, and deployment examples for Astra `0.2.4`.
- Update the example Astra image tags from `0.2.3` to `0.2.4`.
- Preserve the reviewed MatrixOne and Memoria compatibility digests without modification.

## Release contents since v0.2.3

The source selected for this release includes:

- unified hosted and self-hosted Memoria credential authority, including composition-owned user-scoped access for explicit memory tools (`#750`);
- stabilized terminal PTY fragments and additional timing diagnostics;
- documentation improvements for recorded context inspection.

## Related work

- matrixorigin/Astra#750
- matrixorigin/memoria#250

## Change type

- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor or performance improvement
- [ ] Test
- [x] Build, CI, or maintenance

## User and compatibility impact

This PR changes release metadata only; it does not add another runtime, API, configuration, or database migration beyond changes already reviewed and merged into `main`.

The pinned compatibility set remains unchanged:

- `MEMORIA_IMAGE` still points to the previously tested Memoria `0.5.1` digest.
- `MATRIXONE_IMAGE` remains on the previously tested immutable digest.
- `MEMORIA_SELF_HOSTED_MASTER_ACCESS=0` remains fail-closed by default.

Memoria PR #250 has merged, but the all-in-one pin has not yet been replaced with a published and tested image containing that protocol. Consequently, the new owner-scoped self-hosted master fallback remains disabled in the checked-in example. Hosted deployments using persisted per-user Memoria credentials are not enabled through that fallback.

## Architecture and complexity delta

- Canonical owner changed or extended: N/A; metadata-only release preparation.
- Existing implementations and callers searched: N/A.
- Superseded code, states, tables, shims, or self-only tests removed: N/A.
- Parallel implementations remaining: N/A.

## Files synchronized

- `Cargo.toml` and local Astra packages in `Cargo.lock`
- `packages/sdk/package.json` and lockfile
- `web/package.json` and lockfile, including its linked SDK version
- `CITATION.cff`
- Helm chart `version` and `appVersion`
- all-in-one and production Astra image examples

## Verification

- `make release-prepare VERSION=0.2.4` — passed; synchronized all 10 release files.
- `make release-check VERSION=0.2.4` — passed.
  - all release version surfaces match `0.2.4`;
  - repository metadata validation passed for 116 Markdown/rule files, 51 shell scripts, 9 mirrored skills, and 3 monitoring definitions;
  - installer, artifact, workflow ownership, and documentation contracts passed.
- `git diff --check` — passed.
- Dependency pins were inspected and remain unchanged.

Full workspace checks and tests are delegated to the required PR CI because this branch changes only release metadata and a separate worktree build would duplicate the repository's large Rust target artifacts.

## Final checklist

- [x] No behavior test was added because this is a metadata-only release preparation.
- [x] No manual tag or GitHub Release was created.
- [x] MatrixOne and Memoria compatibility pins were reviewed and preserved.
- [x] The diff contains no credentials, private URLs, customer data, or unrelated generated files.
- [x] The PR title follows the repository conventional commit format.
