### PR TITLE
fix(cli): style browser login results and bound callback responses

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,8 @@
 # Keep source, configuration, and executable scripts consistent across platforms.
 *.bash text eol=lf
 *.cff text eol=lf
+*.css text eol=lf
+*.html text eol=lf
 *.js text eol=lf
 *.json text eol=lf
 *.jsx text eol=lf

--- a/crates/astra-cli/src/cli/auth_flow.rs
+++ b/crates/astra-cli/src/cli/auth_flow.rs
@@ -221,6 +221,7 @@ async fn do_memoria_browser_login_with_opener(
 
     let deadline = tokio::time::Instant::now() + Duration::from_secs(300);
     let mut rejected = 0_u8;
+    let mut requests = 0_u8;
     loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
@@ -230,22 +231,67 @@ async fn do_memoria_browser_login_with_opener(
             .await
             .map_err(|_| "browser login timed out; run `astra login` to try again".to_string())?
             .map_err(|error| format!("local login callback failed: {error}"))?;
+        // Bound even harmless-looking traffic (OPTIONS/favicon/unknown paths).
+        // This is resource containment, not protection against a hostile local host.
+        requests += 1;
+        // Read the bounded request before replying, including at the request
+        // limit: closing a socket with unread request bytes can reset the peer
+        // and discard the error response on some platforms.
         let request = tokio::time::timeout_at(deadline, read_callback_request(&mut stream))
             .await
             .map_err(|_| "browser login timed out; run `astra login` to try again")?;
-        let Ok(request) = request else {
-            rejected = rejected.saturating_add(1);
-            write_callback_response(&mut stream, "400 Bad Request", None, "invalid request").await;
-            if rejected >= 3 {
-                return Err("too many invalid browser login callbacks".to_string());
+        if requests > 64 {
+            write_callback_response(
+                &mut stream,
+                "429 Too Many Requests",
+                None,
+                "too many requests",
+                deadline,
+            )
+            .await;
+            return Err("too many browser login requests; run `astra login` again".into());
+        }
+        let request = match request {
+            Ok(request) => request,
+            Err(error) => {
+                rejected = rejected.saturating_add(1);
+                if error.is_navigation {
+                    browser_code::write_result(&mut stream, false, deadline).await;
+                } else {
+                    write_callback_response(
+                        &mut stream,
+                        "400 Bad Request",
+                        None,
+                        "invalid request",
+                        deadline,
+                    )
+                    .await;
+                }
+                if rejected >= 3 {
+                    return Err("too many invalid browser login callbacks".to_string());
+                }
+                continue;
             }
-            continue;
         };
         if request.method == "GET" {
+            let path = request.path.split('?').next().unwrap_or_default();
+            if path != "/callback" {
+                let (status, body) = if path == "/favicon.ico" {
+                    ("204 No Content", "")
+                } else {
+                    ("404 Not Found", "not found")
+                };
+                write_callback_response(&mut stream, status, None, body, deadline).await;
+                continue;
+            }
             let code = match browser_code::callback_code(&request.path, &expected_state) {
                 Ok(code) if request.body.is_empty() => code,
                 _ => {
-                    browser_code::write_result(&mut stream, false).await;
+                    rejected = rejected.saturating_add(1);
+                    browser_code::write_result(&mut stream, false, deadline).await;
+                    if rejected >= 3 {
+                        return Err("too many invalid browser login callbacks".into());
+                    }
                     continue;
                 }
             };
@@ -257,13 +303,13 @@ async fn do_memoria_browser_login_with_opener(
             })
             .await
             .map_err(|_| "Browser login timed out; run astra login again".to_string())?;
-            browser_code::write_result(&mut stream, result.is_ok()).await;
+            browser_code::write_result(&mut stream, result.is_ok(), deadline).await;
             return result;
         }
         if request.method == "OPTIONS" {
             let origin = (request.origin.as_deref() == Some(allowed_origin.as_str()))
                 .then_some(allowed_origin.as_str());
-            write_callback_response(&mut stream, "204 No Content", origin, "").await;
+            write_callback_response(&mut stream, "204 No Content", origin, "", deadline).await;
             continue;
         }
         if request.method != "POST"
@@ -272,7 +318,14 @@ async fn do_memoria_browser_login_with_opener(
             || request.content_type.as_deref() != Some("application/json")
         {
             rejected = rejected.saturating_add(1);
-            write_callback_response(&mut stream, "403 Forbidden", None, "callback rejected").await;
+            write_callback_response(
+                &mut stream,
+                "403 Forbidden",
+                None,
+                "callback rejected",
+                deadline,
+            )
+            .await;
             if rejected >= 3 {
                 return Err("too many invalid browser login callbacks".to_string());
             }
@@ -287,6 +340,7 @@ async fn do_memoria_browser_login_with_opener(
                     "400 Bad Request",
                     Some(&allowed_origin),
                     "invalid callback",
+                    deadline,
                 )
                 .await;
                 if rejected >= 3 {
@@ -305,6 +359,7 @@ async fn do_memoria_browser_login_with_opener(
                 "403 Forbidden",
                 Some(&allowed_origin),
                 "callback rejected",
+                deadline,
             )
             .await;
             if rejected >= 3 {
@@ -312,13 +367,20 @@ async fn do_memoria_browser_login_with_opener(
             }
             continue;
         }
-        match do_memoria_login_with_key(api, profile, &callback.memoria_connection_key).await {
+        match tokio::time::timeout_at(
+            deadline,
+            do_memoria_login_with_key(api, profile, &callback.memoria_connection_key),
+        )
+        .await
+        .map_err(|_| "Browser login timed out; run astra login again".to_string())?
+        {
             Ok(token) => {
                 write_callback_response(
                     &mut stream,
                     "200 OK",
                     Some(&allowed_origin),
                     r#"{"status":"connected"}"#,
+                    deadline,
                 )
                 .await;
                 return Ok(token);
@@ -329,6 +391,7 @@ async fn do_memoria_browser_login_with_opener(
                     "502 Bad Gateway",
                     Some(&allowed_origin),
                     "Astra could not verify the connection key.",
+                    deadline,
                 )
                 .await;
                 return Err(error);
@@ -337,6 +400,7 @@ async fn do_memoria_browser_login_with_opener(
     }
 }
 
+#[derive(Debug)]
 struct CallbackRequest {
     method: String,
     path: String,
@@ -345,16 +409,28 @@ struct CallbackRequest {
     body: Vec<u8>,
 }
 
+#[derive(Debug)]
+struct CallbackReadError {
+    // Presentation hint only, never used to accept or authorize a callback.
+    is_navigation: bool,
+}
+
 async fn read_callback_request(
     stream: &mut tokio::net::TcpStream,
-) -> Result<CallbackRequest, String> {
-    tokio::time::timeout(Duration::from_secs(5), read_callback_request_inner(stream))
-        .await
-        .map_err(|_| "callback read timed out".to_string())?
+) -> Result<CallbackRequest, CallbackReadError> {
+    let mut is_navigation = false;
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        read_callback_request_inner(stream, &mut is_navigation),
+    )
+    .await
+    .unwrap_or_else(|_| Err("callback read timed out".into()))
+    .map_err(|_| CallbackReadError { is_navigation })
 }
 
 async fn read_callback_request_inner(
     stream: &mut tokio::net::TcpStream,
+    is_navigation: &mut bool,
 ) -> Result<CallbackRequest, String> {
     let mut data = Vec::with_capacity(2048);
     let mut chunk = [0_u8; 1024];
@@ -364,6 +440,7 @@ async fn read_callback_request_inner(
             return Err("callback request is incomplete".into());
         }
         data.extend_from_slice(&chunk[..read]);
+        *is_navigation = data.starts_with(b"GET /callback?") || data.starts_with(b"GET /callback ");
         if data.len() > 8192 {
             return Err("callback request is too large".into());
         }
@@ -453,6 +530,7 @@ async fn write_callback_response(
     status: &str,
     origin: Option<&str>,
     body: &str,
+    deadline: tokio::time::Instant,
 ) {
     let cors = origin
         .map(|origin| {
@@ -461,11 +539,42 @@ async fn write_callback_response(
             )
         })
         .unwrap_or_default();
+    let body = if body.is_empty() {
+        String::new()
+    } else {
+        serde_json::from_str::<serde_json::Value>(body)
+            .unwrap_or_else(|_| serde_json::json!({"error": body}))
+            .to_string()
+    };
     let response = format!(
-        "HTTP/1.1 {status}\r\n{cors}Content-Type: application/json\r\nCache-Control: no-store\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        "HTTP/1.1 {status}\r\n{cors}Content-Type: application/json; charset=utf-8\r\nCache-Control: no-store\r\nReferrer-Policy: no-referrer\r\nX-Content-Type-Options: nosniff\r\nContent-Security-Policy: default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
         body.len()
     );
-    let _ = stream.write_all(response.as_bytes()).await;
+    if write_callback_bytes(stream, response.as_bytes(), deadline)
+        .await
+        .is_err()
+    {
+        tracing::warn!("could not deliver browser login callback response");
+    }
+}
+
+async fn write_callback_bytes<W: tokio::io::AsyncWrite + Unpin>(
+    stream: &mut W,
+    response: &[u8],
+    deadline: tokio::time::Instant,
+) -> std::io::Result<()> {
+    let write_deadline = deadline.min(tokio::time::Instant::now() + Duration::from_secs(2));
+    tokio::time::timeout_at(write_deadline, async {
+        stream.write_all(response).await?;
+        stream.shutdown().await
+    })
+    .await
+    .unwrap_or_else(|_| {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "callback write timed out",
+        ))
+    })
 }
 
 fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
@@ -719,6 +828,9 @@ pub(crate) async fn do_register_for_session(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
     #[serial_test::serial]
     #[tokio::test]
     async fn browser_login_entrypoint_supports_local_codes_and_legacy_without_remote_polling() {
@@ -752,6 +864,38 @@ mod tests {
                 let callback = format!("http://127.0.0.1:{}/callback", fields["port"]);
                 let code = super::browser_code::verifier();
                 let client = reqwest::Client::builder().no_proxy().build().unwrap();
+                for (path, status) in [("/favicon.ico", 204), ("/wrong", 404)] {
+                    let response = client
+                        .get(format!("http://127.0.0.1:{}{path}", fields["port"]))
+                        .send()
+                        .await
+                        .unwrap();
+                    assert_eq!(response.status(), status);
+                    assert!(!response.text().await.unwrap().contains("<html"));
+                }
+                // Cookies are shared across loopback ports. Oversized browser
+                // headers must fail closed with a card, not echoed plaintext.
+                let mut stream =
+                    tokio::net::TcpStream::connect(format!("127.0.0.1:{}", fields["port"]))
+                        .await
+                        .unwrap();
+                let request = format!(
+                    "GET /callback?code={code}&state={} HTTP/1.1\r\nHost: 127.0.0.1\r\nCookie: secret-cookie={}\r\n\r\n",
+                    fields["state"],
+                    "x".repeat(8200)
+                );
+                stream.write_all(request.as_bytes()).await.unwrap();
+                let mut malformed_response = String::new();
+                stream
+                    .read_to_string(&mut malformed_response)
+                    .await
+                    .unwrap();
+                assert!(malformed_response.starts_with("HTTP/1.1 400"));
+                assert!(malformed_response.contains("Content-Type: text/html; charset=utf-8"));
+                assert!(malformed_response.contains("class=\"card failure\""));
+                for secret in [&code, &fields["state"], "secret-cookie"] {
+                    assert!(!malformed_response.contains(secret));
+                }
                 // Unrelated/wrong-state requests must not cause credential exchange
                 // or prevent the valid local browser from finishing afterwards.
                 let invalid = client
@@ -761,6 +905,21 @@ mod tests {
                     .await
                     .unwrap();
                 assert_eq!(invalid.status(), 400);
+                assert_eq!(
+                    invalid.headers()["content-type"],
+                    "text/html; charset=utf-8"
+                );
+                let failure_body = invalid.text().await.unwrap();
+                assert!(failure_body.contains("class=\"card failure\""));
+                for secret in [
+                    &code,
+                    &fields["state"],
+                    "test-access",
+                    "test-refresh",
+                    "test-connection-key",
+                ] {
+                    assert!(!failure_body.contains(secret));
+                }
                 assert!(website.received_requests().await.unwrap().is_empty());
                 assert!(server.received_requests().await.unwrap().is_empty());
                 let response = if legacy {
@@ -799,9 +958,37 @@ mod tests {
                 };
                 assert!(response.status().is_success());
                 assert_eq!(response.headers()["cache-control"], "no-store");
-                if !legacy {
+                if legacy {
+                    assert_eq!(
+                        response.headers()["content-type"],
+                        "application/json; charset=utf-8"
+                    );
+                    assert_eq!(
+                        response.headers()["access-control-allow-origin"],
+                        website.uri()
+                    );
+                    assert_eq!(
+                        response.json::<serde_json::Value>().await.unwrap(),
+                        json!({"status":"connected"})
+                    );
+                } else {
                     assert_eq!(response.headers()["referrer-policy"], "no-referrer");
-                    assert!(response.text().await.unwrap().contains("signed in"));
+                    assert_eq!(
+                        response.headers()["content-type"],
+                        "text/html; charset=utf-8"
+                    );
+                    let body = response.text().await.unwrap();
+                    assert!(body.contains("You are signed in to Astra"));
+                    assert!(body.contains("Return to your terminal to continue."));
+                    for secret in [
+                        &code,
+                        &fields["state"],
+                        "test-access",
+                        "test-refresh",
+                        "test-connection-key",
+                    ] {
+                        assert!(!body.contains(secret));
+                    }
                 }
                 assert_eq!(
                     website.received_requests().await.unwrap().len(),
@@ -815,6 +1002,235 @@ mod tests {
             assert_eq!(profile.access_token.as_deref(), Some("test-access"));
             assert_eq!(profile.refresh_token.as_deref(), Some("test-refresh"));
         }
+    }
+
+    #[tokio::test]
+    async fn callback_rejections_and_unrelated_traffic_are_bounded() {
+        for invalid_callback in [true, false] {
+            let website = MockServer::start().await;
+            let server = MockServer::start().await;
+            let api = astra_thin_client::ThinClient::new(&server.uri(), None).unwrap();
+            let (sender, receiver) = tokio::sync::oneshot::channel();
+            let website_url = website.uri();
+            let login =
+                super::do_memoria_browser_login_with_opener(&api, None, &website_url, |url| {
+                    sender.send(url.to_string()).unwrap();
+                });
+            let browser = async {
+                let url = url::Url::parse(&receiver.await.unwrap()).unwrap();
+                let port = url
+                    .query_pairs()
+                    .find(|(key, _)| key == "port")
+                    .unwrap()
+                    .1
+                    .into_owned();
+                let client = reqwest::Client::builder().no_proxy().build().unwrap();
+                let count = if invalid_callback { 3 } else { 65 };
+                for attempt in 1..=count {
+                    if attempt == 65 {
+                        let mut stream =
+                            tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+                                .await
+                                .unwrap();
+                        let mut byte = [0_u8; 1];
+                        assert!(
+                            tokio::time::timeout(Duration::from_millis(20), stream.read(&mut byte))
+                                .await
+                                .is_err(),
+                            "the limit response must wait for the bounded request read"
+                        );
+                        stream
+                            .write_all(b"GET /wrong HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                            .await
+                            .unwrap();
+                        let mut response = String::new();
+                        stream.read_to_string(&mut response).await.unwrap();
+                        assert!(response.starts_with("HTTP/1.1 429 Too Many Requests\r\n"));
+                        assert!(response.contains("too many requests"));
+                        continue;
+                    }
+                    let path = if invalid_callback {
+                        "/callback?state=wrong"
+                    } else {
+                        "/wrong"
+                    };
+                    let response = client
+                        .get(format!("http://127.0.0.1:{port}{path}"))
+                        .send()
+                        .await
+                        .unwrap();
+                    assert_eq!(
+                        response.status().as_u16(),
+                        if invalid_callback { 400 } else { 404 }
+                    );
+                }
+            };
+            let (result, ()) = tokio::time::timeout(Duration::from_secs(10), async {
+                tokio::join!(login, browser)
+            })
+            .await
+            .unwrap();
+            assert!(result.unwrap_err().contains("too many"));
+            assert!(website.received_requests().await.unwrap().is_empty());
+            assert!(server.received_requests().await.unwrap().is_empty());
+        }
+    }
+
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn browser_login_exchange_failure_returns_card_without_saving_or_echoing_secrets() {
+        let _creds_guard = crate::tests::isolate_credentials();
+        let website = MockServer::start().await;
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/auth/astra/browser-login/redeem"))
+            .respond_with(
+                ResponseTemplate::new(503)
+                    .set_body_json(json!({"detail":"private-upstream-error"})),
+            )
+            .expect(1)
+            .mount(&website)
+            .await;
+        let api = astra_thin_client::ThinClient::new(&server.uri(), None).unwrap();
+        let website_url = website.uri();
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let login = super::do_memoria_browser_login_with_opener(&api, None, &website_url, |url| {
+            sender.send(url.to_string()).unwrap();
+        });
+        let browser = async {
+            let url = url::Url::parse(&receiver.await.unwrap()).unwrap();
+            let fields: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+            let code = super::browser_code::verifier();
+            let response = reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .unwrap()
+                .get(format!("http://127.0.0.1:{}/callback", fields["port"]))
+                .query(&[("code", &code), ("state", &fields["state"])])
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), 400);
+            assert_eq!(
+                response.headers()["content-type"],
+                "text/html; charset=utf-8"
+            );
+            let body = response.text().await.unwrap();
+            assert!(body.contains("class=\"card failure\""));
+            assert!(body.contains("Couldn’t complete sign-in"));
+            for secret in [&code, &fields["state"], "private-upstream-error"] {
+                assert!(!body.contains(secret));
+            }
+        };
+        let (result, ()) = tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(login, browser)
+        })
+        .await
+        .unwrap();
+        assert!(result.unwrap_err().contains("unavailable"));
+        assert!(server.received_requests().await.unwrap().is_empty());
+        assert!(
+            load_credentials()
+                .profiles
+                .values()
+                .all(|profile| profile.access_token.is_none() && profile.refresh_token.is_none())
+        );
+    }
+
+    #[tokio::test]
+    async fn callback_writes_bound_stalled_peers_and_report_io_errors() {
+        // A one-byte buffer deterministically stalls write_all without relying
+        // on platform TCP window sizes or timing a real browser.
+        let (mut writer, _reader) = tokio::io::duplex(1);
+        let error = super::write_callback_bytes(
+            &mut writer,
+            b"response",
+            tokio::time::Instant::now() + Duration::from_millis(20),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        let (mut writer, _reader) = tokio::io::duplex(1);
+        let error = tokio::time::timeout(
+            Duration::from_secs(5),
+            super::write_callback_bytes(
+                &mut writer,
+                b"response",
+                tokio::time::Instant::now() + Duration::from_secs(300),
+            ),
+        )
+        .await
+        .expect("the two-second write cap must apply independently of the login deadline")
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        let (mut writer, reader) = tokio::io::duplex(1);
+        drop(reader);
+        let error = super::write_callback_bytes(
+            &mut writer,
+            b"response",
+            tokio::time::Instant::now() + Duration::from_secs(5),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        super::write_callback_bytes(
+            &mut writer,
+            b"complete",
+            tokio::time::Instant::now() + Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        // Shutdown delivers EOF even while the writer remains in scope.
+        let mut response = String::new();
+        tokio::time::timeout(Duration::from_secs(1), reader.read_to_string(&mut response))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(response, "complete");
+    }
+
+    #[tokio::test]
+    async fn malformed_legacy_request_still_receives_json_without_echoing_input() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let server = async {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let error = super::read_callback_request(&mut stream).await.unwrap_err();
+            assert!(!error.is_navigation);
+            super::write_callback_response(
+                &mut stream,
+                "400 Bad Request",
+                None,
+                "invalid request",
+                tokio::time::Instant::now() + Duration::from_secs(5),
+            )
+            .await;
+        };
+        let client = async {
+            let mut stream = tokio::net::TcpStream::connect(listener.local_addr().unwrap())
+                .await
+                .unwrap();
+            stream
+                .write_all(b"POST /callback HTTP/1.1\r\nX-Secret: private-cookie\r\n\r\n")
+                .await
+                .unwrap();
+            let mut response = String::new();
+            stream.read_to_string(&mut response).await.unwrap();
+            let (headers, body) = response.split_once("\r\n\r\n").unwrap();
+            assert!(headers.contains("application/json; charset=utf-8"));
+            assert!(headers.contains("X-Content-Type-Options: nosniff"));
+            assert!(headers.contains("Referrer-Policy: no-referrer"));
+            assert!(!response.contains("private-cookie"));
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(body).unwrap(),
+                json!({"error":"invalid request"})
+            );
+        };
+        tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(server, client);
+        })
+        .await
+        .unwrap();
     }
 
     #[tokio::test]

--- a/crates/astra-cli/src/cli/auth_flow/browser_code.rs
+++ b/crates/astra-cli/src/cli/auth_flow/browser_code.rs
@@ -1,6 +1,9 @@
 //! One-time authorization codes delivered exclusively through the local browser.
 //! There is no remote approval polling or public login-ticket retrieval path.
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use base64::{
+    Engine as _,
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::time::Duration;
@@ -111,24 +114,63 @@ pub(super) async fn redeem(
     Ok(result.connection_key)
 }
 
-pub(super) async fn write_result(stream: &mut tokio::net::TcpStream, success: bool) {
-    use tokio::io::AsyncWriteExt;
-    let (status, body) = if success {
+// Only fixed, application-owned copy enters this template. Never interpolate
+// a callback parameter, credential, account identity, or provider error here.
+fn result_response(success: bool) -> String {
+    const HTML: &str = include_str!("result_page.html");
+    const STYLES: &str = include_str!("result_page.css");
+    let (status, title, message, next_step, icon): (
+        &'static str,
+        &'static str,
+        &'static str,
+        &'static str,
+        &'static str,
+    ) = if success {
         (
             "200 OK",
-            "You are signed in to Astra. You can close this tab and return to your terminal.",
+            "You are signed in to Astra",
+            "Return to your terminal to continue.",
+            "You can close this tab.",
+            "m8 12 3 3 5-6",
         )
     } else {
         (
             "400 Bad Request",
-            "Astra could not complete this login. Return to your terminal and run astra login again.",
+            "Couldn’t complete sign-in",
+            "Return to your terminal and run astra login again.",
+            "Use the new link to try again.",
+            "m9 9 6 6 m0-6-6 6",
         )
     };
-    let response = format!(
-        "HTTP/1.1 {status}\r\nContent-Type: text/plain; charset=utf-8\r\nCache-Control: no-store\r\nReferrer-Policy: no-referrer\r\nContent-Security-Policy: default-src 'none'; frame-ancestors 'none'\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+    let body = HTML
+        .replace("{{status}}", if success { "success" } else { "failure" })
+        .replace("{{title}}", title)
+        .replace("{{message}}", message)
+        .replace("{{next_step}}", next_step)
+        .replace("{{icon}}", icon)
+        .replace("{{styles}}", STYLES);
+    // Authorize only the embedded stylesheet, not arbitrary inline CSS or JS.
+    let style_hash = STANDARD.encode(Sha256::digest(STYLES.as_bytes()));
+    format!(
+        "HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\nCache-Control: no-store\r\nReferrer-Policy: no-referrer\r\nX-Content-Type-Options: nosniff\r\nContent-Security-Policy: default-src 'none'; style-src 'sha256-{style_hash}'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
         body.len()
-    );
-    let _ = stream.write_all(response.as_bytes()).await;
+    )
+}
+
+pub(super) async fn write_result(
+    stream: &mut tokio::net::TcpStream,
+    success: bool,
+    deadline: tokio::time::Instant,
+) {
+    let response = result_response(success);
+    if super::write_callback_bytes(stream, response.as_bytes(), deadline)
+        .await
+        .is_err()
+    {
+        // Presentation failure must not undo an already-persisted login or
+        // obscure its original error. Never log callback contents here.
+        tracing::warn!("could not deliver browser login result page");
+    }
 }
 
 #[cfg(test)]
@@ -138,6 +180,115 @@ mod tests {
         Mock, MockServer, ResponseTemplate,
         matchers::{method, path},
     };
+
+    #[test]
+    fn result_pages_are_self_contained_accessible_and_not_interactive() {
+        for success in [true, false] {
+            let response = result_response(success);
+            let (headers, body) = response.split_once("\r\n\r\n").unwrap();
+            assert!(headers.starts_with(if success {
+                "HTTP/1.1 200 OK"
+            } else {
+                "HTTP/1.1 400 Bad Request"
+            }));
+            assert!(headers.contains("Content-Type: text/html; charset=utf-8"));
+            assert!(headers.contains(&format!("Content-Length: {}\r\n", body.len())));
+            for header in [
+                "Cache-Control: no-store",
+                "Referrer-Policy: no-referrer",
+                "X-Content-Type-Options: nosniff",
+                "default-src 'none'",
+                "form-action 'none'",
+                "base-uri 'none'",
+                "frame-ancestors 'none'",
+            ] {
+                assert!(headers.contains(header), "missing {header}");
+            }
+            let css = body
+                .split_once("<style>")
+                .unwrap()
+                .1
+                .split_once("</style>")
+                .unwrap()
+                .0;
+            let hash = STANDARD.encode(Sha256::digest(css.as_bytes()));
+            assert!(headers.contains(&format!("style-src 'sha256-{hash}'")));
+            assert_eq!(body.matches("<style>").count(), 1);
+            assert_eq!(body.matches("</style>").count(), 1);
+            assert!(!body.contains("style="));
+            assert!(!headers.contains("unsafe-"));
+            assert!(
+                !body.contains('\r'),
+                "embedded assets must use LF for CSP hashing"
+            );
+            for forbidden in [
+                "<script",
+                "<button",
+                "<form",
+                "<a ",
+                "src=",
+                "href=",
+                "url(",
+                "@import",
+                "window.close",
+                "{{",
+                "authorization_code",
+                "code_verifier",
+                "connection_key",
+            ] {
+                assert!(!body.contains(forbidden), "unexpected {forbidden}");
+            }
+            assert!(body.contains("<html lang=\"en\">"));
+            assert!(body.contains("name=\"viewport\""));
+            assert!(body.contains("aria-labelledby=\"result-title\""));
+            assert!(body.contains("prefers-color-scheme: dark"));
+            assert!(body.contains("Astra Cloud"));
+            if success {
+                assert!(body.contains("class=\"card success\""));
+                assert!(body.contains("d=\"m8 12 3 3 5-6\""));
+                assert!(!body.contains("d=\"m9 9 6 6 m0-6-6 6\""));
+                assert!(body.contains("You are signed in to Astra"));
+                assert!(body.contains("You can close this tab."));
+                assert!(!body.contains("astra login"));
+            } else {
+                assert!(body.contains("class=\"card failure\""));
+                assert!(body.contains("d=\"m9 9 6 6 m0-6-6 6\""));
+                assert!(!body.contains("d=\"m8 12 3 3 5-6\""));
+                assert!(body.contains("Couldn’t complete sign-in"));
+                assert!(body.contains("run astra login again."));
+                assert!(!body.contains("You are signed in"));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn result_writer_delivers_complete_html_over_loopback() {
+        use tokio::io::AsyncReadExt;
+        for success in [true, false] {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let client = tokio::net::TcpStream::connect(listener.local_addr().unwrap());
+            let server = async {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                write_result(
+                    &mut stream,
+                    success,
+                    tokio::time::Instant::now() + Duration::from_secs(5),
+                )
+                .await;
+            };
+            let read = async {
+                let mut stream = client.await.unwrap();
+                let mut response = String::new();
+                stream.read_to_string(&mut response).await.unwrap();
+                assert_eq!(response, result_response(success));
+            };
+            tokio::time::timeout(Duration::from_secs(5), async {
+                tokio::join!(server, read);
+            })
+            .await
+            .unwrap();
+        }
+    }
 
     #[test]
     fn capability_is_explicit_and_never_exposes_verifier() {

--- a/crates/astra-cli/src/cli/auth_flow/result_page.css
+++ b/crates/astra-cli/src/cli/auth_flow/result_page.css
@@ -1,0 +1,72 @@
+/* Reference memoria-website's AstraConnect card; preserve the higher-contrast
+   colors and lighter heading here. Loopback cannot read its saved theme/fonts. */
+:root {
+  color-scheme: light dark;
+  --page: #ffffff;
+  --card: #eceef2;
+  --border: rgba(0, 0, 0, 0.09);
+  --text: #111827;
+  --heading: #1f2937;
+  --muted: #4b5563;
+  --success: #047857;
+  --success-bg: rgba(5, 150, 105, 0.1);
+  --error: #b45309;
+  --error-bg: rgba(180, 83, 9, 0.1);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page: #05070a;
+    --card: #10141d;
+    --border: rgba(255, 255, 255, 0.08);
+    --text: #e2e8f0;
+    --heading: #e2e8f0;
+    --muted: #94a3b8;
+    --success: #34d399;
+    --success-bg: rgba(52, 211, 153, 0.1);
+    --error: #fbbf24;
+    --error-bg: rgba(251, 191, 36, 0.1);
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  min-height: 100svh;
+  padding: 24px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--page);
+  color: var(--text);
+  font-family: "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  line-height: 1.5;
+}
+.card {
+  width: 100%;
+  max-width: 448px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--card);
+  text-align: center;
+  overflow-wrap: break-word;
+}
+.brand { margin: 0 0 24px; font-size: 14px; font-weight: 700; }
+.status-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  margin: 0 auto;
+  border-radius: 50%;
+  color: var(--muted);
+  background: var(--card);
+}
+.success .status-icon { color: var(--success); background: var(--success-bg); }
+.failure .status-icon { color: var(--error); background: var(--error-bg); }
+h1 { margin: 20px 0 0; color: var(--heading); font-size: 20px; font-weight: 600; line-height: 1.4; }
+.description { margin: 8px 0 0; color: var(--muted); font-size: 14px; line-height: 1.625; }
+.next-step { margin: 24px 0 0; color: var(--muted); font-size: 14px; }
+@media (min-width: 640px) { .card { padding: 32px; } }
+@media (forced-colors: active) { .status-icon { outline: 1px solid; } }

--- a/crates/astra-cli/src/cli/auth_flow/result_page.html
+++ b/crates/astra-cli/src/cli/auth_flow/result_page.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <title>{{title}} · Astra</title>
+  <style>{{styles}}</style>
+</head>
+<body>
+  <main class="card {{status}}" aria-labelledby="result-title">
+    <p class="brand">Astra Cloud</p>
+    <div class="status-icon" aria-hidden="true">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="9"></circle>
+        <path d="{{icon}}"></path>
+      </svg>
+    </div>
+    <h1 id="result-title">{{title}}</h1>
+    <p class="description">{{message}}</p>
+    <p class="next-step">{{next_step}}</p>
+  </main>
+</body>
+</html>

--- a/docs/design/authentication.md
+++ b/docs/design/authentication.md
@@ -145,15 +145,49 @@ forwarding the final secret authorization code.
 
 After redemption, the CLI uses the existing `/auth/memoria` exchange and saves
 the existing Astra profile tokens. Only then does the local page report
-successful login. The response has no external resources, uses `no-store`
-and `no-referrer`, and contains no credentials. No Astra Server schema, identity
-mapping or session-lifecycle change is needed.
+successful login. No Astra Server schema, identity mapping or session-lifecycle
+change is needed.
+
+The CLI's GET authorization-code callback serves a self-contained HTML card:
+200 on successful login, 400 on invalid callbacks or failed exchange. A malformed
+request whose prefix identifies a GET `/callback` navigation also receives the
+failure card, including oversized cookie headers; unknown/malformed methods
+receive JSON errors. Legacy POST callbacks remain JSON (including valid JSON
+error bodies), and OPTIONS remains an empty 204 response. Unrelated GET paths
+return a small 404; `/favicon.ico` returns an empty 204, not a login failure card.
+Responses use `no-store`, `no-referrer`, and `nosniff`. CSP blocks scripts,
+external resources, base URLs, form submissions and framing. The HTML response
+authorizes only its embedded stylesheet by an exact SHA-256 hash. Only static
+application copy enters the page, never callback fields, identity, credentials
+or upstream error text. There is no close button or additional approval step.
+
+The card references the website's AstraConnect layout and palette, but is not a
+pixel-identical copy. Intentional differences include the Astra Cloud label,
+terminal-specific instructions, no interactive controls, a 600-weight deep-gray
+heading, higher-contrast dark-mode secondary text (`#94a3b8`) and a darker
+light-mode success icon (`#047857`). Do not reduce contrast to match website
+tokens. It follows the system color scheme and locally available fonts, including
+`system-ui`; the loopback origin cannot read the website's saved theme or load
+its web fonts. The standalone assets are
+`crates/astra-cli/src/cli/auth_flow/result_page.html` and
+`crates/astra-cli/src/cli/auth_flow/result_page.css`. They are maintained separately
+from the website and need visual comparison when either design changes. CSS
+changes need no manual CSP update: the hash is calculated from embedded CSS at
+runtime. Both assets use LF even on Windows to avoid browser newline
+normalization changing the hashed style text. Only the CLI binary needs updating.
 
 Website HTTPS is required except explicit loopback development URLs. Code
 exchange does not follow redirects, bounds response size and duration, and is
 not automatically replayed after failure: consumption may already have
 succeeded. Invalid/mismatched GET callbacks do not trigger token exchange.
-The five-minute local listener deadline remains in effect.
+The five-minute local listener deadline remains in effect, including response
+writes and both exchange paths. Each response write/shutdown is additionally
+bounded to two seconds; delivery errors are reported without sensitive contents
+and never undo a persisted login. Three invalid callback attempts end the login;
+favicon, OPTIONS and unknown GET paths do not consume that rejection allowance,
+but an overall 64-request allowance bounds unrelated traffic too. These bounds
+contain resources; they do not guarantee availability against a hostile local
+process, which can also exhaust the existing invalid-attempt allowance.
 
 Compatibility is explicit in the CLI link. An old website can ignore the
 capability fields and use the unchanged JSON POST callback, which still checks


### PR DESCRIPTION
## Summary

Replace the bare-text browser result from `astra login` with a self-contained, accessible Astra result card, and bound the local callback response paths that deliver it.

- Embed both HTML and CSS in the CLI; show distinct success/check and failure/X states, terminal instructions, responsive layout, system light/dark themes, and a lighter 600-weight heading.
- No close button, JavaScript, external fonts/resources, extra approval, or redirect to another product. Only fixed `&'static str` application copy enters the template; callback parameters, credentials and upstream errors are never interpolated.
- Authorize the one embedded stylesheet with its automatically calculated SHA-256 CSP hash. Preserve no-store/no-referrer and add nosniff; forbid scripts, framing, forms and base URLs. Pin HTML/CSS to LF for reproducible style hashing across checkouts.
- Give recognizable malformed GET callback navigations (including oversized cookie headers) the failure card. Keep legacy POST responses JSON and make error bodies valid JSON. Favicon receives an empty 204; unrelated GETs receive a small 404 rather than a misleading failure page.
- Bound response write/shutdown to two seconds and the overall login deadline. Count invalid GET callbacks consistently with legacy rejections; cap total traffic at 64 requests. Read the bounded request before the over-limit reply so closing an unread socket does not discard a normal 429 response. Delivery failure does not undo successful credential persistence.

This is **UI plus CLI loopback callback hardening**, not a UI-only change.

## Related issue

Follow-up to #754 and the browser-login reports in https://github.com/matrixorigin/memoria/issues/251. This PR does not close or change that issue's separate memory-access concerns.

## Change type

- [ ] Feature
- [x] Bug fix
- [x] Documentation
- [ ] Refactor or performance improvement
- [x] Test
- [ ] Build, CI, or maintenance

## User and compatibility impact

- Update the **CLI binary only** for this result page. No Astra Server, Memoria, website, database, deployment, or configuration change is included or required by this PR. This does not replace #754's original website prerequisites for the authorization-code transport.
- Successful GET callback: HTTP 200 HTML after token exchange/persistence. Failed GET callback: HTTP 400 HTML. Recognizable malformed GET `/callback` requests get the same static failure card; unknown/malformed methods remain JSON errors.
- Legacy POST retains exact Origin/state/content-type checks, CORS and `{ "status": "connected" }`. Non-success bodies now contain JSON `{ "error": "..." }` instead of mislabeled plain text; status codes are preserved. The existing website checks `response.ok` before parsing the success object.
- Three invalid callbacks terminate login; benign favicon/OPTIONS/unrelated GET traffic does not consume those three attempts but does count toward the total 64-request allowance. The 65th request receives 429 after its bounded read. These limits contain resources, not guarantee availability against a hostile local process.
- Both GET and legacy exchange paths use the five-minute login deadline. Writes/shutdown use the smaller of that deadline and two seconds. Write failure warns without logging secrets and cannot change an already-completed login result.
- Account authentication, code/state/PKCE validation, issuer mapping, profile/token ownership, refresh, and memory consent are unchanged.
- The card references the website design but intentionally differs in copy, controls, typography and contrast. System theme/local fonts apply; website-saved theme and downloaded fonts are not shared across origins. Templates are maintained separately, as documented.

## Architecture and complexity delta

- Canonical owner changed or extended: `crates/astra-cli/src/cli/auth_flow.rs` and its `browser_code` module. The existing local listener, code redemption and canonical token-persistence path remain the owners.
- Existing implementations and callers searched: GET and legacy POST callback branches, request parsing, response writers, browser capability handling, `do_memoria_login_with_key`, and the website's legacy callback consumer.
- Superseded code, states, tables, shims, or self-only tests removed: replace the plain-text result writer; share one bounded write/shutdown helper between HTML and JSON responses. No dependency, service, table, authentication state machine or separate login flow is added.
- If parallel implementations remain, their boundary and retirement condition: GET HTML is for top-level browser navigation; legacy POST JSON remains for deployed callers. The static CLI card and website React card are intentionally separate origin/runtime assets, with explicit visual-maintenance guidance rather than cross-origin loading.

## Verification

### Commands and results (macOS ARM64)

- `CARGO_INCREMENTAL=0 cargo test --locked -p astra-cli --lib cli::auth_flow::`: **26 passed**, including final callback-limit ordering and independent write-budget tests.
- `CARGO_INCREMENTAL=0 cargo clippy --locked -p astra-cli --lib -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- `python3 scripts/ci/validate_repository.py`: passed.
- `git diff --check` and staged diff check: passed. Both `include_str!` assets are explicitly tracked with LF attributes.
- The macOS debug test link emitted the existing large `__eh_frame` warning; the test binary built and all selected tests passed.

### Public entrypoint and unhappy paths

- Exercise the real browser-login function with isolated credentials and mock website/Astra endpoints for both GET authorization-code and legacy POST success, including exact S256/state/redirect binding and persisted profile tokens.
- Before valid login, send unrelated GET, favicon, oversized-cookie GET and wrong-state GET; verify no early exchanges, correct result/JSON formats, no secret echoes, and subsequent successful login.
- Provider redemption failure returns a failure card, hides upstream error text, makes no Astra token-exchange request and saves no session tokens.
- Three invalid GET callbacks terminate; unrelated traffic reaches the overall cap, and request 65 cannot receive a response before sending its request.
- Deterministic one-byte duplex streams cover blocked writes under both a short overall deadline and the independent two-second cap; disconnected peers report I/O failure; successful shutdown delivers EOF.
- Template tests pin status classes, matching/opposite icon paths, a single embedded stylesheet, exact CSP hash, UTF-8 byte length, LF, no inline style attributes/unsafe CSP or interactive/external elements. Loopback writer tests exercise complete actual HTTP responses.

### Browser evidence and limits

- Final HTML/CSS: eight headless Chrome scenes (success/failure x light/dark x 1280/360 widths), using the same templates, fixed copy and CSP hash. Check computed colors/weight/icons, absence of overflow/interactive controls/external resources, and capture screenshots.
- Four actual Safari scenes (success/failure at wide/narrow windows) passed on the preceding revision with the same rendered layout and colors. The final Safari rerun timed out in browser automation at an empty window before a callback URL was loaded; **that rerun is not claimed as passed**, and the driver was stopped. Later changes were callback/test hardening and a CSS comment, not a new Safari interaction.
- Browser fixtures are isolated loopback previews, not production OAuth or an AWS login. Final public-entrypoint coverage is the Rust mock-backed test above; an earlier standalone CLI smoke test is not presented as validation of this final revision.
- Not run: full workspace suite, live OAuth, Windows/Linux browser execution, VoiceOver, Windows high-contrast UI. No production services were started or deployed; no real credentials are involved.
- Database verification: N/A; no database code or schema changed.

## Final checklist

- [x] I added or updated tests at the layer that owns the behavior.
- [x] I updated public or design documentation for contract changes.
- [x] I checked the diff for credentials, private URLs, customer data, generated files, and other sensitive information.
- [x] The PR title follows the repository's Conventional Commit format.
